### PR TITLE
Add sourcemap support to build and mocha

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,7 @@ const eslint_lib = require('gulp-eslint');
 const mocha = require('gulp-mocha');
 const newer = require('gulp-newer');
 const shell = require('gulp-shell');
+const sourcemaps = require('gulp-sourcemaps');
 const tslint_lib = require('gulp-tslint');
 const typescript = require('gulp-typescript');
 const mergeStream = require('merge-stream');
@@ -76,7 +77,9 @@ task('compile', function() {
   // Use this once typescript-gulp supports `include` in tsconfig:
   // const srcs = tsProject.src();
   return mergeStream(
-             srcs.pipe(typescript(tsProject)),
+             srcs.pipe(sourcemaps.init())
+                 .pipe(typescript(tsProject))
+                 .pipe(sourcemaps.write('../lib')),
              gulp.src(['src/**/*', '!src/**/*.ts']))
       .pipe(gulp.dest('lib'));
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-mocha": "^2.2.0",
     "gulp-newer": "^1.2.0",
     "gulp-shell": "^0.5.2",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^5.0.0",
     "gulp-typescript": "^2.13.4",
     "jsdoc-to-markdown": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mocha": "^2.2.4",
     "run-sequence": "^1.2.0",
     "sinon": "^1.17.4",
+    "source-map-support": "^0.4.2",
     "temp": "^0.8.3",
     "tslint": "^3.10.2",
     "typescript": "^2.0.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --ui tdd
+--require source-map-support/register
 lib/test/*_test.js lib/test/**/*_test.js


### PR DESCRIPTION
Tired of figuring out which javascript line was which typescript line when npm test failures happened so I'm adding sourcemap support.

Note: because we use gulp-typescript to incrementally build (it wont build if js file is newer than ts), you need to blow out your lib/ folder to have the maps generate if you're pulling this to existing clone.