### PR TITLE
Documentation extraction for elements:

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
   "browserify": true,
-  "node":       true
+  "node":       true,
+  "boss":       true
 }

--- a/index.js
+++ b/index.js
@@ -10,12 +10,13 @@
 'use strict';
 
 module.exports = {
+  docs:        require('./lib/ast-utils/docs'),
+  fsResolver:  require('./lib/loader/fs-resolver'),
   hydrolyze:   require('./lib/hydrolyze'),
   importParse: require('./lib/ast-utils/import-parse'),
   jsdoc:       require('./lib/ast-utils/jsdoc'),
   jsParse:     require('./lib/ast-utils/js-parse'),
   loader:      require('./lib/loader/file-loader'),
-  fsResolver:  require('./lib/loader/fs-resolver'),
   urlResolver: require('./lib/loader/url-resolver'),
   xhrResolver: require('./lib/loader/xhr-resolver')
 };

--- a/lib/ast-utils/docs.js
+++ b/lib/ast-utils/docs.js
@@ -1,0 +1,139 @@
+/*
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+* This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+* The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+* The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+* Code distributed by Google as part of the polymer project is also
+* subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+'use strict';
+
+var jsdoc = require('./jsdoc');
+
+var serializer = new (require('parse5').Serializer)();
+
+/**
+ * Annotates Hydrolysis descriptors, recursively processing any `desc`
+ * properties as JSDoc.
+ *
+ * You probably want to use a more specialized version of this, such as
+ * `annotateElement`.
+ *
+ * Processed JSDoc values will be made available via the `jsdoc` property on a
+ * descriptor node.
+ *
+ * @param {Object} descriptor The descriptor node to recursively process.
+ * @return {Object} The descriptor that was given.
+ */
+function annotate(descriptor) {
+  if (!descriptor) return descriptor;
+
+  if (typeof descriptor.desc === 'string') {
+    descriptor.jsdoc = jsdoc.parseJsdoc(descriptor.desc);
+  }
+
+  Object.keys(descriptor).forEach(function(key) {
+    var value = descriptor[key];
+    if (value && typeof value === 'object') {
+      // Don't annotate parse5 nodes.
+      if ('nodeName' in value) return;
+      annotate(value);
+    }
+  });
+
+  return descriptor;
+}
+
+/**
+ * Annotates documentation found within a Hydrolysis element descriptor.
+ *
+ * If the element was processed via `hydrolize`, the element's documentation
+ * will also be extracted via its <dom-module>.
+ *
+ * @param {Object} descriptor The element descriptor.
+ * @return {Object} The descriptor that was given.
+ */
+function annotateElement(descriptor) {
+  descriptor.desc = _findElementDocs(descriptor.is, descriptor.domModule);
+  if (descriptor.desc) {
+    descriptor.desc  = _unindent(descriptor.desc);
+    descriptor.jsdoc = annotate(descriptor.desc);
+  }
+
+  // Descriptors that should have their `desc` properties parsed as JSDoc.
+  descriptor.properties.forEach(annotate);
+
+  return descriptor;
+}
+
+/**
+ * @param {string} elementId
+ * @param {DocumentAST} domModule
+ */
+function _findElementDocs(elementId, domModule) {
+  // Note that we concatenate docs from all sources if we find them.
+  var found = [];
+
+  // Do we have a HTML comment on the `<dom-module>`?
+  //
+  // Confusingly, with our current style, the comment will be attached to
+  // `<head>`, rather than being a sibling to the `<dom-module>`
+  var grandparent = domModule.parentNode && domModule.parentNode.parentNode;
+  if (grandparent.nodeName === 'html') {
+    var head = _findLastChildNamed('head', grandparent);
+    if (head) {
+      var comment = _findLastChildNamed('#comment', head);
+      if (comment) {
+        found.push(comment.data);
+      }
+    }
+  }
+
+  // What about a `<template is="doc-summary">`?
+  for (var i = 0, child; child = domModule.childNodes[i]; i++) {
+    if (child.tagName === 'template' && _getNodeAttribute(child, 'is') === 'doc-summary') {
+      var fragment = child.childNodes[0];
+      found.push(serializer.serialize(fragment));
+      break;
+    }
+  }
+
+  if (!found.length) return null;
+  return found.map(_unindent).join('\n');
+}
+
+function _findLastChildNamed(name, parent) {
+  var children = parent.childNodes;
+  for (var i = children.length - 1, child; child = children[i]; i--) {
+    if (child.nodeName === name) return child;
+  }
+  return null;
+}
+
+function _unindent(docText) {
+  var lines  = docText.replace(/\t/g, '  ').split('\n');
+  var indent = lines.reduce(function(prev, line) {
+    if (/^\s*$/.test(line)) return prev;  // Completely ignore blank lines.
+
+    var lineIndent = line.match(/^(\s*)/)[0].length;
+    if (prev === null) return lineIndent;
+    return lineIndent < prev ? lineIndent : prev;
+  }, null);
+
+  return lines.map(function(l) { return l.substr(indent); }).join('\n');
+}
+
+// TODO(nevir): parse5-utils!
+function _getNodeAttribute(node, name) {
+  for (var i = 0, attr; attr = node.attrs[i]; i++) {
+    if (attr.name === name) {
+      return attr.value;
+    }
+  }
+}
+
+module.exports = {
+  annotate:        annotate,
+  annotateElement: annotateElement,
+};

