### PR TITLE
Measure and improve resolution performance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "4"
   - "6"
 script:
-- npm test
+- npm test && npm run benchmark

--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="./chai.d.ts" />
 /// <reference path="./espree.d.ts" />
 /// <reference path="./jsonschema.d.ts" />
+/// <reference path="./performance-now.d.ts" />
 /// <reference path="./shady-css-parser.d.ts" />

--- a/custom_typings/performance-now.d.ts
+++ b/custom_typings/performance-now.d.ts
@@ -1,0 +1,5 @@
+declare module 'performance-now' {
+  function now(): number;
+  namespace now {}
+  export = now;
+}

--- a/package.json
+++ b/package.json
@@ -23,13 +23,15 @@
     "lint": "gulp lint",
     "test": "npm run clean && npm run build && npm run lint && mocha",
     "quicktest": "npm run build && mocha",
-    "benchmark": "npm run build && time node lib/perf/parse-all-benchmark.js",
+    "initBench": "if [ ! -d bower_components ]; then bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi",
+    "benchmark": "npm run build && npm run initBench && node lib/perf/parse-all-benchmark.js",
     "test:watch": "watchy -w src/ -- npm run quicktest --loglevel=silent",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i"
   },
   "devDependencies": {
     "@types/chai": "^3.4.29",
     "@types/mocha": "^2.2.28",
+    "bower": "^1.7.9",
     "chai": "^2.2.0",
     "chai-subset": "^1.3.0",
     "clang-format": "^1.0.42",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "gulp lint",
     "test": "npm run clean && npm run build && npm run lint && mocha",
     "quicktest": "npm run build && mocha",
+    "benchmark": "npm run build && time node lib/perf/parse-all-benchmark.js",
     "test:watch": "watchy -w src/ -- npm run quicktest --loglevel=silent",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i"
   },
@@ -68,6 +69,7 @@
     "espree": "^3.1.7",
     "estraverse": "^3.1.0",
     "parse5": "^2.1.5",
+    "performance-now": "^0.2.0",
     "shady-css-parser": "0.0.8"
   }
 }

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -73,7 +73,7 @@ function existsSync(fn: string): boolean {
 }
 
 const fakeFileContents =
