### PR TITLE
Add a stdin/stdout interface to editor-server.

### DIFF
--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -3,3 +3,4 @@
 /// <reference path="./jsonschema.d.ts" />
 /// <reference path="./performance-now.d.ts" />
 /// <reference path="./shady-css-parser.d.ts" />
+/// <reference path="./split.d.ts" />

--- a/custom_typings/split.d.ts
+++ b/custom_typings/split.d.ts
@@ -1,0 +1,13 @@
+// The upstream version of this file isn't es module compatible.
+// Need to send a PR to fix that.
+
+declare module 'split' {
+  interface SplitOptions {
+    maxLength: number
+  }
+
+  function split(matcher?: any, mapper?: any, options?: SplitOptions): any;
+  namespace split {}
+
+  export = split;
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "estraverse": "^3.1.0",
     "parse5": "^2.1.5",
     "performance-now": "^0.2.0",
-    "shady-css-parser": "0.0.8"
+    "shady-css-parser": "0.0.8",
+    "split": "^1.0.0"
   }
 }

--- a/src/editor-service/editor-server.ts
+++ b/src/editor-service/editor-server.ts
@@ -12,6 +12,16 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+/**
+ * This file is a binary not a library, and should be run via
+ * `node editor-server.js` or `child_process.fork`
+ *
+ * Communication with this server is done via the Remote Editor Protocol via
+ * stdin and stdout, as well as the node process.on('message') IPC process.
+ *
+ * See 'remote-editor-protocol.ts' for details on the communication protocol.
+ */
+
 import * as split from 'split';
 import * as util from 'util';
 

--- a/src/editor-service/editor-server.ts
+++ b/src/editor-service/editor-server.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as split from 'split';
 import * as util from 'util';
 
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
@@ -21,74 +22,83 @@ import {LocalEditorService} from './local-editor-service';
 import {Request, RequestWrapper, ResponseWrapper, SettledValue} from './remote-editor-protocol';
 
 
