### PR TITLE
Add ast node back on ScannedFeature and Feature

### DIFF
--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -59,7 +59,7 @@ export class HtmlImportScanner implements HtmlScanner {
       const importUrl = resolveUrl(document.url, href);
       imports.push(new ScannedImport(
           type, importUrl, document.sourceRangeForNode(node),
-          document.sourceRangeForAttribute(node, 'href')));
+          document.sourceRangeForAttribute(node, 'href'), node));
     });
     return imports;
   }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -43,7 +43,7 @@ export class HtmlScriptScanner implements HtmlScanner {
           const importUrl = resolveUrl(document.url, src);
           features.push(new ScannedImport(
               'html-script', importUrl, document.sourceRangeForNode(node),
-              document.sourceRangeForAttribute(node, 'src')));
+              document.sourceRangeForAttribute(node, 'src'), node));
         } else {
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const attachedCommentText = getAttachedCommentText(node);
@@ -51,7 +51,7 @@ export class HtmlScriptScanner implements HtmlScanner {
 
           features.push(new InlineParsedDocument(
               'js', contents, locationOffset, attachedCommentText,
-              document.sourceRangeForNode(node)));
+              document.sourceRangeForNode(node), node));
         }
       }
     };

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -46,14 +46,14 @@ export class HtmlStyleScanner implements HtmlScanner {
           const importUrl = resolveUrl(document.url, href);
           features.push(new ScannedImport(
               'html-style', importUrl, document.sourceRangeForNode(node),
-              document.sourceRangeForAttribute(node, 'href')));
+              document.sourceRangeForAttribute(node, 'href'), node));
         } else {
           const contents = dom5.getTextContent(node);
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const commentText = getAttachedCommentText(node);
           features.push(new InlineParsedDocument(
               'css', contents, locationOffset, commentText,
-              document.sourceRangeForNode(node)));
+              document.sourceRangeForNode(node), node));
         }
       }
     });

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -161,7 +161,8 @@ export function toScannedPolymerProperty(
     name: objectKeyToString(node.key),
     type: type,
     description: description,
-    sourceRange: sourceRange
+    sourceRange: sourceRange,
+    ast: node
   };
 
   if (type === 'Function') {

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -36,7 +36,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
         const importUrl = resolveUrl(document.url, source);
         imports.push(new ScannedImport(
             'js-import', importUrl, document.sourceRangeForNode(node),
-            document.sourceRangeForNode(node.source)));
+            document.sourceRangeForNode(node.source), node));
       }
     });
     return imports;

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -63,6 +63,8 @@ export class Document implements Feature {
   kinds: Set<string>;
   identifiers: Set<string>;
   sourceRange: SourceRange;
+  /** See parsedDocument. */
+  ast: null = null;
 
   private _rootDocument: Document;
   private _localFeatures = new Set<Feature>();

--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -12,10 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as estree from 'estree';
 import * as jsdoc from '../javascript/jsdoc';
 import {SourceRange} from '../model/model';
 
-import {correctSourceRange, Document, Event, Feature, LocationOffset, Property, Resolvable, ScannedEvent, ScannedFeature, ScannedProperty} from './model';
+import {correctSourceRange, Document, Event, Feature, LocationOffset, Property, Resolvable, ScannedEvent, ScannedProperty} from './model';
 
 export {Visitor} from '../javascript/estree-visitor';
 
@@ -26,7 +27,7 @@ export interface ScannedAttribute {
   type?: string;
 }
 
-export class ScannedElement implements ScannedFeature, Resolvable {
+export class ScannedElement implements Resolvable {
   tagName?: string;
   className?: string;
   superClass?: string;
@@ -37,6 +38,7 @@ export class ScannedElement implements ScannedFeature, Resolvable {
   demos: {desc?: string; path: string}[] = [];
   events: ScannedEvent[] = [];
   sourceRange: SourceRange;
+  ast: estree.Node|null;
 
   jsdoc?: jsdoc.Annotation;
 
@@ -83,6 +85,7 @@ export class Element implements Feature {
   events: Event[] = [];
   sourceRange: SourceRange;
   jsdoc?: jsdoc.Annotation;
+  ast: estree.Node|null;
   kinds: Set<string> = new Set(['element']);
   get identifiers(): Set<string> {
     const result: Set<string> = new Set();

--- a/src/model/event.ts
+++ b/src/model/event.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as estree from 'estree';
 import {ScannedFeature} from './feature';
 
 export interface ScannedEvent extends ScannedFeature {
@@ -19,6 +20,7 @@ export interface ScannedEvent extends ScannedFeature {
   type?: string;
   description?: string;
   params?: {type: string, desc: string, name: string}[];
+  ast: estree.Node|null;
 }
 
 export interface Event {
@@ -27,4 +29,5 @@ export interface Event {
   // TODO: represent detail object properly
   description?: string;
   inheritedFrom?: string;
+  ast: estree.Node|null;
 }

--- a/src/model/feature.ts
+++ b/src/model/feature.ts
@@ -18,7 +18,12 @@ import {SourceRange} from './source-range';
 export interface Feature {
   kinds: Set<string>;
   identifiers?: Set<string>;
+
+  /** Tracks the source that this feature came from. */
   sourceRange: SourceRange;
+
+  /** The AST Node, if any, that corresponds to this feature. */
+  ast: any;
 }
 
 export interface ScannedFeature {
@@ -29,4 +34,7 @@ export interface ScannedFeature {
 
   /** Tracks the source that this feature came from. */
   sourceRange: SourceRange;
+
+  /** The AST Node, if any, that corresponds to this feature. */
+  ast: any;
 }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -13,7 +13,7 @@
  */
 
 import {Document, ScannedDocument} from './document';
-import {Feature, ScannedFeature} from './feature';
+import {Feature} from './feature';
 import {SourceRange} from './model';
 import {Resolvable} from './resolvable';
 
@@ -24,7 +24,7 @@ import {Resolvable} from './resolvable';
  *
  * @template N The AST node type
  */
-export class ScannedImport implements ScannedFeature, Resolvable {
+export class ScannedImport implements Resolvable {
   type: 'html-import'|'html-script'|'html-style'|'js-import'|string;
 
   /**
@@ -42,19 +42,22 @@ export class ScannedImport implements ScannedFeature, Resolvable {
    */
   urlSourceRange: SourceRange;
 
+  ast: any|null;
+
   constructor(
       type: string, url: string, sourceRange: SourceRange,
-      urlSourceRange: SourceRange) {
+      urlSourceRange: SourceRange, ast: any|null) {
     this.type = type;
     this.url = url;
     this.sourceRange = sourceRange;
     this.urlSourceRange = urlSourceRange;
+    this.ast = ast;
   }
 
   resolve(_contextDocument: Document): Import {
     // The caller will set import.document;
     return new Import(
-        this.url, this.type, this.sourceRange, this.urlSourceRange);
+        this.url, this.type, this.sourceRange, this.urlSourceRange, this.ast);
   }
 }
 
@@ -66,15 +69,17 @@ export class Import implements Feature {
   kinds: Set<string>;
   sourceRange: SourceRange;
   urlSourceRange: SourceRange;
+  ast: any|null;
 
   constructor(
       url: string, type: string, sourceRange: SourceRange,
-      urlSourceRange: SourceRange) {
+      urlSourceRange: SourceRange, ast: any) {
     this.url = url;
     this.type = type;
     this.kinds = new Set(['import', this.type]);
     this.sourceRange = sourceRange;
     this.urlSourceRange = urlSourceRange;
+    this.ast = ast;
   }
 
   toString() {

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -42,14 +42,17 @@ export class InlineParsedDocument implements ScannedFeature {
 
   sourceRange: SourceRange;
 
+  ast: dom5.Node;
+
   constructor(
       type: string, contents: string, locationOffset: LocationOffset,
-      attachedComment: string, sourceRange: SourceRange) {
+      attachedComment: string, sourceRange: SourceRange, ast: dom5.Node) {
     this.type = type;
     this.contents = contents;
     this.locationOffset = locationOffset;
     this.attachedComment = attachedComment;
     this.sourceRange = sourceRange;
+    this.ast = ast;
   }
 }
 

--- a/src/model/property.ts
+++ b/src/model/property.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as estree from 'estree';
 import * as jsdoc from '../javascript/jsdoc';
 import {SourceRange} from '../model/model';
 
@@ -26,6 +27,7 @@ export interface ScannedProperty extends ScannedFeature {
   'default'?: string;
   readOnly?: boolean;
   sourceRange: SourceRange;
+  ast: estree.Node|null;
 }
 
 export interface Property {

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -20,7 +20,6 @@ import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
-import {ScannedFeature} from '../model/model';
 
 import {ScannedBehavior} from './behavior-descriptor';
 import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
@@ -51,7 +50,7 @@ const templatizer = 'Polymer.Templatizer';
 export class BehaviorScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedFeature[]> {
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedBehavior[]> {
     let visitor = new BehaviorVisitor(document);
     await visit(visitor);
     return Array.from(visitor.behaviors);

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -38,7 +38,7 @@ export class CssImportScanner implements HtmlScanner {
         const importUrl = resolveUrl(document.url, href);
         imports.push(new ScannedImport(
             'css-import', importUrl, document.sourceRangeForNode(node),
-            document.sourceRangeForAttribute(node, 'href')));
+            document.sourceRangeForAttribute(node, 'href'), node));
       }
     });
     return imports;

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -110,7 +110,8 @@ export function annotateEvent(annotation: jsdoc.Annotation): ScannedEvent {
         'N/A',
     description: eventTag.description || annotation.description,
     jsdoc: annotation,
-    sourceRange: null
+    sourceRange: null,
+    ast: null
   };
 
   const tags = (annotation && annotation.tags || []);
@@ -228,8 +229,9 @@ export function featureElement(features: ScannedPolymerCoreFeature[]):
  * called `annotate`.
  */
 export function clean(scannedFeature: ScannedFeature) {
-  if (!scannedFeature.jsdoc)
+  if (!scannedFeature.jsdoc) {
     return;
+  }
   // The doctext was written to `scannedFeature.description`
   delete scannedFeature.jsdoc.description;
 

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -17,27 +17,31 @@ import {ASTNode} from 'parse5';
 
 import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
 import {HtmlScanner} from '../html/html-scanner';
-import {Feature, getAttachedCommentText, Resolvable, ScannedFeature, SourceRange} from '../model/model';
+import {Feature, getAttachedCommentText, Resolvable, SourceRange} from '../model/model';
 
 const p = dom5.predicates;
 
 const isDomModule = p.hasTagName('dom-module');
 
-export class ScannedDomModule implements ScannedFeature, Resolvable {
+export class ScannedDomModule implements Resolvable {
   id?: string;
   node: ASTNode;
   comment?: string;
   sourceRange: SourceRange;
+  ast: dom5.Node;
 
-  constructor(id: string, node: ASTNode, sourceRange: SourceRange) {
+  constructor(
+      id: string, node: ASTNode, sourceRange: SourceRange, ast: dom5.Node) {
     this.id = id;
     this.node = node;
     this.comment = getAttachedCommentText(node);
     this.sourceRange = sourceRange;
+    this.ast = ast;
   }
 
   resolve() {
-    return new DomModule(this.node, this.id, this.comment, this.sourceRange);
+    return new DomModule(
+        this.node, this.id, this.comment, this.sourceRange, this.ast);
   }
 }
 
@@ -48,8 +52,10 @@ export class DomModule implements Feature {
   id: string|undefined;
   comment: string|undefined;
   sourceRange: SourceRange;
+  ast: dom5.Node;
   constructor(
-      node: ASTNode, id: string, comment: string, sourceRange: SourceRange) {
+      node: ASTNode, id: string, comment: string, sourceRange: SourceRange,
+      ast: dom5.Node) {
     this.node = node;
     this.id = id;
     this.comment = comment;
@@ -57,6 +63,7 @@ export class DomModule implements Feature {
       this.identifiers.add(id);
     }
     this.sourceRange = sourceRange;
+    this.ast = ast;
   }
 }
 
@@ -71,7 +78,7 @@ export class DomModuleScanner implements HtmlScanner {
       if (isDomModule(node)) {
         domModules.push(new ScannedDomModule(
             dom5.getAttribute(node, 'id'), node,
-            document.sourceRangeForNode(node)));
+            document.sourceRangeForNode(node), node));
       }
     });
     return domModules;

--- a/src/polymer/element-descriptor.ts
+++ b/src/polymer/element-descriptor.ts
@@ -97,7 +97,8 @@ export class ScannedPolymerElement extends ScannedElement {
       this.events.push({
         name: `${attributeName}-changed`,
         description: `Fired when the \`${prop.name}\` property changes.`,
-        sourceRange: prop.sourceRange
+        sourceRange: prop.sourceRange,
+        ast: prop.ast
       });
     }
   }

--- a/src/test/vanilla-custom-elements/element-scanner_test.ts
+++ b/src/test/vanilla-custom-elements/element-scanner_test.ts
@@ -21,34 +21,32 @@ import * as path from 'path';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ScannedElement, ScannedFeature} from '../../model/model';
+import {ScannedElement} from '../../model/model';
 import {ElementScanner} from '../../vanilla-custom-elements/element-scanner';
 
 chai.use(require('chai-subset'));
 
 suite('VanillaElementScanner', () => {
 
+  const elements = new Map<string, ScannedElement>();
   let document: JavaScriptDocument;
-  let elements: Map<string, ScannedElement>;
   let elementsList: ScannedElement[];
 
-  suiteSetup(() => {
-    let parser = new JavaScriptParser({sourceType: 'script'});
-    let file = fs.readFileSync(
+  suiteSetup(async() => {
+    const parser = new JavaScriptParser({sourceType: 'script'});
+    const file = fs.readFileSync(
         path.resolve(__dirname, '../static/vanilla-elements.js'), 'utf8');
     document = parser.parse(file, '/static/vanilla-elements.js');
-    let scanner = new ElementScanner();
-    let visit = (visitor: Visitor) =>
+    const scanner = new ElementScanner();
+    const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    return scanner.scan(document, visit).then((features: ScannedFeature[]) => {
-      elements = new Map();
-      elementsList =
-          <ScannedElement[]>features.filter((e) => e instanceof ScannedElement);
-      for (let element of elementsList) {
-        elements.set(element.tagName, element);
-      }
-    });
+    const features = await scanner.scan(document, visit);
+    elementsList =
+        <ScannedElement[]>features.filter((e) => e instanceof ScannedElement);
+    for (const element of elementsList) {
+      elements.set(element.tagName, element);
+    }
   });
 
   test('Finds elements', () => {

--- a/src/vanilla-custom-elements/element-scanner.ts
+++ b/src/vanilla-custom-elements/element-scanner.ts
@@ -25,6 +25,7 @@ import {ScannedElement, ScannedFeature} from '../model/model';
 export interface ScannedAttribute extends ScannedFeature {
   name: string;
   type?: string;
+  ast: estree.Node|null;
 }
 
 export class ElementScanner implements JavaScriptScanner {
@@ -179,7 +180,8 @@ class ElementVisitor implements Visitor {
         const attribute: ScannedAttribute = {
           name: value,
           description: description,
-          sourceRange: this._document.sourceRangeForNode(expr)
+          sourceRange: this._document.sourceRangeForNode(expr),
+          ast: expr
         };
         if (type) {
           attribute.type = type;


### PR DESCRIPTION
Useful in the bundler, as well as in the upgrader.

I initially tried to track the type of ast nodes by a type parameter, but it was more viral than I remember it being when we removed the property last.

I'm not super opinionated about the decision, but it felt kinda ugh if `Document` and the `Feature`s it returns require type parameters.

On the other hand, we could make `Document` extend `Feature<null>` or `Feature<any>` and it would be somewhat rare for a user to spend too much time with undifferentiated `Feature`s.

Hm. WDYT?

Motivated by https://github.com/Polymer/polymer-analyzer/issues/315