### PR TITLE
Update vscode settings to be shared

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "clang-format.style": "file",
   "clang-format.formatOnSave": true,
   "search.exclude": {
-    "node_modules/**": true,
-    "lib/**": true
+    "**/node_modules": true,
+    "**/lib": true
   },
   "json.schemas": [{
     "fileMatch": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,13 +2,11 @@
 {
   "clang-format.style": "file",
   "clang-format.formatOnSave": true,
-  "files.exclude": {
-    "lib/**": true
-  },
   "json.schemas": [{
     "fileMatch": [
       "elements.json"
     ],
     "url": "./lib/analysis.schema.json"
-  }]
+  }],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,10 @@
 {
   "clang-format.style": "file",
   "clang-format.formatOnSave": true,
+  "search.exclude": {
+    "node_modules/**": true,
+    "lib/**": true
+  },
   "json.schemas": [{
     "fileMatch": [
       "elements.json"


### PR DESCRIPTION
Two small changes I made to get vscode set up on my machine:

- I sometimes need to dig into the lib folder to see the code that is being executed. Excluding the folder from the tree feels a lot like personal preference.
- added `"typescript.tsdk"` to always match the same version of typescript we use to build, lint, etc.

Is there a way to add personal, project-scoped preferences to vscode? You should still be able to exclude the lib folder if you personally would like to.

/cc @rictic @justinfagnani 