--- a/lib/ast-utils/import-parse.js
+++ b/lib/ast-utils/import-parse.js
@@ -40,9 +40,10 @@
 /**
  * The ASTs of the HTML elements needed to represent Polymer elements.
  * @typedef {Object} ParsedImport
- * @property {Array.<DocumentAST>} template The entry points to the AST at each outermost template tag.
- * @property {Array.<DocumentAST>} script The entry points to the AST at each script tag not inside a template.
- * @property {Array.<DocumentAST>} style The entry points to the AST at style tag outside a template.
+ * @property {Array<DocumentAST>} template The entry points to the AST at each outermost template tag.
+ * @property {Array<DocumentAST>} script The entry points to the AST at each script tag not inside a template.
+ * @property {Array<DocumentAST>} style The entry points to the AST at style tag outside a template.
+ * @property {Array<DocumentAST>} dom-module The entry points to the AST at each outermost dom-module element.
  * @property {DocumentAST} ast The full parse5 ast for the document.
  */
 
@@ -61,7 +62,7 @@
       return null;
     }
 
-    var registry = {template: [], script: [], style: [], import: []};
+    var registry = {template: [], script: [], style: [], import: [], 'dom-module': []};
 
     var queue = [].concat(doc.childNodes);
     var nextNode;

--- a/lib/ast-utils/jsdoc.js
+++ b/lib/ast-utils/jsdoc.js
@@ -39,33 +39,6 @@ var JsdocTag;
  */
 var JsdocAnnotation;
 
-/**
- * Annotates Hydrolysis descriptors, recursively processing any `desc`
- * properties as JSDoc.
- *
- * Processed JSDoc values will be made available via the `jsdoc` property on a
- * descriptor node.
- *
- * @param {Object} descriptor The descriptor node to recursively process.
- * @return {Object} The descriptor that was given.
- */
-function annotate(descriptor) {
-  if (!descriptor) return descriptor;
-
-  if (typeof descriptor.desc === 'string') {
-    descriptor.jsdoc = parseJsdoc(descriptor.desc);
-  }
-
-  Object.keys(descriptor).forEach(function(key) {
-    var value = descriptor[key];
-    if (typeof value === 'object') {
-      annotate(value);
-    }
-  });
-
-  return descriptor;
-}
-
 var LINE_PREFIX  = /^[ \t]*\*?[ \t]?/;
 var DOC_SPLITTER = /(?=[ \t]*\*?[ \t]?@)/;
 
@@ -141,7 +114,6 @@ function parseTag(source) {
 }
 
 module.exports = {
-  annotate:   annotate,
   parseJsdoc: parseJsdoc,
   parseTag:   parseTag,
 };

--- a/lib/hydrolyze.js
+++ b/lib/hydrolyze.js
@@ -76,6 +76,7 @@
       }
       metadata.url = href;
       metadata.external_scripts = external_scripts;
+      metadata.elements.forEach(attachDomModule.bind(null, parsed));
       if (attachAST) {
         metadata.html = parsed;
       }
@@ -113,6 +114,33 @@
     }
     return promise;
   };
+
+  /**
+   * Finds a <dom-module> associated with `element`, and stores it on the
+   * `domModule` property of `element`. No-op if there is no <dom-module> that
+   * matches.
+   *
+   * @param {Object} element
+   * @param {Object} parsedImport
+   */
+  function attachDomModule(parsedImport, element) {
+    var domModules = parsedImport['dom-module'];
+    for (var i = 0, domModule; domModule = domModules[i]; i++) {
+      if (getNodeAttribute(domModule, 'id') === element.is) {
+        element.domModule = domModule;
+        return;
+      }
+    }
+  }
+
+  // TODO(nevir): parse5-utils!
+  function getNodeAttribute(node, name) {
+    for (var i = 0, attr; attr = node.attrs[i]; i++) {
+      if (attr.name === name) {
+        return attr.value;
+      }
+    }
+  }
 
   context.exports = hydrolyze;
 }(module));


### PR DESCRIPTION
- Supports comments before <dom-module> elements (assuming they
  follow the usual element format.
- Supports <template is="doc-summary"> inside the <dom-module>.

Note that I'm using `<core-doc-viewer>` as a lamesauce integration test case for this, but it does cover it...