+
 /**
- * Runs out of process and handles decoded Requests.
+ * Handles decoded Requests, dispatching them to a local editor service.
  */
 class EditorServer {
   private _localEditorService: LocalEditorService;
-  constructor(basedir: string) {
-    this._localEditorService = new LocalEditorService({
-      urlLoader: new FSUrlLoader(basedir),
-      urlResolver: new PackageUrlResolver()
-    });
-  }
 
   async handleMessage(message: Request): Promise<any> {
+    if (message.kind === 'init') {
+      if (this._localEditorService) {
+        throw new Error('Already initialized!');
+      }
+      this._localEditorService = new LocalEditorService({
+        urlLoader: new FSUrlLoader(message.basedir),
+        urlResolver: new PackageUrlResolver()
+      });
+      return;
+    }
+    const localEditorService = this._localEditorService;
+    if (!localEditorService) {
+      throw new Error(
+          `Must send an 'init' message before any others. ` +
+          `Received '${message.kind}' message before 'init'.`);
+    }
     switch (message.kind) {
       case 'getWarningsFor':
-        return this._localEditorService.getWarningsForFile(message.localPath);
+        return localEditorService.getWarningsForFile(message.localPath);
       case 'fileChanged':
-        await this._localEditorService.fileChanged(
+        await localEditorService.fileChanged(
             message.localPath, message.contents);
         return;
-      case 'init':
-        throw new Error('Already initialized!');
       case 'getDefinitionFor':
-        return this._localEditorService.getDefinitionForFeatureAtPosition(
+        return localEditorService.getDefinitionForFeatureAtPosition(
             message.localPath, message.position);
       case 'getDocumentationFor':
-        return this._localEditorService.getDocumentationAtPosition(
+        return localEditorService.getDocumentationAtPosition(
             message.localPath, message.position);
       case 'getTypeaheadCompletionsFor':
-        return this._localEditorService.getTypeaheadCompletionsAtPosition(
+        return localEditorService.getTypeaheadCompletionsAtPosition(
             message.localPath, message.position);
       case '_clearCaches':
-        return this._localEditorService._clearCaches();
+        return localEditorService._clearCaches();
       default:
-        // This assignment makes it a type error if we don't handle all possible
-        // values of `message.kind`.
         const never: never = message;
         throw new Error(`Got unknown kind of message: ${util.inspect(never)}`);
     }
   }
 }
 
-let server: EditorServer;
-process.once('message', (initRequest: RequestWrapper) => {
-  if (initRequest.value.kind !== 'init') {
-    process.send(<ResponseWrapper>{
-      id: initRequest.id,
-      value: {
-        kind: 'rejection',
-        rejection: `Expected first message to be 'init', ` +
-            `got ${initRequest.value.kind}`
-      }
-    });
-    return;
-  }
-  server = new EditorServer(initRequest.value.basedir);
 
-  process.on('message', async(request: RequestWrapper) => {
-    const result = await getSettledValue(request.value);
-    process.send(<ResponseWrapper>{id: request.id, value: result});
-  });
+const server: EditorServer = new EditorServer();
+
+// stdin/stdout interface
+process.stdin.setEncoding('utf8');
+process.stdin.resume();
+process.stdin.pipe(split()).on('data', async function(line: string) {
+  const request: RequestWrapper = JSON.parse(line);
+  const result = await getSettledValue(request.value);
+  process.stdout.write(
+      JSON.stringify(<ResponseWrapper>{id: request.id, value: result}) + '\n');
 });
 
-async function getSettledValue(message: Request): Promise<SettledValue> {
+// node child_process.fork() IPC interface
+process.on('message', async function(request: RequestWrapper) {
+  const result = await getSettledValue(request.value);
+  process.send(<ResponseWrapper>{id: request.id, value: result});
+});
+
+
+/**
+ * Calls into the server and converts its responses into SettledValues.
+ */
+async function getSettledValue(request: Request): Promise<SettledValue> {
   try {
-    const value = await server.handleMessage(message);
+    const value = await server.handleMessage(request);
     return {kind: 'resolution', resolution: value};
   } catch (e) {
-    return {kind: 'rejection', rejection: e.stack || e.message || e.toString()};
+    return {kind: 'rejection', rejection: e.message || e.stack || e.toString()};
   }
 }

--- a/src/test/editor-service/editor-server-test.ts
+++ b/src/test/editor-service/editor-server-test.ts
@@ -16,6 +16,7 @@ import {assert} from 'chai';
 import * as child_process from 'child_process';
 import * as path from 'path';
 import * as split from 'split';
+import * as util from 'util';
 
 import {invertPromise} from '../test-utils';
 
@@ -103,13 +104,15 @@ suite('RemoteEditorService', () => {
             });
           });
           assert.equal(message.id, expectedId);
-          return new Promise((resolve, reject) => {
-            if (message.value.kind === 'resolution') {
-              resolve(message.value.resolution);
-            } else if (message.value.kind === 'rejection') {
-              reject(message.value.rejection);
-            }
-          });
+
+          if (message.value.kind === 'resolution') {
+            return message.value.resolution;
+          }
+          if (message.value.kind === 'rejection') {
+            throw message.value.rejection;
+          }
+          throw new Error(
+              `Response with unexpected kind: ${util.inspect(message.value)}`);
         };
 
         editorServiceInterfaceTests(sendRequest, getNextResponse);

--- a/src/test/editor-service/editor-server-test.ts
+++ b/src/test/editor-service/editor-server-test.ts
@@ -147,13 +147,13 @@ suite('RemoteEditorService', () => {
           await new Promise<string>(resolve => lines.once('data', resolve));
       const message = JSON.parse(line);
       assert.equal(message.id, expectedId);
-      return new Promise((resolve, reject) => {
-        if (message.value.kind === 'resolution') {
-          resolve(message.value.resolution);
-        } else if (message.value.kind === 'rejection') {
-          reject(message.value.rejection);
-        }
-      });
+      if (message.value.kind === 'resolution') {
+        return message.value.resolution;
+      } else if (message.value.kind === 'rejection') {
+        throw message.value.rejection;
+      }
+      throw new Error(
+          `Response with unexpected kind: ${util.inspect(message.value)}`);
     }
 
     editorServiceInterfaceTests(sendRequest, getNextResponse);

--- a/src/test/editor-service/editor-server-test.ts
+++ b/src/test/editor-service/editor-server-test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as child_process from 'child_process';
+import * as path from 'path';
+import * as split from 'split';
+
+import {invertPromise} from '../test-utils';
+
+const pathToServer =
+    path.join(__dirname, '../../editor-service/editor-server.js');
+
+suite('RemoteEditorService', function() {
+  /**
+   * These are the tests. We run these tests using a few different ways of
+   * communicating with the server.
+   */
+  function editorServiceInterfaceTests(
+      sendRequest: (request: any) => Promise<void>,
+      getNextResponse: (expectedId: number) => Promise<any>) {
+    const initMessage = {
+      kind: 'init',
+      basedir: `${path.join(__dirname, 'static')}`
+    };
+    const getWarningsMessage = {
+      kind: 'getWarningsFor',
+      localPath: 'malformed.html'
+    };
+
+
+    test('can create and initialize', async function() {
+      await sendRequest({id: 0, value: initMessage});
+      const response = await getNextResponse(0);
+      assert.deepEqual(response, undefined);
+    });
+    test('initializing twice is an error', async function() {
+      await sendRequest({id: 0, value: initMessage});
+      await getNextResponse(0);
+      await sendRequest({id: 1, value: initMessage});
+      const errorMessage = await invertPromise(getNextResponse(1));
+      assert.equal(errorMessage, 'Already initialized!');
+    });
+    test('the first request must be initialization', async function() {
+      await sendRequest({id: 0, value: getWarningsMessage});
+      const errorMessage = await invertPromise(getNextResponse(0));
+      assert.equal(
+          errorMessage,
+          `Must send an 'init' message before any others. Received ` +
+              `'getWarningsFor' message before 'init'.`);
+    });
+    const testName = 'can perform editor service functions once initialized';
+    test(testName, async function() {
+      await sendRequest({id: 0, value: initMessage});
+      await getNextResponse(0);
+      await sendRequest({id: 1, value: getWarningsMessage});
+      const warnings = await getNextResponse(1);
+      assert.deepEqual(warnings, [{
+                         code: 'parse-error',
+                         message: 'Unexpected token <',
+                         severity: 0,
+                         sourceRange: {
+                           file: 'malformed.html',
+                           start: {line: 266, column: 0},
+                           end: {line: 266, column: 0}
+                         }
+                       }]);
+    });
+  }
+
+  let suiteName =
+      'from node with child_process.fork() and process.send() for IPC';
+  suite(suiteName, function() {
+    let child: child_process.ChildProcess;
+    setup(() => {
+      child = child_process.fork(pathToServer);
+    });
+    teardown(() => {
+      child.kill();
+    });
+
+    async function sendRequest(request: any) {
+      child.send(request);
+    };
+
+    async function getNextResponse(expectedId: number) {
+      const message = await new Promise<any>((resolve) => {
+        child.once('message', function(msg: any) {
+          resolve(msg);
+        });
+      });
+      assert.equal(message.id, expectedId);
+      return new Promise((resolve, reject) => {
+        if (message.value.kind === 'resolution') {
+          resolve(message.value.resolution);
+        } else if (message.value.kind === 'rejection') {
+          reject(message.value.rejection);
+        }
+      });
+    };
+
+    editorServiceInterfaceTests(sendRequest, getNextResponse);
+  });
+
+  suiteName = 'from the command line with stdin and stdout';
+  suite(suiteName, function() {
+    let child: child_process.ChildProcess;
+    let lines: NodeJS.ReadableStream;
+    setup(() => {
+      child = child_process.spawn(
+          'node', [pathToServer], {stdio: ['pipe', 'pipe', 'pipe']});
+      child.stdout.setEncoding('utf8');
+      child.stdout.resume();
+      lines = child.stdout.pipe(split());
+    });
+    teardown(() => {
+      child.kill();
+    });
+
+    async function sendRequest(message: any) {
+      return new Promise<void>((resolve, reject) => {
+        child.stdin.write(JSON.stringify(message) + '\n', (err: any) => {
+          err ? reject(err) : resolve();
+        });
+      });
+    };
+
+    async function getNextResponse(expectedId: number) {
+      const line =
+          await new Promise<string>(resolve => lines.once('data', resolve));
+      const message = JSON.parse(line);
+      assert.equal(message.id, expectedId);
+      return new Promise((resolve, reject) => {
+        if (message.value.kind === 'resolution') {
+          resolve(message.value.resolution);
+        } else if (message.value.kind === 'rejection') {
+          reject(message.value.rejection);
+        }
+      });
+    }
+
+    editorServiceInterfaceTests(sendRequest, getNextResponse);
+  });
+});

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -27,10 +27,12 @@ import {invertPromise} from '../test-utils';
 function editorTests(editorFactory: (basedir: string) => EditorService) {
   const basedir = path.join(__dirname, '../static');
   const indexFile = path.join('editor-service', 'index.html');
+
   const tagPosition = {line: 7, column: 9};
   const tagPositionEnd = {line: 7, column: 21};
   const localAttributePosition = {line: 7, column: 31};
   const deepAttributePosition = {line: 7, column: 49};
+
   const elementTypeahead: ElementCompletion = {
     kind: 'element-tags',
     elements: [
@@ -74,6 +76,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
         copy.expandTo = `<${e.tagname}${space}></${e.tagname}>`;
         return copy;
       });
+
   const attributeTypeahead: AttributesCompletion = {
     kind: 'attributes',
     attributes: [
@@ -191,6 +194,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   });
 
   suite('getDefinitionForFeatureAtPosition', function() {
+
     test(
         `it supports getting the definition of ` +
             `an element from its tag`,
@@ -236,6 +240,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   });
 
   suite('getTypeaheadCompletionsAtPosition', function() {
+
     test('Get element completions for an empty text region.', async() => {
       await editorService.fileChanged(indexFile, `\n${indexContents}`);
       deepEqual(
@@ -349,6 +354,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   });
 
   suite('getWarningsForFile', function() {
+
     test('For a good document we get no warnings', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       deepEqual(await editorService.getWarningsForFile(indexFile), []);
@@ -446,6 +452,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   });
 
   suite('getWarnings', function() {
+
     test('For a good document we get no warnings', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       assert.deepEqual(await editorService.getWarningsForFile(indexFile), []);
@@ -504,10 +511,12 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
  * gone through a JSON stringify/parse pass.
  */
 let deepEqual: (actual: any, expected: any, message?: string) => void;
+
 suite('LocalEditorService', function() {
   suiteSetup(() => {
     deepEqual = assert.deepEqual;
   });
+
   editorTests((basedir) => new LocalEditorService({
                 urlLoader: new FSUrlLoader(basedir),
                 urlResolver: new PackageUrlResolver()
@@ -518,11 +527,14 @@ suite('LocalEditorService', function() {
 // in fast mode we cache them by basedir.
 const sloppyTest = !!process.env.QUICK_TESTS;
 suite('RemoteEditorService', function() {
+
   suiteSetup(() => {
     deepEqual = expectJsonDeepEqual;
   });
+
   const remoteEditorsByBasedir = new Map<string, RemoteEditorService>();
   const editors: RemoteEditorService[] = [];
+
   editorTests((basedir) => {
     if (sloppyTest) {
       const cachedServer = remoteEditorsByBasedir.get(basedir);

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -127,7 +127,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   // The weird cast is because the service will always be non-null when we
   // actually use it.
   let editorService: EditorService = <EditorService><any>null;
-  setup(async function() {
+  setup(async() => {
     editorService = editorFactory(basedir);
   });
 
@@ -138,37 +138,39 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
     const deepAttributeDescription =
         '{Array} This is a deeply inherited property.';
 
-    let testName = 'it supports getting the element description ' +
-        'when asking for docs at its tag name';
+    test(
+        'it supports getting the element description ' +
+            'when asking for docs at its tag name',
+        async() => {
+          await editorService.fileChanged(indexFile, indexContents);
+          assert.equal(
+              await editorService.getDocumentationAtPosition(
+                  indexFile, tagPosition),
+              tagDescription);
+        });
 
-    test(testName, async function() {
-      await editorService.fileChanged(indexFile, indexContents);
-      assert.equal(
-          await editorService.getDocumentationAtPosition(
-              indexFile, tagPosition),
-          tagDescription);
-    });
+    test(
+        'it can still get element info after changing a file in memory',
+        async() => {
+          await editorService.fileChanged(indexFile, indexContents);
+          const contents =
+              fs.readFileSync(path.join(basedir, indexFile), 'utf-8');
+          // Add a newline at the beginning of the file, shifting the lines
+          // down.
+          await editorService.fileChanged(indexFile, `\n${contents}`);
 
-    testName = 'it can still get element info after changing a file in memory';
-    test(testName, async function() {
-      await editorService.fileChanged(indexFile, indexContents);
-      const contents = fs.readFileSync(path.join(basedir, indexFile), 'utf-8');
-      // Add a newline at the beginning of the file, shifting the lines
-      // down.
-      await editorService.fileChanged(indexFile, `\n${contents}`);
+          assert.equal(
+              await editorService.getDocumentationAtPosition(
+                  indexFile, tagPosition),
+              undefined);
+          assert.equal(
+              await editorService.getDocumentationAtPosition(
+                  indexFile,
+                  {line: tagPosition.line + 1, column: tagPosition.column}),
+              tagDescription, );
+        });
 
-      assert.equal(
-          await editorService.getDocumentationAtPosition(
-              indexFile, tagPosition),
-          undefined);
-      assert.equal(
-          await editorService.getDocumentationAtPosition(
-              indexFile,
-              {line: tagPosition.line + 1, column: tagPosition.column}),
-          tagDescription, );
-    });
-
-    test('it supports getting an attribute description', async function() {
+    test('it supports getting an attribute description', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       assert.equal(
           await editorService.getDocumentationAtPosition(
@@ -176,34 +178,35 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           localAttributeDescription);
     });
 
-    testName = 'it supports getting a description of an attribute ' +
-        'defined in a behavior';
-    test(testName, async function() {
-      await editorService.fileChanged(indexFile, indexContents);
-      assert.equal(
-          await editorService.getDocumentationAtPosition(
-              indexFile, deepAttributePosition),
-          deepAttributeDescription);
-    });
+    test(
+        'it supports getting a description of an attribute ' +
+            'defined in a behavior',
+        async() => {
+          await editorService.fileChanged(indexFile, indexContents);
+          assert.equal(
+              await editorService.getDocumentationAtPosition(
+                  indexFile, deepAttributePosition),
+              deepAttributeDescription);
+        });
   });
 
   suite('getDefinitionForFeatureAtPosition', function() {
-    let testName = `it supports getting the definition of ` +
-        `an element from its tag`;
-    test(testName, async function() {
-      await editorService.fileChanged(indexFile, indexContents);
-      deepEqual(
-          await editorService.getDefinitionForFeatureAtPosition(
-              indexFile, tagPosition),
-          {
-            file: 'analysis/behaviors/elementdir/element.html',
-            start: {line: 4, column: 10},
-            end: {line: 24, column: 3}
-          });
-    });
+    test(
+        `it supports getting the definition of ` +
+            `an element from its tag`,
+        async() => {
+          await editorService.fileChanged(indexFile, indexContents);
+          deepEqual(
+              await editorService.getDefinitionForFeatureAtPosition(
+                  indexFile, tagPosition),
+              {
+                file: 'analysis/behaviors/elementdir/element.html',
+                start: {line: 4, column: 10},
+                end: {line: 24, column: 3}
+              });
+        });
 
-    testName = 'it supports getting the definition of a local attribute';
-    test(testName, async function() {
+    test('it supports getting the definition of a local attribute', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       deepEqual(
           await editorService.getDefinitionForFeatureAtPosition(
@@ -215,25 +218,25 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           });
     });
 
-    testName = 'it supports getting the definition of an attribute ' +
-        'defined in a behavior';
-    test(testName, async function() {
-      await editorService.fileChanged(indexFile, indexContents);
-      deepEqual(
-          await editorService.getDefinitionForFeatureAtPosition(
-              indexFile, deepAttributePosition),
-          {
-            file: 'analysis/behaviors/subdir/subbehavior.html',
-            start: {line: 5, column: 6},
-            end: {line: 11, column: 7}
-          });
-    });
+    test(
+        'it supports getting the definition of an attribute ' +
+            'defined in a behavior',
+        async() => {
+          await editorService.fileChanged(indexFile, indexContents);
+          deepEqual(
+              await editorService.getDefinitionForFeatureAtPosition(
+                  indexFile, deepAttributePosition),
+              {
+                file: 'analysis/behaviors/subdir/subbehavior.html',
+                start: {line: 5, column: 6},
+                end: {line: 11, column: 7}
+              });
+        });
 
   });
 
   suite('getTypeaheadCompletionsAtPosition', function() {
-    let testName = 'Get element completions for an empty text region.';
-    test(testName, async function() {
+    test('Get element completions for an empty text region.', async() => {
       await editorService.fileChanged(indexFile, `\n${indexContents}`);
       deepEqual(
           await editorService.getTypeaheadCompletionsAtPosition(
@@ -241,8 +244,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           emptyStartElementTypeahead);
     });
 
-    testName = 'Get element completions for a start tag.';
-    test(testName, async function() {
+    test('Get element completions for a start tag.', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       deepEqual(
           await editorService.getTypeaheadCompletionsAtPosition(
@@ -250,8 +252,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           elementTypeahead);
     });
 
-    testName = 'Gets element completions with an incomplete tag';
-    test(testName, async function() {
+    test('Gets element completions with an incomplete tag', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       const incompleteText = `<behav>`;
       editorService.fileChanged(
@@ -262,7 +263,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           elementTypeahead);
     });
 
-    test('Get element completions for the end of a tag', async function() {
+    test('Get element completions for the end of a tag', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       deepEqual(
           await editorService.getTypeaheadCompletionsAtPosition(
@@ -270,17 +271,17 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           elementTypeahead);
     });
 
-    testName = 'Get attribute completions when editing an existing attribute';
-    test(testName, async function() {
-      await editorService.fileChanged(indexFile, indexContents);
-      deepEqual(
-          await editorService.getTypeaheadCompletionsAtPosition(
-              indexFile, localAttributePosition),
-          attributeTypeahead);
-    });
+    test(
+        'Get attribute completions when editing an existing attribute',
+        async() => {
+          await editorService.fileChanged(indexFile, indexContents);
+          deepEqual(
+              await editorService.getTypeaheadCompletionsAtPosition(
+                  indexFile, localAttributePosition),
+              attributeTypeahead);
+        });
 
-    testName = 'Get attribute completions when adding a new attribute';
-    test(testName, async function() {
+    test('Get attribute completions when adding a new attribute', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       const partialContents = [
         `<behavior-test-elem >`, `<behavior-test-elem existing-attr>`,
@@ -299,8 +300,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
       }
     });
 
-    testName = 'Recover from references to undefined files.';
-    test(testName, async function() {
+    test('Recover from references to undefined files.', async() => {
       await editorService.fileChanged(indexFile, indexContents);
 
       // Load a file that contains a reference error.
@@ -316,8 +316,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           attributeTypeahead);
     });
 
-    testName = 'Remain useful in the face of unloadable files.';
-    test(testName, async function() {
+    test('Remain useful in the face of unloadable files.', async() => {
       await editorService.fileChanged(indexFile, indexContents);
 
       // We load a file that contains a reference error.
@@ -331,8 +330,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           attributeTypeahead);
     });
 
-    testName = 'Remain useful in the face of syntax errors.';
-    test(testName, async function() {
+    test('Remain useful in the face of syntax errors.', async() => {
       const goodContents =
           fs.readFileSync(path.join(basedir, indexFile), 'utf-8');
       // Load a file with a syntax error
@@ -351,12 +349,12 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   });
 
   suite('getWarningsForFile', function() {
-    test('For a good document we get no warnings', async function() {
+    test('For a good document we get no warnings', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       deepEqual(await editorService.getWarningsForFile(indexFile), []);
     });
 
-    test(`Warn on imports of files that aren't found.`, async function() {
+    test(`Warn on imports of files that aren't found.`, async() => {
       const badImport = `<link rel="import" href="./does-not-exist.html">`;
       await editorService.fileChanged(
           indexFile, `${badImport}\n\n${indexContents}`);
@@ -375,7 +373,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           /Unable to load import:.*no such file or directory/);
     });
 
-    test(`Warn on imports of files that don't parse.`, async function() {
+    test(`Warn on imports of files that don't parse.`, async() => {
       const badImport = `<script src="../js-parse-error.js"></script>`;
       await editorService.fileChanged(
           indexFile, `${badImport}\n\n${indexContents}`);
@@ -393,8 +391,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           }]);
     });
 
-    let testName = `Don't warn on imports of files with no known parser`;
-    test(testName, async function() {
+    test(`Don't warn on imports of files with no known parser`, async() => {
       const badImport = `<script src="./foo.unknown_extension"></script>`;
       await editorService.fileChanged(
           indexFile, `${badImport}\n\n${indexContents}`);
@@ -402,8 +399,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           await editorService.getWarningsForFile(indexFile), []);
     });
 
-    testName = `Warn on syntax errors in inline javascript documents`;
-    test(testName, async function() {
+    test(`Warn on syntax errors in inline javascript documents`, async() => {
       const badScript = `\n<script>var var var var var let const;</script>`;
       await editorService.fileChanged(indexFile, badScript);
       const warnings = await editorService.getWarningsForFile(indexFile);
@@ -419,41 +415,43 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
                            }]);
     });
 
-    testName = `Do not warn on a sibling import ` +
-        `if configured with a package url resolver`;
-    test(testName, async function() {
-      const testBaseDir = path.join(basedir, 'package-url-resolver');
-      editorService = editorFactory(testBaseDir);
-      const warnings =
-          await editorService.getWarningsForFile('simple-elem.html');
-      deepEqual(warnings, []);
-    });
+    test(
+        `Do not warn on a sibling import ` +
+            `if configured with a package url resolver`,
+        async() => {
+          const testBaseDir = path.join(basedir, 'package-url-resolver');
+          editorService = editorFactory(testBaseDir);
+          const warnings =
+              await editorService.getWarningsForFile('simple-elem.html');
+          deepEqual(warnings, []);
+        });
 
-    testName = `Warn about parse errors in the file ` +
-        `we're requesting errors for.`;
-    test(testName, async function() {
-      const warnings =
-          await editorService.getWarningsForFile('js-parse-error.js');
-      deepEqual(warnings, [{
-                  code: 'parse-error',
-                  message: 'Unexpected token ,',
-                  severity: Severity.ERROR,
-                  sourceRange: {
-                    file: 'js-parse-error.js',
-                    start: {line: 17, column: 8},
-                    end: {line: 17, column: 8}
-                  }
-                }]);
-    });
+    test(
+        `Warn about parse errors in the file ` +
+            `we're requesting errors for.`,
+        async() => {
+          const warnings =
+              await editorService.getWarningsForFile('js-parse-error.js');
+          deepEqual(warnings, [{
+                      code: 'parse-error',
+                      message: 'Unexpected token ,',
+                      severity: Severity.ERROR,
+                      sourceRange: {
+                        file: 'js-parse-error.js',
+                        start: {line: 17, column: 8},
+                        end: {line: 17, column: 8}
+                      }
+                    }]);
+        });
   });
 
   suite('getWarnings', function() {
-    test('For a good document we get no warnings', async function() {
+    test('For a good document we get no warnings', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       assert.deepEqual(await editorService.getWarningsForFile(indexFile), []);
     });
 
-    test(`Warn on imports of files that aren't found.`, async function() {
+    test(`Warn on imports of files that aren't found.`, async() => {
       const badImport = `<link rel="import" href="./does-not-exist.html">`;
       await editorService.fileChanged(
           indexFile, `${badImport}\n\n${indexContents}`);
@@ -472,7 +470,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           /Unable to load import:.*no such file or directory/);
     });
 
-    test(`Warn on imports of files that don't parse.`, async function() {
+    test(`Warn on imports of files that don't parse.`, async() => {
       const badImport = `<script src="../js-parse-error.js"></script>`;
       await editorService.fileChanged(
           indexFile, `${badImport}\n\n${indexContents}`);
@@ -490,8 +488,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
           }]);
     });
 
-    let testName = `Don't warn on imports of files with no known parser`;
-    test(testName, async function() {
+    test(`Don't warn on imports of files with no known parser`, async() => {
       const badImport = `<script src="./foo.unknown_extension"></script>`;
       await editorService.fileChanged(
           indexFile, `${badImport}\n\n${indexContents}`);


### PR DESCRIPTION
Useful for extending editors like Sublime Text that (for some reason) aren't written in Node and can't use the Node IPC interface. The protocol is the same, this just extends editor-service.ts to speak the same protocol also over stdin/stdout.