-    filesToAnalyze.map(fn => `<link rel="import" href="${fn}">`).join('\n');
+    filesToAnalyze.map((fn) => `<link rel="import" href="${fn}">`).join('\n');
 
 function padLeft(str: string, num: number): string {
   if (str.length < num) {
@@ -82,7 +82,7 @@ function padLeft(str: string, num: number): string {
   return str;
 }
 
-const measure = async() => {
+async function measure() {
   let document: any;
   for (let i = 0; i < 10; i++) {
     document = await analyzer.analyzeRoot('ephemeral.html', fakeFileContents);
@@ -147,9 +147,9 @@ class Averager<K> {
 
   entries(): Iterable<[K, number]> {
     const entries = this.count.keys().map(
-        k => <[K, number]>[k, this.elapsed.get(k) / this.count.get(k)]);
+        (k) => <[K, number]>[k, this.elapsed.get(k) / this.count.get(k)]);
     return entries.sort((a, b) => a[1] - b[1]);
   }
 }
 
-measure().catch(err => console.log(err.stack));
+measure().catch((err) => console.log(err.stack));

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -14,6 +14,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as now from 'performance-now';
 
 import {Analyzer} from '../analyzer';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
@@ -83,6 +84,7 @@ function padLeft(str: string, num: number): string {
 }
 
 async function measure() {
+  const start = now();
   let document: any;
   for (let i = 0; i < 10; i++) {
     document = await analyzer.analyzeRoot('ephemeral.html', fakeFileContents);
@@ -92,6 +94,8 @@ async function measure() {
   printMeasurements(measurements);
 
   console.log(`\n\n\n${document.getFeatures().size} total features resolved.`);
+  console.log(
+      `${((now() - start) / 1000).toFixed(2)} seconds total elapsed time`);
 };
 
 function printMeasurements(measurements: Measurement[]) {
@@ -123,7 +127,10 @@ function printMeasurements(measurements: Measurement[]) {
 
 class Counter<K> {
   private _map = new Map<K, number>();
-  add(k: K, v = 1) {
+  add(k: K, v?: number) {
+    if (v == null) {
+      v = 1;
+    }
     let i = this._map.get(k) || 0;
     this._map.set(k, i + v);
   }
@@ -152,4 +159,4 @@ class Averager<K> {
   }
 }
 
-measure().catch((err) => console.log(err.stack));
+measure().catch(((err) => console.log(err.stack) && process.exit(1)));

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {Analyzer} from '../analyzer';
+import {FSUrlLoader} from '../url-loader/fs-url-loader';
+import {UrlLoader} from '../url-loader/url-loader';
+
+import {Measurement} from './telemetry';
+
+class PermissiveUrlLoader implements UrlLoader {
+  private _realLoader: UrlLoader;
+  constructor(realLoader: UrlLoader) {
+    this._realLoader = realLoader;
+  }
+  canLoad() {
+    return true;
+  }
+  async load(path: string) {
+    try {
+      return await this._realLoader.load(path);
+    } catch (_) {
+      // muddle on!
+    }
+    return '';
+  }
+}
+
+const bowerDir = path.resolve(__dirname, `../../bower_components`);
+const analyzer = new Analyzer(
+    {urlLoader: new PermissiveUrlLoader(new FSUrlLoader(bowerDir))});
+
+const filesToAnalyze: string[] = [];
+
+for (const baseDir of fs.readdirSync(bowerDir)) {
+  const bowerJsonPath = path.join(bowerDir, baseDir, 'bower.json');
+  let bowerJson: any;
+  try {
+    bowerJson = JSON.parse(fs.readFileSync(bowerJsonPath, 'utf-8'));
+  } catch (e) {
+    continue;
+  }
+  const main: string|string[] = bowerJson.main || [];
+  const mains = Array.isArray(main) ? main : [main];
+  for (const mainFile of mains) {
+    if (existsSync(path.join(bowerDir, baseDir, mainFile))) {
+      filesToAnalyze.push(path.join(baseDir, mainFile));
+    }
+  }
+}
+
+
+function existsSync(fn: string): boolean {
+  try {
+    fs.statSync(fn);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+const fakeFileContents =
+    filesToAnalyze.map(fn => `<link rel="import" href="${fn}">`).join('\n');
+
+function padLeft(str: string, num: number): string {
+  if (str.length < num) {
+    return padLeft(' ' + str, num);
+  }
+  return str;
+}
+
+const measure = async() => {
+  let document: any;
+  for (let i = 0; i < 10; i++) {
+    document = await analyzer.analyzeRoot('ephemeral.html', fakeFileContents);
+  }
+
+  const measurements = await analyzer.getTelemetryMeasurements();
+  printMeasurements(measurements);
+
+  console.log(`\n\n\n${document.getFeatures().size} total features resolved.`);
+};
+
+function printMeasurements(measurements: Measurement[]) {
+  console.log(`\n\n\n\n
+      The most important thing to benchmark is the resolve step, as everything
+      else is cacheable. Here are times for resolving every element in the
+      PolymerElements org.
+
+      The total time for this benchmark will also include the initial parse and
+      scan and so should be much much longer.
+  `);
+  const averager = new Averager<string>();
+  console.log(`${padLeft('elapsed ms', 10)} - ${padLeft('operation', 30)}`);
+  for (const m of measurements) {
+    if (m.kind === 'Document.makeRootDocument') {
+      console.log(
+          `${padLeft(m.elapsedTime.toFixed(0), 10)} - ${padLeft(m.kind, 30)}`);
+    }
+    averager.addElapsed(m.kind, m.elapsedTime);
+  }
+
+  console.log('\n');
+  console.log(`${padLeft('average ms', 10)} - ${padLeft('operation', 30)}`);
+  for (const entry of averager.entries()) {
+    console.log(
+        `${padLeft(entry[1].toFixed(0), 10)} - ${padLeft(entry[0], 30)}`);
+  }
+}
+
+class Counter<K> {
+  private _map = new Map<K, number>();
+  add(k: K, v = 1) {
+    let i = this._map.get(k) || 0;
+    this._map.set(k, i + v);
+  }
+
+  get(k: K): number {
+    return this._map.get(k);
+  }
+
+  keys(): K[] {
+    return Array.from(this._map.keys());
+  }
+}
+class Averager<K> {
+  private count = new Counter<K>();
+  private elapsed = new Counter<K>();
+
+  addElapsed(k: K, elapsed: number) {
+    this.count.add(k);
+    this.elapsed.add(k, elapsed);
+  }
+
+  entries(): Iterable<[K, number]> {
+    const entries = this.count.keys().map(
+        k => <[K, number]>[k, this.elapsed.get(k) / this.count.get(k)]);
+    return entries.sort((a, b) => a[1] - b[1]);
+  }
+}
+
+measure().catch(err => console.log(err.stack));

--- a/src/perf/telemetry.ts
+++ b/src/perf/telemetry.ts
@@ -15,6 +15,7 @@
 import * as now from 'performance-now';
 
 export interface Measurement {
+  /** The time that the measured operation took, in milliseconds. */
   elapsedTime: number;
   /**
    * A descriptive category for the measured operation, e.g. 'parse' or

--- a/src/perf/telemetry.ts
+++ b/src/perf/telemetry.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as now from 'performance-now';
+
+export interface Measurement {
+  elapsedTime: number;
+  kind: string;
+  identifier: string;
+}
+
+export class TelemetryTracker {
+  private _measurements: Measurement[] = [];
+  private _promises: Promise<any>[] = [];
+  async getMeasurements(): Promise<Measurement[]> {
+    await Promise.all(this._promises);
+    return this._measurements;
+  }
+
+  /**
+   * Less useful than it seems, because the time between promise creation and
+   * the promise settling isn't just work related to the promise. e.g. if you
+   * begin loading a remote file, but then get stuck parsing hydrolysis.js then
+   * you're going to be charged both for the loading and the parsing time,
+   * because the parsing doesn't get interrupted when the loading completes.
+   */
+  async track(promise: Promise<any>, kind: string, identifier: string) {
+    const track = this._track(promise, kind, identifier);
+    this._promises.push(track);
+  }
+
+  private async _track(
+      promise: Promise<any>, kind: string, identifier: string) {
+    const start = now();
+    try {
+      await promise;
+    } catch (_) { /* don't care */
+    }
+    const elapsed = now() - start;
+    this._measurements.push({elapsedTime: elapsed, kind, identifier});
+  }
+
+  start(kind: string, identifier: string): () => void {
+    let resolve: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    this.track(promise, kind, identifier);
+    return resolve;
+  }
+}

--- a/src/perf/telemetry.ts
+++ b/src/perf/telemetry.ts
@@ -23,6 +23,7 @@ export interface Measurement {
 export class TelemetryTracker {
   private _measurements: Measurement[] = [];
   private _promises: Promise<any>[] = [];
+
   async getMeasurements(): Promise<Measurement[]> {
     await Promise.all(this._promises);
     return this._measurements;

--- a/src/perf/telemetry.ts
+++ b/src/perf/telemetry.ts
@@ -16,7 +16,16 @@ import * as now from 'performance-now';
 
 export interface Measurement {
   elapsedTime: number;
+  /**
+   * A descriptive category for the measured operation, e.g. 'parse' or
+   * 'resolve'.
+   */
   kind: string;
+  /**
+   * A helpful identifier for the item that the measured operation was working
+   * on. e.g. a url or file path like
+   * './bower_components/paper-button/paper-button.html'
+   */
   identifier: string;
 }
 

--- a/src/test/perf/telemetry_test.ts
+++ b/src/test/perf/telemetry_test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+
+import {TelemetryTracker} from '../../perf/telemetry';
+
+suite('TelemetryTracker', function() {
+
+  test('it can track the performance of synchronous code', async() => {
+    const tracker = new TelemetryTracker();
+    const doneTracking = tracker.start('test-kind', 'test-id');
+    doneTracking();
+    const measurements = await tracker.getMeasurements();
+    assert.lengthOf(measurements, 1);
+    const measurement = measurements[0]!;
+    assert.deepEqual(measurement.kind, 'test-kind');
+    assert.deepEqual(measurement.identifier, 'test-id');
+    assert(measurement.elapsedTime >= 0);
+    assert(measurement.elapsedTime <= 10);
+  });
+
+  test('it can track the performance of async code.. kinda', async() => {
+    const tracker = new TelemetryTracker();
+    const promise = new Promise((resolve) => setTimeout(resolve, 0));
+    tracker.track(promise, 'test-kind', 'test-id');
+    const measurements = await tracker.getMeasurements();
+    assert.lengthOf(measurements, 1);
+    const measurement = measurements[0]!;
+    assert.deepEqual(measurement.kind, 'test-kind');
+    assert.deepEqual(measurement.identifier, 'test-id');
+    assert(measurement.elapsedTime >= 0);
+    assert(measurement.elapsedTime <= 10);
+  });
+
+});


### PR DESCRIPTION
Makes Document generation linear (was quadratic) by adding some simple indexes on kind and kind+identifier on the root document.

Before this change Document.makeRootDocument on all PolymerElements sources took 1500ms, after this it takes ~30ms.

Also adds a resolution benchmark runnable with `npm run benchmark`