### PR TITLE
Rootless

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -107,7 +107,7 @@ export class Analyzer {
    * reading it from disk. Clears the caches so that the news contents is used
    * and reanalyzed. Useful for editors that want to re-analyze changed files.
    */
-  async analyzeRoot(url: string, contents?: string): Promise<Document> {
+  async analyze(url: string, contents?: string): Promise<Document> {
     const resolvedUrl = this._resolveUrl(url);
 
     // if we're given new contents, clear the cache

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -15,9 +15,8 @@
 import {Analyzer} from '../analyzer';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {PackageUrlResolver} from '../url-loader/package-url-resolver';
-import {Severity, WarningCarryingException} from '../warning/warning';
+import {Severity, Warning, WarningCarryingException} from '../warning/warning';
 import {WarningPrinter} from '../warning/warning-printer';
-
 
 /**
  * A basic demo of a linter CLI using the Analyzer API.
@@ -31,15 +30,15 @@ async function main() {
   const warnings = await getWarnings(analyzer, process.argv[2]);
   const warningPrinter = new WarningPrinter(process.stderr, {analyzer});
   await warningPrinter.printWarnings(warnings);
-  const worstSeverity = Math.min.apply(Math, warnings.map(m => m.severity));
+  const worstSeverity = Math.min.apply(Math, warnings.map((w) => w.severity));
   if (worstSeverity === Severity.ERROR) {
     process.exit(1);
   }
 };
 
-async function getWarnings(analyzer: Analyzer, localPath: string) {
+async function getWarnings(analyzer: Analyzer, localPath: string): Promise<Warning[]> {
   try {
-    const document = await analyzer.analyzeRoot(localPath);
+    const document = await analyzer.analyze(localPath);
     return document.getWarnings();
   } catch (e) {
     if (e instanceof WarningCarryingException) {

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -29,7 +29,7 @@ export class LocalEditorService extends EditorService {
   }
 
   async fileChanged(localPath: string, contents?: string): Promise<void> {
-    await this._analyzer.analyzeRoot(localPath, contents);
+    await this._analyzer.analyze(localPath, contents);
   }
 
   async getDocumentationAtPosition(localPath: string, position: SourcePosition):
@@ -58,7 +58,7 @@ export class LocalEditorService extends EditorService {
   async getTypeaheadCompletionsAtPosition(
       localPath: string,
       position: SourcePosition): Promise<TypeaheadCompletion|undefined> {
-    const document = await this._analyzer.analyzeRoot(localPath);
+    const document = await this._analyzer.analyze(localPath);
     const location = await this._getLocationResult(document, position);
     if (location.kind === 'tagName' || location.kind === 'text') {
       const elements = Array.from(document.getByKind('element'));
@@ -120,7 +120,7 @@ export class LocalEditorService extends EditorService {
 
   async getWarningsForFile(localPath: string): Promise<Warning[]> {
     try {
-      const doc = await this._analyzer.analyzeRoot(localPath);
+      const doc = await this._analyzer.analyze(localPath);
       return doc.getWarnings();
     } catch (e) {
       // This might happen if, e.g. `localPath` has a parse error. In that case
@@ -140,7 +140,7 @@ export class LocalEditorService extends EditorService {
 
   private async _getFeatureAt(localPath: string, position: SourcePosition):
       Promise<Element|Property|undefined> {
-    const document = await this._analyzer.analyzeRoot(localPath);
+    const document = await this._analyzer.analyze(localPath);
     const location = await this._getLocationResult(document, position);
     if (!location) {
       return;

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -15,10 +15,11 @@
 import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
-import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, InlineParsedDocument, ScannedFeature, ScannedImport} from '../model/model';
+import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedFeature, ScannedImport, ScannedInlineDocument} from '../model/model';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
+import {ScannedScriptTagImport} from './html-script-tag';
 
 const p = dom5.predicates;
 
@@ -34,14 +35,14 @@ export class HtmlScriptScanner implements HtmlScanner {
       document: ParsedHtmlDocument,
       visit: (visitor: HtmlVisitor) => Promise<void>):
       Promise<ScannedFeature[]> {
-    const features: (ScannedImport|InlineParsedDocument)[] = [];
+    const features: (ScannedImport|ScannedInlineDocument)[] = [];
 
     const myVisitor: HtmlVisitor = (node) => {
       if (isJsScriptNode(node)) {
         const src = dom5.getAttribute(node, 'src');
         if (src) {
           const importUrl = resolveUrl(document.url, src);
-          features.push(new ScannedImport(
+          features.push(new ScannedScriptTagImport(
               'html-script', importUrl, document.sourceRangeForNode(node),
               document.sourceRangeForAttribute(node, 'src')));
         } else {
@@ -49,7 +50,7 @@ export class HtmlScriptScanner implements HtmlScanner {
           const attachedCommentText = getAttachedCommentText(node);
           const contents = dom5.getTextContent(node);
 
-          features.push(new InlineParsedDocument(
+          features.push(new ScannedInlineDocument(
               'js', contents, locationOffset, attachedCommentText,
               document.sourceRangeForNode(node)));
         }

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Document, Import, ScannedImport} from '../model/model';
+
+/**
+ * <script> tags are represented in two different ways: as inline documents,
+ * or as imports, dependeng on whether the tag has a `src` attribute. This class
+ * represents a script tag with a `src` attribute as an import, so that the
+ * analyzer loads and parses the referenced document.
+ */
+export class ScriptTagImport extends Import {
+  type: 'html-script';
+}
+
+export class ScannedScriptTagImport extends ScannedImport {
+
+  resolve(document: Document): ScriptTagImport {
+    // TODO(justinfagnani): warn if the same URL is loaded from more than one
+    // non-module script tag
+
+    // TODO(justinfagnani): Use the analyzer cache, since this is duplicating an
+    // analysis of the external script, but the document the analyzer has
+    // doesn't have its container as a feature.
+    // A better design might be to have the import itself be in charge of
+    // producing document objects. This will fit better with JS modules, where
+    // the type attribute drives how the document is parsed.
+
+    if (this.scannedDocument) {
+      const importedDocument =
+          new Document(this.scannedDocument, document.analyzer);
+      importedDocument._addFeature(document);
+      importedDocument.resolve();
+      return new ScriptTagImport(
+          this.url, this.type, importedDocument, this.sourceRange,
+          this.urlSourceRange);
+    } else {
+      // not found or syntax error
+      return null;
+    }
+  }
+}

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -15,7 +15,7 @@
 import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
-import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, InlineParsedDocument, ScannedFeature, ScannedImport} from '../model/model';
+import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedFeature, ScannedImport, ScannedInlineDocument} from '../model/model';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
@@ -36,7 +36,7 @@ export class HtmlStyleScanner implements HtmlScanner {
       document: ParsedHtmlDocument,
       visit: (visitor: HtmlVisitor) => Promise<void>):
       Promise<ScannedFeature[]> {
-    const features: (ScannedImport|InlineParsedDocument)[] = [];
+    const features: (ScannedImport|ScannedInlineDocument)[] = [];
 
     await visit(async(node) => {
       if (isStyleNode(node)) {
@@ -51,7 +51,7 @@ export class HtmlStyleScanner implements HtmlScanner {
           const contents = dom5.getTextContent(node);
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const commentText = getAttachedCommentText(node);
-          features.push(new InlineParsedDocument(
+          features.push(new ScannedInlineDocument(
               'css', contents, locationOffset, commentText,
               document.sourceRangeForNode(node)));
         }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -51,10 +51,11 @@ export class ScannedImport implements ScannedFeature, Resolvable {
     this.urlSourceRange = urlSourceRange;
   }
 
-  resolve(_contextDocument: Document): Import {
-    // The caller will set import.document;
-    return new Import(
-        this.url, this.type, this.sourceRange, this.urlSourceRange);
+  resolve(document: Document): Import {
+    const importedDocument = document.analyzer._getDocument(this.url);
+    return importedDocument && new Import(
+                                   this.url, this.type, importedDocument,
+                                   this.sourceRange, this.urlSourceRange);
   }
 }
 
@@ -63,16 +64,17 @@ export class Import implements Feature {
   url: string;
   document: Document;
   identifiers = new Set();
-  kinds: Set<string>;
+  kinds = new Set(['import']);
   sourceRange: SourceRange;
   urlSourceRange: SourceRange;
 
   constructor(
-      url: string, type: string, sourceRange: SourceRange,
+      url: string, type: string, document: Document, sourceRange: SourceRange,
       urlSourceRange: SourceRange) {
     this.url = url;
     this.type = type;
-    this.kinds = new Set(['import', this.type]);
+    this.document = document;
+    this.kinds.add(this.type);
     this.sourceRange = sourceRange;
     this.urlSourceRange = urlSourceRange;
   }

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -19,8 +19,9 @@ import * as util from 'util';
 
 import * as jsdoc from '../javascript/jsdoc';
 
-import {ScannedDocument} from './document';
+import {Document, ScannedDocument} from './document';
 import {ScannedFeature} from './feature';
+import {Resolvable} from './resolvable';
 import {LocationOffset, SourceRange} from './source-range';
 
 /**
@@ -29,7 +30,7 @@ import {LocationOffset, SourceRange} from './source-range';
  *
  * @template N The AST node type
  */
-export class InlineParsedDocument implements ScannedFeature {
+export class ScannedInlineDocument implements ScannedFeature, Resolvable {
   type: 'html'|'javascript'|'css'|/* etc */ string;
 
   contents: string;
@@ -50,6 +51,23 @@ export class InlineParsedDocument implements ScannedFeature {
     this.locationOffset = locationOffset;
     this.attachedComment = attachedComment;
     this.sourceRange = sourceRange;
+  }
+
+  resolve(document: Document): Document {
+    if (!this.scannedDocument) {
+      // Parse error on the inline document.
+      return;
+    }
+    const inlineDocument = new InlineDocument(this.scannedDocument, document);
+    inlineDocument.resolve();
+    return inlineDocument;
+  }
+}
+
+export class InlineDocument extends Document {
+  constructor(base: ScannedDocument, containerDocument: Document) {
+    super(base, containerDocument.analyzer);
+    this._addFeature(containerDocument);
   }
 }
 

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -67,7 +67,7 @@ async function measure() {
   const start = now();
   let document: any;
   for (let i = 0; i < 10; i++) {
-    document = await analyzer.analyzeRoot('ephemeral.html', fakeFileContents);
+    document = await analyzer.analyze('ephemeral.html', fakeFileContents);
   }
 
   const measurements = await analyzer.getTelemetryMeasurements();

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -90,7 +90,7 @@ function printMeasurements(measurements: Measurement[]) {
   const averager = new Averager<string>();
   console.log(`${padLeft('elapsed ms', 10)} - ${padLeft('operation', 30)}`);
   for (const m of measurements) {
-    if (m.kind === 'Document.makeRootDocument') {
+    if (m.kind === 'analyze: make document') {
       console.log(
           `${padLeft(m.elapsedTime.toFixed(0), 10)} - ${padLeft(m.kind, 30)}`);
     }

--- a/src/polymer/behavior-descriptor.ts
+++ b/src/polymer/behavior-descriptor.ts
@@ -38,4 +38,8 @@ export class Behavior extends PolymerElement {
     super();
     this.kinds = new Set(['behavior']);
   }
+
+  toString() {
+    return `<Behavior className=${this.className}>`;
+  }
 }

--- a/src/polymer/element-descriptor.ts
+++ b/src/polymer/element-descriptor.ts
@@ -197,8 +197,10 @@ function _getFlattenedAndResolvedBehaviors(
     const behavior = document.getOnlyAtId('behavior', behaviorName);
     if (!behavior) {
       throw new Error(
-          `Unable to resolve behavior \`${behaviorName}\` ` +
-          `Did you import it? Is it annotated with @polymerBehavior?`);
+          `In ${document &&
+          document.url}:` +
+              `Unable to resolve behavior \`${behaviorName}\` ` +
+              `Did you import it? Is it annotated with @polymerBehavior?`);
     }
     if (resolvedBehaviors.has(behavior)) {
       continue;

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -51,12 +51,12 @@ suite('Analyzer', () => {
   suite('analyze()', () => {
 
     test('returns a Document with warnings for malformed files', async() => {
-      const document = await analyzer.analyzeRoot('static/malformed.html');
+      const document = await analyzer.analyze('static/malformed.html');
       assert(document.getWarnings().length >= 1);
     });
 
     test('analyzes transitive dependencies', async() => {
-      const root = await analyzer.analyzeRoot('static/dependencies/root.html');
+      const root = await analyzer.analyze('static/dependencies/root.html');
 
       // If we ask for documents we get every document in evaluation order.
       assert.deepEqual(
@@ -123,7 +123,7 @@ suite('Analyzer', () => {
     });
 
     test(`rejects for files that don't exist`, async() => {
-      await invertPromise(analyzer.analyzeRoot('/static/does_not_exist'));
+      await invertPromise(analyzer.analyze('/static/does_not_exist'));
     });
 
   });
@@ -207,7 +207,7 @@ suite('Analyzer', () => {
     // FIXME(rictic): I've temporarily disabled most recognition of Polymer ES6
     //     classes because the scanner is buggy and triggers when it shouldn't.
     test.skip('parses classes', async() => {
-      const document = await analyzer.analyzeRoot('static/es6-support.js');
+      const document = await analyzer.analyze('static/es6-support.js');
 
       const elements = Array.from(document.getByKind('polymer-element'));
       assert.deepEqual(

--- a/src/test/generate_elements_test.ts
+++ b/src/test/generate_elements_test.ts
@@ -155,7 +155,7 @@ async function analyzeDir(baseDir: string) {
       Array.from(filterI(walkRecursively(baseDir), (f) => f.endsWith('.html')))
           .map(
               fn => `<link rel="import" href="${path.relative(baseDir, fn)}">`);
-  const document = await analyzer.analyzeRoot(
+  const document = await analyzer.analyze(
       path.join('ephemeral.html'), importStatements.join('\n'));
   return Array.from(document.getByKind('element'));
 }

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -17,8 +17,7 @@ import {assert} from 'chai';
 import {HtmlVisitor} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {HtmlScriptScanner} from '../../html/html-script-scanner';
-import {ScannedImport} from '../../model/import';
-import {InlineParsedDocument} from '../../model/model';
+import {ScannedImport, ScannedInlineDocument} from '../../model/model';
 
 suite('HtmlScriptScanner', () => {
 
@@ -43,8 +42,8 @@ suite('HtmlScriptScanner', () => {
       const feature0 = <ScannedImport>features[0];
       assert.equal(feature0.type, 'html-script');
       assert.equal(feature0.url, 'foo.js');
-      assert.instanceOf(features[1], InlineParsedDocument);
-      const feature1 = <InlineParsedDocument>features[1];
+      assert.instanceOf(features[1], ScannedInlineDocument);
+      const feature1 = <ScannedInlineDocument>features[1];
       assert.equal(feature1.type, 'js');
       assert.equal(feature1.contents, `console.log('hi')`);
       assert.deepEqual(feature1.locationOffset, {line: 2, col: 19});

--- a/src/test/static/script-tags/external/test-behavior.html
+++ b/src/test/static/script-tags/external/test-behavior.html
@@ -1,0 +1,4 @@
+<script>
+  /** @polymerBehavior */
+  TestBehavior = {};
+</script>

--- a/src/test/static/script-tags/external/test-element.html
+++ b/src/test/static/script-tags/external/test-element.html
@@ -1,0 +1,2 @@
+<link rel="import" href="test-behavior.html">
+<script src="test-element.js"></script>

--- a/src/test/static/script-tags/external/test-element.js
+++ b/src/test/static/script-tags/external/test-element.js
@@ -1,0 +1,4 @@
+Polymer({
+  is: 'test-element',
+  behaviors: [TestBehavior],
+});

--- a/src/test/static/script-tags/inline/test-behavior.html
+++ b/src/test/static/script-tags/inline/test-behavior.html
@@ -1,0 +1,4 @@
+<script>
+  /** @polymerBehavior */
+  TestBehavior = {};
+</script>

--- a/src/test/static/script-tags/inline/test-element.html
+++ b/src/test/static/script-tags/inline/test-element.html
@@ -1,0 +1,7 @@
+<link rel="import" href="test-behavior.html">
+<script>
+Polymer({
+  is: 'test-element',
+  behaviors: [TestBehavior],
+});
+</script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,6 @@
         "moduleResolution": "node",
         "isolatedModules": false,
         "noImplicitAny": true,
-        // TODO: enable these
-        // "strictNullChecks": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "removeComments": false,
@@ -20,5 +18,8 @@
     },
     "include": [
         "src/**/*.ts"
+    ],
+    "exclude": [
+      "node_modules"
     ]
 }


### PR DESCRIPTION
Remove the concept of root documents. Cache analyzed document. This requires that documents import all of their dependencies. It increases performance of repeated analysis in the benchmark by 2-3x.

<script> tags need special handling, since we want them to see dependencies imported by their container. We support this by adding a document feature pointing to its container document.

Other changes:
 * Added HtmlScriptTagImport and ScannedHtmlScriptTagImport
 * Renamed InlineParsedDocument to ScannedInlineDocument
 * Added InlineDocument
 * Added `deep` option to getFeatures()
 * Imports no longer automatically add their document as a feature
 * Added analyzed document cache to analyzer, and getDocument()