### PR TITLE
Put all responsibility of location offsets on ParsedDocument

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bower": "^1.7.9",
     "chai": "^2.2.0",
     "chai-subset": "^1.3.0",
-    "clang-format": "^1.0.44",
+    "clang-format": "=1.0.45",
     "depcheck": "^0.6.3",
     "fs-extra": "^0.30.0",
     "gulp": "^3.9.1",

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -238,7 +238,8 @@ export class Analyzer {
    * Scans a parsed Document object.
    */
   private async _scanDocument(
-      document: ParsedDocument<any, any>, maybeAttachedComment?: string): Promise<ScannedDocument> {
+      document: ParsedDocument<any, any>,
+      maybeAttachedComment?: string): Promise<ScannedDocument> {
     // TODO(rictic): We shouldn't be calling _scanDocument with
     // null/undefined.
     if (document == null) {
@@ -271,8 +272,8 @@ export class Analyzer {
     const dependencies =
         (await Promise.all(scannedSubDocuments)).filter(s => !!s);
 
-    const scannedDocument = new ScannedDocument(
-        document, dependencies, scannedFeatures, warnings);
+    const scannedDocument =
+        new ScannedDocument(document, dependencies, scannedFeatures, warnings);
     this._scannedDocuments.set(scannedDocument.url, scannedDocument);
     return scannedDocument;
   }

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -84,7 +84,7 @@ export class ParsedCssDocument extends ParsedDocument<shady.Node, Visitor> {
     throw new Error('Not implemented');
   }
 
-  sourceRangeForNode(_node: shady.Node): SourceRange {
+  _sourceRangeForNode(_node: shady.Node): SourceRange {
     throw new Error('Not implemented');
   }
 

--- a/src/css/css-parser.ts
+++ b/src/css/css-parser.ts
@@ -14,7 +14,9 @@
 
 import * as shadyCss from 'shady-css-parser';
 
+import {LocationOffset} from '../model/model';
 import {Parser} from '../parser/parser';
+
 import {ParsedCssDocument} from './css-document';
 
 export class CssParser implements Parser<ParsedCssDocument> {
@@ -24,11 +26,10 @@ export class CssParser implements Parser<ParsedCssDocument> {
     this._parser = new shadyCss.Parser();
   }
 
-  parse(contents: string, url: string): ParsedCssDocument {
+  parse(contents: string, url: string, locationOffset?: LocationOffset):
+      ParsedCssDocument {
     let ast = this._parser.parse(contents);
 
-    return new ParsedCssDocument({
-        url, contents, ast,
-    });
+    return new ParsedCssDocument({url, contents, ast, locationOffset});
   }
 }

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -36,17 +36,18 @@ async function main() {
   }
 };
 
-async function getWarnings(analyzer: Analyzer, localPath: string): Promise<Warning[]> {
-  try {
-    const document = await analyzer.analyze(localPath);
-    return document.getWarnings();
-  } catch (e) {
-    if (e instanceof WarningCarryingException) {
-      return [e.warning];
+async function getWarnings(analyzer: Analyzer, localPath: string):
+    Promise<Warning[]> {
+      try {
+        const document = await analyzer.analyze(localPath);
+        return document.getWarnings();
+      } catch (e) {
+        if (e instanceof WarningCarryingException) {
+          return [e.warning];
+        }
+        throw e;
+      }
     }
-    throw e;
-  }
-}
 
 main()
     .catch(err => {

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -46,7 +46,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
     });
   }
 
-  sourceRangeForNode(node: ASTNode): SourceRange {
+  _sourceRangeForNode(node: ASTNode): SourceRange {
     if (!node || !node.__location) {
       return;
     }

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -14,6 +14,7 @@
 
 import {parse as parseHtml} from 'parse5';
 
+import {LocationOffset} from '../model/model';
 import {Parser} from '../parser/parser';
 
 import {ParsedHtmlDocument} from './html-document';
@@ -25,8 +26,9 @@ export class HtmlParser implements Parser<ParsedHtmlDocument> {
   * @param {string} htmlString an HTML document.
   * @param {string} href is the path of the document.
   */
-  parse(contents: string, url: string): ParsedHtmlDocument {
+  parse(contents: string, url: string, locationOffset?: LocationOffset):
+      ParsedHtmlDocument {
     let ast = parseHtml(contents, {locationInfo: true});
-    return new ParsedHtmlDocument({url, contents, ast});
+    return new ParsedHtmlDocument({url, contents, ast, locationOffset});
   }
 }

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -20,12 +20,9 @@ import {Document, Import, ScannedImport} from '../model/model';
  * represents a script tag with a `src` attribute as an import, so that the
  * analyzer loads and parses the referenced document.
  */
-export class ScriptTagImport extends Import {
-  type: 'html-script';
-}
+export class ScriptTagImport extends Import { type: 'html-script'; }
 
 export class ScannedScriptTagImport extends ScannedImport {
-
   resolve(document: Document): ScriptTagImport {
     // TODO(justinfagnani): warn if the same URL is loaded from more than one
     // non-module script tag

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -29,9 +29,10 @@ interface SkipRecord {
   depth: number;
 }
 
-export class JavaScriptDocument extends ParsedDocument<Program, Visitor> {
+export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
   type = 'js';
   private visitorSkips = new Map<Visitor, SkipRecord>();
+  ast: Program;
 
   constructor(from: Options<Program>) {
     super(from);
@@ -124,7 +125,7 @@ export class JavaScriptDocument extends ParsedDocument<Program, Visitor> {
     });
   }
 
-  sourceRangeForNode(node: Node): SourceRange|undefined {
+  _sourceRangeForNode(node: Node): SourceRange|undefined {
     if (!node || !node.loc) {
       return;
     }

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -15,6 +15,7 @@
 import * as espree from 'espree';
 import {Program} from 'estree';
 
+import {LocationOffset} from '../model/model';
 import {Parser} from '../parser/parser';
 import {Severity, WarningCarryingException} from '../warning/warning';
 
@@ -35,7 +36,8 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
     this.sourceType = options.sourceType;
   }
 
-  parse(contents: string, url: string): JavaScriptDocument {
+  parse(contents: string, url: string, locationOffset?: LocationOffset):
+      JavaScriptDocument {
     let ast: Program;
     try {
       ast = <Program>espree.parse(contents, {
@@ -61,6 +63,6 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
       throw err;
     }
 
-    return new JavaScriptDocument({url, contents, ast});
+    return new JavaScriptDocument({url, contents, ast, locationOffset});
   }
 }

--- a/src/json/json-document.ts
+++ b/src/json/json-document.ts
@@ -51,7 +51,7 @@ export class ParsedJsonDocument extends ParsedDocument<Json, Visitor> {
     this.visit([{visit: callback}]);
   }
 
-  sourceRangeForNode(_node: Json): SourceRange {
+  _sourceRangeForNode(_node: Json): SourceRange {
     throw new Error('Not Implemented.');
   }
 

--- a/src/json/json-parser.ts
+++ b/src/json/json-parser.ts
@@ -12,12 +12,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {LocationOffset} from '../model/model';
 import {Parser} from '../parser/parser';
 
 import {ParsedJsonDocument} from './json-document';
 
 export class JsonParser implements Parser<ParsedJsonDocument> {
-  parse(contents: string, url: string): ParsedJsonDocument {
-    return new ParsedJsonDocument({url, contents, ast: JSON.parse(contents)});
+  parse(contents: string, url: string, locationOffset?: LocationOffset):
+      ParsedJsonDocument {
+    return new ParsedJsonDocument(
+        {url, contents, ast: JSON.parse(contents), locationOffset});
   }
 }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -23,7 +23,7 @@ import {Element} from './element';
 import {Feature, ScannedFeature} from './feature';
 import {Import} from './import';
 import {isResolvable} from './resolvable';
-import {LocationOffset, SourceRange} from './source-range';
+import {SourceRange} from './source-range';
 
 /**
  * The metadata for all features and elements defined in one document
@@ -32,19 +32,16 @@ export class ScannedDocument {
   document: ParsedDocument<any, any>;
   dependencies: ScannedDocument[];
   features: ScannedFeature[];
-  locationOffset?: LocationOffset;
   isInline = false;
   sourceRange: SourceRange = null;  // TODO(rictic): track this
   warnings: Warning[];
 
   constructor(
       document: ParsedDocument<any, any>, dependencies: ScannedDocument[],
-      features: ScannedFeature[], locationOffset?: LocationOffset,
-      warnings?: Warning[]) {
+      features: ScannedFeature[], warnings?: Warning[]) {
     this.document = document;
     this.dependencies = dependencies;
     this.features = features;
-    this.locationOffset = locationOffset;
     this.warnings = warnings || [];
   }
 
@@ -124,7 +121,7 @@ export class Document implements Feature {
    *
    * This method can only be called once
    */
-   // TODO(justinfagnani): move to ScannedDocument
+  // TODO(justinfagnani): move to ScannedDocument
   resolve() {
     if (this._doneResolving) {
       throw new Error('resolve can only be called once');
@@ -239,6 +236,7 @@ export class Document implements Feature {
         }
       }
     }
+
     return result;
   }
 
@@ -271,8 +269,7 @@ export class Document implements Feature {
   }
 
   /**
-   * Adds and indexes a feature to this document. Thie method can only be
-   * called before resolve().
+   * Adds and indexes a feature to this documentled before resolve().
    */
   _addFeature(feature: Feature) {
     if (this._doneResolving) {

--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -15,7 +15,7 @@
 import * as jsdoc from '../javascript/jsdoc';
 import {SourceRange} from '../model/model';
 
-import {correctSourceRange, Document, Event, Feature, LocationOffset, Property, Resolvable, ScannedEvent, ScannedFeature, ScannedProperty} from './model';
+import {Document, Event, Feature, Property, Resolvable, ScannedEvent, ScannedFeature, ScannedProperty} from './model';
 
 export {Visitor} from '../javascript/estree-visitor';
 
@@ -39,23 +39,6 @@ export class ScannedElement implements ScannedFeature, Resolvable {
   sourceRange: SourceRange;
 
   jsdoc?: jsdoc.Annotation;
-
-  applyLocationOffset(locationOffset?: LocationOffset) {
-    if (!locationOffset) {
-      return;
-    }
-    this.sourceRange = correctSourceRange(this.sourceRange, locationOffset);
-    for (const prop of this.properties) {
-      prop.sourceRange = correctSourceRange(prop.sourceRange, locationOffset);
-    }
-    for (const attribute of this.attributes) {
-      attribute.sourceRange =
-          correctSourceRange(attribute.sourceRange, locationOffset);
-    }
-    for (const event of this.events) {
-      event.sourceRange = correctSourceRange(event.sourceRange, locationOffset);
-    }
-  }
 
   applyHtmlComment(commentText: string|undefined) {
     this.description = this.description || commentText || '';

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {SourceRange} from '../model/source-range';
+import {correctSourceRange, LocationOffset, SourceRange} from '../model/source-range';
 
 /**
  * A parsed Document.
@@ -25,11 +25,13 @@ export abstract class ParsedDocument<A, V> {
   url: string;
   contents: string;
   ast: A;
+  private _locationOffset: LocationOffset|null;
 
   constructor(from: Options<A>) {
     this.url = from.url;
     this.contents = from.contents;
     this.ast = from.ast;
+    this._locationOffset = from.locationOffset;
   }
 
   /**
@@ -45,7 +47,12 @@ export abstract class ParsedDocument<A, V> {
    */
   abstract forEachNode(callback: (node: A) => void): void;
 
-  abstract sourceRangeForNode(node: A): SourceRange;
+  sourceRangeForNode(node: A): SourceRange {
+    const baseSource = this._sourceRangeForNode(node);
+    return correctSourceRange(baseSource, this._locationOffset);
+  };
+
+  abstract _sourceRangeForNode(node: A): SourceRange;
 
   /**
    * Convert `this.ast` back into a string document.
@@ -57,4 +64,5 @@ export interface Options<A> {
   url: string;
   contents: string;
   ast: A;
+  locationOffset: LocationOffset|null;
 }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -12,8 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {LocationOffset} from '../model/model';
+
 import {ParsedDocument} from './document';
 
 export interface Parser<D extends ParsedDocument<any, any>> {
-  parse(contents: string, url: string): D;
+  parse(contents: string, url: string, locationOffset?: LocationOffset): D;
 }

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -73,7 +73,8 @@ suite('Analyzer', () => {
           await analyzer.analyze('static/analysis/behaviors/behavior.html');
 
       const behaviors = Array.from(document.getByKind('behavior'));
-      assert.deepEqual(behaviors.map(b => b.className),
+      assert.deepEqual(
+          behaviors.map(b => b.className),
           ['MyNamespace.SubBehavior', 'MyNamespace.SimpleBehavior']);
     });
 

--- a/src/test/scanning/scan_test.ts
+++ b/src/test/scanning/scan_test.ts
@@ -109,7 +109,7 @@ function makeTestDocument(options: TestDocumentMakerOptions):
     stringify() {
       return 'test stringify output';
     }
-  };
+  } as any;
 }
 
 interface TestScannerMakerOptions {


### PR DESCRIPTION
Should make #320 much more feasible. `ParsedDocument.getSourceRange` should now just Do The Right Thing in all circumstances.

Parsed Documents are now aware of their location offsets from the moment that they're created, and all implementations of `getSourceRange` now automatically apply the appropriate location offsets (if any).