### PR TITLE
Created a CssImportScanner to support deprecated, but still supported, polymer-specific <link rel="import" type="css"> imports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/node": "^4.0.30",
     "@types/parse5": "0.0.27",
     "doctrine": "^0.7.0",
-    "dom5": "^1.1.0",
+    "dom5": "^1.3.5",
     "escodegen": "^1.7.0",
     "espree": "^3.1.7",
     "estraverse": "^3.1.0",

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -29,6 +29,7 @@ import {ParsedDocument} from './parser/document';
 import {Parser} from './parser/parser';
 import {Measurement, TelemetryTracker} from './perf/telemetry';
 import {BehaviorScanner} from './polymer/behavior-scanner';
+import {CssImportScanner} from './polymer/css-import-scanner';
 import {DomModuleScanner} from './polymer/dom-module-scanner';
 import {PolymerElementScanner} from './polymer/polymer-element-scanner';
 import {scan} from './scanning/scan';
@@ -67,7 +68,8 @@ export class Analyzer {
       'html',
       [
         new HtmlImportScanner(), new HtmlScriptScanner(),
-        new HtmlStyleScanner(), new DomModuleScanner()
+        new HtmlStyleScanner(), new DomModuleScanner(),
+        new CssImportScanner()
       ]
     ],
     [

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -22,10 +22,9 @@ import {HtmlScanner} from './html-scanner';
 
 const p = dom5.predicates;
 
-const isHtmlImportNode = p.AND(p.hasTagName('link'), (node) => {
-  const rel = dom5.getAttribute(node, 'rel') || '';
-  return rel.split(' ').indexOf('import') !== -1;
-}, p.NOT(p.hasAttrValue('type', 'css')));
+const isHtmlImportNode = p.AND(
+    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'import'),
+    p.NOT(p.hasAttrValue('type', 'css')));
 
 export class HtmlImportScanner implements HtmlScanner {
   async scan(

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -26,10 +26,8 @@ const isStyleElement = p.AND(
     p.hasTagName('style'),
     p.OR(p.NOT(p.hasAttr('type')), p.hasAttrValue('type', 'text/css')));
 
-const isStyleLink = p.AND(p.hasTagName('link'), (node) => {
-  const rel = dom5.getAttribute(node, 'rel') || '';
-  return rel.split(' ').indexOf('stylesheet') !== -1;
-});
+const isStyleLink = p.AND(p.hasTagName('link'),
+    p.hasSpaceSeparatedAttrValue('rel', 'stylesheet'));
 
 const isStyleNode = p.OR(isStyleElement, isStyleLink);
 

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as dom5 from 'dom5';
+import {resolve as resolveUrl} from 'url';
+
+import {ScannedImport} from '../ast/ast';
+
+import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
+import {HtmlScanner} from '../html/html-scanner';
+
+const p = dom5.predicates;
+
+const isCssImportNode = p.AND(p.hasTagName('link'), (node) => {
+  const rel = dom5.getAttribute(node, 'rel') || '';
+  return rel.split(' ').indexOf('import') !== -1;
+}, p.hasAttrValue('type', 'css'));
+
+export class CssImportScanner implements HtmlScanner {
+  async scan(
+      document: ParsedHtmlDocument,
+      visit: (visitor: HtmlVisitor) => Promise<void>):
+      Promise<ScannedImport[]> {
+    const imports: ScannedImport[] = [];
+
+    await visit((node) => {
+      if (isCssImportNode(node)) {
+        const href = dom5.getAttribute(node, 'href');
+        const importUrl = resolveUrl(document.url, href);
+        imports.push(new ScannedImport(
+            'css-import', importUrl, document.sourceRangeForNode(node)));
+      }
+    });
+    return imports;
+  }
+}

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -22,10 +22,8 @@ import {HtmlScanner} from '../html/html-scanner';
 
 const p = dom5.predicates;
 
-const isCssImportNode = p.AND(p.hasTagName('link'), (node) => {
-  const rel = dom5.getAttribute(node, 'rel') || '';
-  return rel.split(' ').indexOf('import') !== -1;
-}, p.hasAttrValue('type', 'css'));
+const isCssImportNode = p.AND(
+    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'import'), p.hasAttrValue('type', 'css'), p.parentMatches(p.hasTagName('dom-module')));
 
 export class CssImportScanner implements HtmlScanner {
   async scan(

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -170,17 +170,19 @@ suite('Analyzer', () => {
 
     test('polymer css import scanner', async() => {
       let contents = `<html><head>
-          <link rel="import" type="css" href="bar.css">
-        </head></html>`;
+          <link rel="import" type="css" href="foo.css">
+        </head>
+        <body>
+          <dom-module>
+            <link rel="import" type="css" href="bar.css">
+          </dom-module>
+        </body></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
-      const features =
-          <ScannedImport[]>(await analyzer['_getScannedFeatures'](document));
-      assert.deepEqual(
-          features.map(e => e.type),
-          ['css-import']);
-      assert.deepEqual(
-          features.map(e => e.url),
-          ['bar.css']);
+      const features = <ScannedImport[]>(await analyzer['_getScannedFeatures'](document))
+          .filter(e => e instanceof ScannedImport);
+      assert.equal(features.length, 1);
+      assert.equal(features[0].type, 'css-import');
+      assert.equal(features[0].url, 'bar.css');
     });
 
     test('HTML inline document scanners', async() => {

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -168,6 +168,21 @@ suite('Analyzer', () => {
           ['polymer.html', 'foo.js', 'foo.css']);
     });
 
+    test('polymer css import scanner', async() => {
+      let contents = `<html><head>
+          <link rel="import" type="css" href="bar.css">
+        </head></html>`;
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const features =
+          <ScannedImport[]>(await analyzer['_getScannedFeatures'](document));
+      assert.deepEqual(
+          features.map(e => e.type),
+          ['css-import']);
+      assert.deepEqual(
+          features.map(e => e.url),
+          ['bar.css']);
+    });
+
     test('HTML inline document scanners', async() => {
       let contents = `<html><head>
           <script>console.log('hi')</script>

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -13,9 +13,8 @@
  */
 
 import {assert} from 'chai';
-import * as parse5 from 'parse5';
-
-import {HtmlVisitor, ParsedHtmlDocument} from '../../html/html-document';
+import {HtmlParser} from '../../html/html-parser';
+import {HtmlVisitor} from '../../html/html-document';
 import {HtmlImportScanner} from '../../html/html-import-scanner';
 
 suite('HtmlImportScanner', () => {
@@ -28,19 +27,14 @@ suite('HtmlImportScanner', () => {
     });
 
     test('finds HTML Imports', async() => {
-      let contents = `<html><head>
+      const contents = `<html><head>
           <link rel="import" href="polymer.html">
           <link rel="import" type="css" href="polymer.css">
           <script src="foo.js"></script>
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
-      let ast = parse5.parse(contents);
-      let document = new ParsedHtmlDocument({
-        url: 'test.html',
-        contents,
-        ast,
-      });
-      let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
       const features = await scanner.scan(document, visit);
       assert.equal(features.length, 1);

--- a/src/test/polymer/css-import-scanner_test.ts
+++ b/src/test/polymer/css-import-scanner_test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+
+ import {assert} from 'chai';
+ import * as parse5 from 'parse5';
+
+ import {HtmlVisitor, ParsedHtmlDocument} from '../../html/html-document';
+ import {CssImportScanner} from '../../polymer/css-import-scanner';
+
+ suite('CssImportScanner', () => {
+
+   suite('scan()', () => {
+     let scanner: CssImportScanner;
+
+     setup(() => {
+       scanner = new CssImportScanner();
+     });
+
+     test('finds CSS Imports', async() => {
+       let contents = `<html><head>
+           <link rel="import" href="polymer.html">
+           <link rel="import" type="css" href="polymer.css">
+           <script src="foo.js"></script>
+           <link rel="stylesheet" href="foo.css"></link>
+         </head></html>`;
+       let ast = parse5.parse(contents);
+       let document = new ParsedHtmlDocument({
+         url: 'test.html',
+         contents,
+         ast,
+       });
+       let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+       const features = await scanner.scan(document, visit);
+       assert.equal(features.length, 1);
+       assert.equal(features[0].type, 'css-import');
+       assert.equal(features[0].url, 'polymer.css');
+     });
+
+   });
+
+ });


### PR DESCRIPTION
 - Created a new CssImportScanner and test suite.
 - Include the new scanner in Analyzer's html document scanners list.
 - Added a new Analyzer test.

Note: required for bundler to support css inlining.