### PR TITLE
Enable strict null checks.

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -23,7 +23,7 @@ import {HtmlScriptScanner} from './html/html-script-scanner';
 import {HtmlStyleScanner} from './html/html-style-scanner';
 import {JavaScriptParser} from './javascript/javascript-parser';
 import {JsonParser} from './json/json-parser';
-import {correctSourceRange, Document, InlineDocInfo, LocationOffset, ScannedDocument, ScannedElement, ScannedFeature, ScannedImport, ScannedInlineDocument} from './model/model';
+import {Document, InlineDocInfo, LocationOffset, ScannedDocument, ScannedElement, ScannedFeature, ScannedImport, ScannedInlineDocument} from './model/model';
 import {ParsedDocument} from './parser/document';
 import {Parser} from './parser/parser';
 import {Measurement, TelemetryTracker} from './perf/telemetry';
@@ -173,9 +173,9 @@ export class Analyzer {
    *
    * If a document has been analyzed, it returns the analyzed Document. If not
    * the scanned document cache is used and a new analyzed Document is returned.
-   * If a file is in neither cache, it returns `null`.
+   * If a file is in neither cache, it returns `undefined`.
    */
-  _getDocument(url: string): Document {
+  _getDocument(url: string): Document|undefined {
     const resolvedUrl = this._resolveUrl(url);
     let document = this._analyzedDocuments.get(resolvedUrl);
     if (document) {
@@ -240,11 +240,6 @@ export class Analyzer {
   private async _scanDocument(
       document: ParsedDocument<any, any>,
       maybeAttachedComment?: string): Promise<ScannedDocument> {
-    // TODO(rictic): We shouldn't be calling _scanDocument with
-    // null/undefined.
-    if (document == null) {
-      return null;
-    }
     const warnings: Warning[] = [];
     const scannedFeatures = await this._getScannedFeatures(document);
     // If there's an HTML comment that applies to this document then we assume
@@ -269,8 +264,8 @@ export class Analyzer {
           }
         });
 
-    const dependencies =
-        (await Promise.all(scannedSubDocuments)).filter(s => !!s);
+    const dependencies = (await Promise.all(scannedSubDocuments))
+                             .filter(s => !!s) as ScannedDocument[];
 
     const scannedDocument =
         new ScannedDocument(document, dependencies, scannedFeatures, warnings);
@@ -300,10 +295,7 @@ export class Analyzer {
       return scannedDocument;
     } catch (err) {
       if (err instanceof WarningCarryingException) {
-        const e: WarningCarryingException = err;
-        e.warning.sourceRange =
-            correctSourceRange(e.warning.sourceRange, locationOffset);
-        warnings.push(e.warning);
+        warnings.push(err.warning);
         return null;
       }
       throw err;
@@ -372,7 +364,7 @@ export class Analyzer {
 
       const doneTiming = this._telemetryTracker.start('parse', 'resolvedUrl');
       const parsedDoc =
-          this._parseContents(extension, content, resolvedUrl, null);
+          this._parseContents(extension, content, resolvedUrl, undefined);
       doneTiming();
       return parsedDoc;
     })();
@@ -382,7 +374,7 @@ export class Analyzer {
 
   private _parseContents(
       type: string, contents: string, url: string,
-      inlineInfo: InlineDocInfo<any>|null): ParsedDocument<any, any> {
+      inlineInfo?: InlineDocInfo<any>): ParsedDocument<any, any> {
     const parser = this._parsers.get(type);
     if (parser == null) {
       throw new NoKnownParserError(`No parser for for file type ${type}`);

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -363,8 +363,7 @@ export class Analyzer {
       const extension = path.extname(resolvedUrl).substring(1);
 
       const doneTiming = this._telemetryTracker.start('parse', 'resolvedUrl');
-      const parsedDoc =
-          this._parseContents(extension, content, resolvedUrl, undefined);
+      const parsedDoc = this._parseContents(extension, content, resolvedUrl);
       doneTiming();
       return parsedDoc;
     })();

--- a/src/editor-service/editor-server.ts
+++ b/src/editor-service/editor-server.ts
@@ -97,7 +97,7 @@ process.stdin.pipe(split()).on('data', async function(line: string) {
 // node child_process.fork() IPC interface
 process.on('message', async function(request: RequestWrapper) {
   const result = await getSettledValue(request.value);
-  process.send(<ResponseWrapper>{id: request.id, value: result});
+  process.send!(<ResponseWrapper>{id: request.id, value: result});
 });
 
 

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -70,7 +70,7 @@ export class LocalEditorService extends EditorService {
       return {
         kind: 'element-tags',
         elements: elements.map(e => {
-          let attributesSpace = e.attributes.length > 0 ? ' ' : '';
+          const attributesSpace = e.attributes.length > 0 ? ' ' : '';
           return {
             tagname: e.tagName!,
             description: e.description,
@@ -84,11 +84,11 @@ export class LocalEditorService extends EditorService {
       const elements = document.getById('element', location.element.nodeName);
       let attributes: AttributeCompletion[] = [];
       for (const element of elements) {
-        // A map from the inheritedFrom to a sort prefix.
-        let sortPrefixes = new Map<string|undefined|null, string>();
+        // A map from the inheritedFrom to a sort prefix. Note that
+        // `undefined` is a legal value for inheritedFrom.
+        const sortPrefixes = new Map<string|undefined, string>();
         // Not inherited, that means local! Sort it early.
         sortPrefixes.set(undefined, 'aaa-');
-        sortPrefixes.set(null, 'aaa-');
         if (element.superClass) {
           sortPrefixes.set(element.superClass, 'bbb-');
         }

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -47,7 +47,8 @@ export class LocalEditorService extends EditorService {
   }
 
   async getDefinitionForFeatureAtPosition(
-      localPath: string, position: SourcePosition): Promise<SourceRange> {
+      localPath: string,
+      position: SourcePosition): Promise<SourceRange|undefined> {
     const feature = await this._getFeatureAt(localPath, position);
     if (!feature) {
       return;
@@ -60,14 +61,18 @@ export class LocalEditorService extends EditorService {
       position: SourcePosition): Promise<TypeaheadCompletion|undefined> {
     const document = await this._analyzer.analyze(localPath);
     const location = await this._getLocationResult(document, position);
+    if (!location) {
+      return;
+    }
     if (location.kind === 'tagName' || location.kind === 'text') {
-      const elements = Array.from(document.getByKind('element'));
+      const elements =
+          Array.from(document.getByKind('element')).filter(e => e.tagName);
       return {
         kind: 'element-tags',
         elements: elements.map(e => {
           let attributesSpace = e.attributes.length > 0 ? ' ' : '';
           return {
-            tagname: e.tagName,
+            tagname: e.tagName!,
             description: e.description,
             expandTo: location.kind === 'text' ?
                 `<${e.tagName}${attributesSpace}></${e.tagName}>` :
@@ -80,7 +85,7 @@ export class LocalEditorService extends EditorService {
       let attributes: AttributeCompletion[] = [];
       for (const element of elements) {
         // A map from the inheritedFrom to a sort prefix.
-        let sortPrefixes = new Map<string, string>();
+        let sortPrefixes = new Map<string|undefined|null, string>();
         // Not inherited, that means local! Sort it early.
         sortPrefixes.set(undefined, 'aaa-');
         sortPrefixes.set(null, 'aaa-');
@@ -90,29 +95,31 @@ export class LocalEditorService extends EditorService {
         if (element.extends) {
           sortPrefixes.set(element.extends, 'ccc-');
         }
-        attributes = attributes.concat(
-            element.attributes
-                .map(p => ({
-                       name: p.name,
-                       description: p.description,
-                       type: p.type,
-                       inheritedFrom: p.inheritedFrom,
-                       sortKey: `${sortPrefixes.get(p.inheritedFrom) ||
-                           'ddd-'
-                           }` +
-                               `${p.name}`
-                     }))
-                .concat(element.events.map(
-                    e => ({
-                      name: `on-${e.name}`,
-                      description: e.description,
-                      type: e.type || 'CustomEvent',
-                      inheritedFrom: e.inheritedFrom,
-                      sortKey: `eee-${sortPrefixes.get(e.inheritedFrom) ||
-                          'ddd-'
-                          }` +
-                              `on-${e.name}`
-                    }))));
+        const elementAttributes: AttributeCompletion[] =
+            element.attributes.map(p => {
+              const sortKey =
+                  (sortPrefixes.get(p.inheritedFrom) || `ddd-`) + p.name;
+              return {
+                name: p.name,
+                description: p.description || '',
+                type: p.type,
+                inheritedFrom: p.inheritedFrom, sortKey
+              };
+            });
+
+        const eventAttributes: AttributeCompletion[] =
+            element.events.map((e) => {
+              const postfix = sortPrefixes.get(e.inheritedFrom) || 'ddd-';
+              const sortKey = `eee-${postfix}on-${e.name}`;
+              return {
+                name: `on-${e.name}`,
+                description: e.description || '',
+                type: e.type || 'CustomEvent',
+                inheritedFrom: e.inheritedFrom, sortKey
+              };
+            });
+        attributes =
+            attributes.concat(elementAttributes).concat(eventAttributes);
       }
       return {kind: 'attributes', attributes};
     };

--- a/src/generate-elements.ts
+++ b/src/generate-elements.ts
@@ -25,6 +25,7 @@ export function generateElementMetadata(
   return {
     schema_version: '1.0.0',
     elements: elements.map(e => serializeElement(e, packagePath))
+                  .filter(e => !!e) as Element[]
   };
 }
 
@@ -85,7 +86,7 @@ function serializeElement(
   const events = resolvedElement.events.map(
       e => ({
         name: e.name,
-        description: e.description,
+        description: e.description || '',
         type: 'CustomEvent',
         metadata: resolvedElement.emitEventMetadata(e)
       }));
@@ -105,7 +106,7 @@ function serializeElement(
     slots: [],
     events: events,
     metadata: resolvedElement.emitMetadata(),
-    sourceRange: resolveSourceRangePath(path, resolvedElement.sourceRange)
+    sourceRange: resolveSourceRangePath(path, resolvedElement.sourceRange),
   };
 }
 

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -47,7 +47,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
     });
   }
 
-  _sourceRangeForNode(node: ASTNode): SourceRange {
+  _sourceRangeForNode(node: ASTNode): SourceRange|undefined {
     if (!node || !node.__location) {
       return;
     }
@@ -79,7 +79,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
     if (!node || !node.__location) {
       return;
     }
-    let attrs: parse5.AttributesLocationInfo;
+    let attrs: parse5.AttributesLocationInfo|undefined = undefined;
     if (node.__location['startTag'] && node.__location['startTag'].attrs) {
       attrs = node.__location['startTag'].attrs;
     } else if (node.__location['attrs']) {
@@ -124,7 +124,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
 
     // We can modify these, as they don't escape this method.
     const mutableDocuments = clone(immutableDocuments);
-    const selfClone = mutableDocuments.shift();
+    const selfClone = mutableDocuments.shift()!;
 
     for (const doc of mutableDocuments) {
       // TODO(rictic): infer this from doc.astNode's indentation.

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -26,13 +26,14 @@ const linkTag = p.hasTagName('link');
 const notCssLink = p.NOT(p.hasAttrValue('type', 'css'));
 
 const isHtmlImportNode = p.AND(
-    linkTag, p.hasSpaceSeparatedAttrValue('rel', 'import'),
+    linkTag, p.hasAttr('href'), p.hasSpaceSeparatedAttrValue('rel', 'import'),
     p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'lazy-import')), notCssLink,
     p.NOT(p.parentMatches(p.hasTagName('template'))));
 
 const isLazyImportNode = p.AND(
     p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'lazy-import'),
-    p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'import')), notCssLink,
+    p.hasAttr('href'), p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'import')),
+    notCssLink,
     p.parentMatches(
         p.AND(p.hasTagName('dom-module'), p.NOT(p.hasTagName('template')))));
 
@@ -55,11 +56,11 @@ export class HtmlImportScanner implements HtmlScanner {
       } else {
         return;
       }
-      const href = dom5.getAttribute(node, 'href');
+      const href = dom5.getAttribute(node, 'href')!;
       const importUrl = resolveUrl(document.url, href);
       imports.push(new ScannedImport(
-          type, importUrl, document.sourceRangeForNode(node),
-          document.sourceRangeForAttribute(node, 'href'), node));
+          type, importUrl, document.sourceRangeForNode(node)!,
+          document.sourceRangeForAttribute(node, 'href')!, node));
     });
     return imports;
   }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -43,16 +43,16 @@ export class HtmlScriptScanner implements HtmlScanner {
         if (src) {
           const importUrl = resolveUrl(document.url, src);
           features.push(new ScannedScriptTagImport(
-              'html-script', importUrl, document.sourceRangeForNode(node),
-              document.sourceRangeForAttribute(node, 'src'), node));
+              'html-script', importUrl, document.sourceRangeForNode(node)!,
+              document.sourceRangeForAttribute(node, 'src')!, node));
         } else {
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
-          const attachedCommentText = getAttachedCommentText(node);
+          const attachedCommentText = getAttachedCommentText(node) || '';
           const contents = dom5.getTextContent(node);
 
           features.push(new ScannedInlineDocument(
               'js', contents, locationOffset, attachedCommentText,
-              document.sourceRangeForNode(node), node));
+              document.sourceRangeForNode(node)!, node));
         }
       }
     };

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -23,7 +23,7 @@ import {Document, Import, ScannedImport} from '../model/model';
 export class ScriptTagImport extends Import { type: 'html-script'; }
 
 export class ScannedScriptTagImport extends ScannedImport {
-  resolve(document: Document): ScriptTagImport {
+  resolve(document: Document): ScriptTagImport|undefined {
     // TODO(justinfagnani): warn if the same URL is loaded from more than one
     // non-module script tag
 
@@ -41,10 +41,10 @@ export class ScannedScriptTagImport extends ScannedImport {
       importedDocument.resolve();
       return new ScriptTagImport(
           this.url, this.type, importedDocument, this.sourceRange,
-          this.urlSourceRange, this.astNode);
+          this.urlSourceRange, this.astNode, this.warnings);
     } else {
       // not found or syntax error
-      return null;
+      return undefined;
     }
   }
 }

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -27,7 +27,8 @@ const isStyleElement = p.AND(
     p.OR(p.NOT(p.hasAttr('type')), p.hasAttrValue('type', 'text/css')));
 
 const isStyleLink = p.AND(
-    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'stylesheet'));
+    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'stylesheet'),
+    p.hasAttr('href'));
 
 const isStyleNode = p.OR(isStyleElement, isStyleLink);
 
@@ -42,18 +43,18 @@ export class HtmlStyleScanner implements HtmlScanner {
       if (isStyleNode(node)) {
         const tagName = node.nodeName;
         if (tagName === 'link') {
-          const href = dom5.getAttribute(node, 'href');
+          const href = dom5.getAttribute(node, 'href')!;
           const importUrl = resolveUrl(document.url, href);
           features.push(new ScannedImport(
-              'html-style', importUrl, document.sourceRangeForNode(node),
-              document.sourceRangeForAttribute(node, 'href'), node));
+              'html-style', importUrl, document.sourceRangeForNode(node)!,
+              document.sourceRangeForAttribute(node, 'href')!, node));
         } else {
           const contents = dom5.getTextContent(node);
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
-          const commentText = getAttachedCommentText(node);
+          const commentText = getAttachedCommentText(node) || '';
           features.push(new ScannedInlineDocument(
               'css', contents, locationOffset, commentText,
-              document.sourceRangeForNode(node), node));
+              document.sourceRangeForNode(node)!, node));
         }
       }
     });

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -91,7 +91,8 @@ function blockStatementToValue(block: estree.BlockStatement): LiteralValue {
  * Evaluates return's argument
  */
 function returnStatementToValue(ret: estree.ReturnStatement): LiteralValue {
-  return expressionToValue(ret.argument);
+  return expressionToValue(
+      ret.argument || {type: 'Literal', value: null, raw: 'null'});
 }
 
 /**
@@ -118,7 +119,7 @@ function objectExpressionToValue(obj: estree.ObjectExpression): LiteralValue {
     if (prop.key.type !== 'Literal') {
       return;
     }
-    const evaluatedKey = literalToValue(prop.key).toString();
+    const evaluatedKey = '' + literalToValue(prop.key);
     const evaluatedValue = expressionToValue(prop.value);
     if (evaluatedValue === undefined) {
       return;
@@ -131,8 +132,8 @@ function objectExpressionToValue(obj: estree.ObjectExpression): LiteralValue {
 /**
  * Binary expressions, like 5 + 5
  */
-function binaryExpressionToValue(member: estree.BinaryExpression): (number|
-                                                                    string) {
+function binaryExpressionToValue(member: estree.BinaryExpression):
+    (number|string|undefined) {
   const left = expressionToValue(member.left);
   const right = expressionToValue(member.right);
   if (left == null || right == null) {

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -23,6 +23,13 @@ import {Visitor, VisitResult} from './estree-visitor';
 
 export {Visitor} from './estree-visitor';
 
+/**
+ * estree.Node#type is one of around a hundred string literals. We don't have
+ * a direct reference to the type that represents any of those string literals
+ * though. We can get a reference by taking a Node and using the `typeof`
+ * operator, and it doesn't need to be a real Node as all of this happens at
+ * analysis time, and nothing happens at runtime.
+ */
 const __exampleNode: Node = <any>null;
 interface SkipRecord {
   type: typeof __exampleNode.type;

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -23,7 +23,7 @@ import {Visitor, VisitResult} from './estree-visitor';
 
 export {Visitor} from './estree-visitor';
 
-let __exampleNode: Node;
+const __exampleNode: Node = <any>null;
 interface SkipRecord {
   type: typeof __exampleNode.type;
   depth: number;

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -35,8 +35,8 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
         }
         const importUrl = resolveUrl(document.url, source);
         imports.push(new ScannedImport(
-            'js-import', importUrl, document.sourceRangeForNode(node),
-            document.sourceRangeForNode(node.source), node));
+            'js-import', importUrl, document.sourceRangeForNode(node)!,
+            document.sourceRangeForNode(node.source)!, node));
       }
     });
     return imports;

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -15,7 +15,7 @@
 import * as espree from 'espree';
 import {Program} from 'estree';
 
-import {InlineDocInfo} from '../model/model';
+import {correctSourceRange, InlineDocInfo} from '../model/model';
 import {Parser} from '../parser/parser';
 import {Severity, WarningCarryingException} from '../warning/warning';
 
@@ -54,11 +54,13 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
           message: err.message.split('\n')[0],
           severity: Severity.ERROR,
           code: 'parse-error',
-          sourceRange: {
-            file: url,
-            start: {line: err.lineNumber - 1, column: err.column - 1},
-            end: {line: err.lineNumber - 1, column: err.column - 1}
-          }
+          sourceRange: correctSourceRange(
+              {
+                file: url,
+                start: {line: err.lineNumber - 1, column: err.column - 1},
+                end: {line: err.lineNumber - 1, column: err.column - 1}
+              },
+              inlineInfo.locationOffset)!
         });
       }
       throw err;

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -105,8 +105,8 @@ function _tagsToHydroTags(tags: doctrine.Tag[]|null): Tag[]|null {
       return {
         tag: tag.title,
         type: tag.type ? doctrine.type.stringify(tag.type) : null,
-        name: tag.name,
-        description: tag.description,
+        name: tag.name == null ? null : tag.name,
+        description: tag.description
       };
     }
   });

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -54,7 +54,7 @@ export class Document implements Feature {
   kinds: Set<string> = new Set(['document']);
   identifiers: Set<string> = new Set();
   analyzer: Analyzer;
-  warnings = [] as Warning[];
+  warnings: Warning[] = [];
 
   private _localFeatures = new Set<Feature>();
   private _scannedDocument: ScannedDocument;

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -33,7 +33,7 @@ export class ScannedDocument {
   dependencies: ScannedDocument[];
   features: ScannedFeature[];
   isInline = false;
-  sourceRange: SourceRange = null;  // TODO(rictic): track this
+  sourceRange: SourceRange|undefined = undefined;  // TODO(rictic): track this
   warnings: Warning[];
 
   constructor(
@@ -54,6 +54,7 @@ export class Document implements Feature {
   kinds: Set<string> = new Set(['document']);
   identifiers: Set<string> = new Set();
   analyzer: Analyzer;
+  warnings = [] as Warning[];
 
   private _localFeatures = new Set<Feature>();
   private _scannedDocument: ScannedDocument;
@@ -102,7 +103,7 @@ export class Document implements Feature {
     return this._scannedDocument.document;
   }
 
-  get sourceRange(): SourceRange {
+  get sourceRange(): SourceRange|undefined {
     return this._scannedDocument.sourceRange;
   }
 
@@ -322,16 +323,18 @@ export class Document implements Feature {
     return this.parsedDocument.stringify({inlineDocuments: inlineDocuments});
   }
 
-  private _featuresByKind: Map<string, Set<Feature>> = null;
-  private _featuresByKindAndId: Map<string, Map<string, Set<Feature>>> = null;
+  private _featuresByKind: Map<string, Set<Feature>>|null = null;
+  private _featuresByKindAndId: Map<string, Map<string, Set<Feature>>>|null =
+      null;
   private _initIndexes() {
     this._featuresByKind = new Map<string, Set<Feature>>();
     this._featuresByKindAndId = new Map<string, Map<string, Set<Feature>>>();
   }
 
   private _indexFeature(feature: Feature) {
-    if (!this._featuresByKind)
+    if (!this._featuresByKind || !this._featuresByKindAndId) {
       return;
+    }
     for (const kind of feature.kinds) {
       const kindSet = this._featuresByKind.get(kind) || new Set<Feature>();
       kindSet.add(feature);

--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -33,14 +33,14 @@ export class ScannedElement implements Resolvable {
   className?: string;
   superClass?: string;
   extends?: string;
-  properties = [] as ScannedProperty[];
-  attributes = [] as ScannedAttribute[];
+  properties: ScannedProperty[] = [];
+  attributes: ScannedAttribute[] = [];
   description = '';
   demos: {desc?: string; path: string}[] = [];
-  events = [] as ScannedEvent[];
+  events: ScannedEvent[] = [];
   sourceRange: SourceRange|undefined;
   astNode: estree.Node|null;
-  warnings = [] as Warning[];
+  warnings: Warning[] = [];
 
   jsdoc?: jsdoc.Annotation;
 
@@ -72,7 +72,7 @@ export class Element implements Feature {
   jsdoc?: jsdoc.Annotation;
   astNode: estree.Node|null;
   kinds: Set<string> = new Set(['element']);
-  warnings = [] as Warning[];
+  warnings: Warning[] = [];
   get identifiers(): Set<string> {
     const result: Set<string> = new Set();
     if (this.tagName) {

--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -15,6 +15,7 @@
 import * as estree from 'estree';
 import * as jsdoc from '../javascript/jsdoc';
 import {SourceRange} from '../model/model';
+import {Warning} from '../warning/warning';
 
 import {Document, Event, Feature, Property, Resolvable, ScannedEvent, ScannedProperty} from './model';
 
@@ -22,7 +23,7 @@ export {Visitor} from '../javascript/estree-visitor';
 
 export interface ScannedAttribute {
   name: string;
-  sourceRange: SourceRange;
+  sourceRange: SourceRange|undefined;
   description?: string;
   type?: string;
 }
@@ -32,13 +33,14 @@ export class ScannedElement implements Resolvable {
   className?: string;
   superClass?: string;
   extends?: string;
-  properties: ScannedProperty[] = [];
-  attributes: ScannedAttribute[] = [];
+  properties = [] as ScannedProperty[];
+  attributes = [] as ScannedAttribute[];
   description = '';
   demos: {desc?: string; path: string}[] = [];
-  events: ScannedEvent[] = [];
-  sourceRange: SourceRange;
+  events = [] as ScannedEvent[];
+  sourceRange: SourceRange|undefined;
   astNode: estree.Node|null;
+  warnings = [] as Warning[];
 
   jsdoc?: jsdoc.Annotation;
 
@@ -70,6 +72,7 @@ export class Element implements Feature {
   jsdoc?: jsdoc.Annotation;
   astNode: estree.Node|null;
   kinds: Set<string> = new Set(['element']);
+  warnings = [] as Warning[];
   get identifiers(): Set<string> {
     const result: Set<string> = new Set();
     if (this.tagName) {

--- a/src/model/feature.ts
+++ b/src/model/feature.ts
@@ -13,20 +13,25 @@
  */
 
 import * as jsdoc from '../javascript/jsdoc';
+import {Warning} from '../warning/warning';
+
 import {SourceRange} from './source-range';
 
 export interface Feature {
   kinds: Set<string>;
-  identifiers?: Set<string>;
+  identifiers: Set<string>;
 
   /** Tracks the source that this feature came from. */
-  sourceRange: SourceRange;
+  sourceRange: SourceRange|undefined;
 
   /**
    * The AST Node, if any, that corresponds to this feature in its containing
    * document.
    */
   astNode: any;
+
+  /** Warnings that were encountered while processing this feature. */
+  warnings: Warning[];
 }
 
 export interface ScannedFeature {
@@ -36,11 +41,14 @@ export interface ScannedFeature {
   jsdoc?: jsdoc.Annotation;
 
   /** Tracks the source that this feature came from. */
-  sourceRange: SourceRange;
+  sourceRange: SourceRange|undefined;
 
   /**
    * The AST Node, if any, that corresponds to this feature in its containing
    * document.
    */
   astNode: any;
+
+  /** Warnings that were encountered while processing this feature. */
+  warnings: Warning[];
 }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -46,7 +46,7 @@ export class ScannedImport implements Resolvable {
 
   astNode: any|null;
 
-  warnings = [] as Warning[];
+  warnings: Warning[] = [];
 
   constructor(
       type: string, url: string, sourceRange: SourceRange,

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Warning} from '../warning/warning';
+
 import {Document, ScannedDocument} from './document';
 import {Feature} from './feature';
 import {SourceRange} from './model';
@@ -44,6 +46,8 @@ export class ScannedImport implements Resolvable {
 
   astNode: any|null;
 
+  warnings = [] as Warning[];
+
   constructor(
       type: string, url: string, sourceRange: SourceRange,
       urlSourceRange: SourceRange, ast: any|null) {
@@ -54,12 +58,12 @@ export class ScannedImport implements Resolvable {
     this.astNode = ast;
   }
 
-  resolve(document: Document): Import {
+  resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
     return importedDocument &&
         new Import(
                this.url, this.type, importedDocument, this.sourceRange,
-               this.urlSourceRange, this.astNode);
+               this.urlSourceRange, this.astNode, this.warnings);
   }
 }
 
@@ -72,10 +76,11 @@ export class Import implements Feature {
   sourceRange: SourceRange;
   urlSourceRange: SourceRange;
   astNode: any|null;
+  warnings: Warning[];
 
   constructor(
       url: string, type: string, document: Document, sourceRange: SourceRange,
-      urlSourceRange: SourceRange, ast: any) {
+      urlSourceRange: SourceRange, ast: any, warnings: Warning[]) {
     this.url = url;
     this.type = type;
     this.document = document;
@@ -83,6 +88,7 @@ export class Import implements Feature {
     this.sourceRange = sourceRange;
     this.urlSourceRange = urlSourceRange;
     this.astNode = ast;
+    this.warnings = warnings;
   }
 
   toString() {

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -48,7 +48,7 @@ export class ScannedInlineDocument implements ScannedFeature, Resolvable {
   scannedDocument?: ScannedDocument;
 
   sourceRange: SourceRange;
-  warnings = [] as Warning[];
+  warnings: Warning[] = [];
 
   astNode: dom5.Node;
 

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -18,6 +18,7 @@ import {ASTNode} from 'parse5';
 import * as util from 'util';
 
 import * as jsdoc from '../javascript/jsdoc';
+import {Warning} from '../warning/warning';
 
 import {Document, ScannedDocument} from './document';
 import {ScannedFeature} from './feature';
@@ -47,6 +48,7 @@ export class ScannedInlineDocument implements ScannedFeature, Resolvable {
   scannedDocument?: ScannedDocument;
 
   sourceRange: SourceRange;
+  warnings = [] as Warning[];
 
   astNode: dom5.Node;
 
@@ -61,7 +63,7 @@ export class ScannedInlineDocument implements ScannedFeature, Resolvable {
     this.astNode = ast;
   }
 
-  resolve(document: Document): Document {
+  resolve(document: Document): Document|undefined {
     if (!this.scannedDocument) {
       // Parse error on the inline document.
       return;
@@ -100,7 +102,8 @@ function isLocationInfo(loc: (parse5.LocationInfo|parse5.ElementLocationInfo)):
 
 export function getLocationOffsetOfStartOfTextContent(node: ASTNode):
     LocationOffset {
-  let firstChildNodeWithLocation = node.childNodes.find(n => !!n.__location);
+  const childNodes = node.childNodes || [];
+  let firstChildNodeWithLocation = childNodes.find(n => !!n.__location);
   let bestLocation = firstChildNodeWithLocation ?
       firstChildNodeWithLocation.__location :
       node.__location;

--- a/src/model/literal.ts
+++ b/src/model/literal.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-export type LiteralValue =
-    string | number | boolean | RegExp | undefined | LiteralArray | LiteralObj;
+export type LiteralValue = string | number | boolean | RegExp | undefined |
+    LiteralArray | LiteralObj | null;
 export interface LiteralArray extends Array<LiteralValue> {}
 export interface LiteralObj { [key: string]: LiteralValue; }

--- a/src/model/property.ts
+++ b/src/model/property.ts
@@ -26,7 +26,7 @@ export interface ScannedProperty extends ScannedFeature {
   private?: boolean;
   'default'?: string;
   readOnly?: boolean;
-  sourceRange: SourceRange;
+  sourceRange: SourceRange|undefined;
   astNode: estree.Node|null;
 }
 
@@ -38,6 +38,6 @@ export interface Property {
   private?: boolean;
   'default'?: string;
   readOnly?: boolean;
-  sourceRange: SourceRange;
+  sourceRange: SourceRange|undefined;
   inheritedFrom?: string;
 }

--- a/src/model/resolvable.ts
+++ b/src/model/resolvable.ts
@@ -20,7 +20,7 @@ import {Feature, ScannedFeature} from './feature';
  * representation.
  */
 export interface Resolvable extends ScannedFeature {
-  resolve(document: Document): Feature;
+  resolve(document: Document): Feature|undefined;
 }
 
 export function isResolvable(x: any): x is Resolvable {

--- a/src/model/source-range.ts
+++ b/src/model/source-range.ts
@@ -49,8 +49,8 @@ export interface LocationOffset {
  * first line of the <script> contents.
  */
 export function correctSourceRange(
-    sourceRange?: SourceRange, locationOffset?: LocationOffset): SourceRange|
-    undefined {
+    sourceRange?: SourceRange,
+    locationOffset?: LocationOffset|null): SourceRange|undefined {
   if (!locationOffset || !sourceRange) {
     return sourceRange;
   }

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -31,7 +31,8 @@ export abstract class ParsedDocument<A, V> {
    * this document inside of the parent. (e.g. the <style> or <script> tag)
    */
   astNode: any;
-  private _locationOffset: LocationOffset|null;
+
+  private _locationOffset: LocationOffset|undefined;
 
   constructor(from: Options<A>) {
     this.url = from.url;
@@ -54,12 +55,12 @@ export abstract class ParsedDocument<A, V> {
    */
   abstract forEachNode(callback: (node: A) => void): void;
 
-  sourceRangeForNode(node: A): SourceRange {
+  sourceRangeForNode(node: A): SourceRange|undefined {
     const baseSource = this._sourceRangeForNode(node);
     return correctSourceRange(baseSource, this._locationOffset);
   };
 
-  abstract _sourceRangeForNode(node: A): SourceRange;
+  abstract _sourceRangeForNode(node: A): SourceRange|undefined;
 
   /**
    * Convert `this.ast` back into a string document.
@@ -71,7 +72,7 @@ export interface Options<A> {
   url: string;
   contents: string;
   ast: A;
-  locationOffset: LocationOffset|null;
+  locationOffset: LocationOffset|undefined;
   astNode: any|null;
 }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -17,5 +17,5 @@ import {InlineDocInfo} from '../model/model';
 import {ParsedDocument} from './document';
 
 export interface Parser<D extends ParsedDocument<any, any>> {
-  parse(contents: string, url: string, inlineDocInfo: InlineDocInfo<any>): D;
+  parse(contents: string, url: string, inlineDocInfo?: InlineDocInfo<any>): D;
 }

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -115,7 +115,7 @@ class Counter<K> {
     this._map.set(k, i + v);
   }
 
-  get(k: K): number {
+  get(k: K): number|undefined {
     return this._map.get(k);
   }
 

--- a/src/perf/telemetry.ts
+++ b/src/perf/telemetry.ts
@@ -63,7 +63,7 @@ export class TelemetryTracker {
   }
 
   start(kind: string, identifier: string): () => void {
-    let resolve: () => void;
+    let resolve: () => void = () => undefined;
     const promise = new Promise<void>((r) => {
       resolve = r;
     });

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -23,7 +23,8 @@ const p = dom5.predicates;
 
 const isCssImportNode = p.AND(
     p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'import'),
-    p.hasAttrValue('type', 'css'), p.parentMatches(p.hasTagName('dom-module')));
+    p.hasAttr('href'), p.hasAttrValue('type', 'css'),
+    p.parentMatches(p.hasTagName('dom-module')));
 
 export class CssImportScanner implements HtmlScanner {
   async scan(
@@ -34,11 +35,11 @@ export class CssImportScanner implements HtmlScanner {
 
     await visit((node) => {
       if (isCssImportNode(node)) {
-        const href = dom5.getAttribute(node, 'href');
+        const href = dom5.getAttribute(node, 'href')!;
         const importUrl = resolveUrl(document.url, href);
         imports.push(new ScannedImport(
-            'css-import', importUrl, document.sourceRangeForNode(node),
-            document.sourceRangeForAttribute(node, 'href'), node));
+            'css-import', importUrl, document.sourceRangeForNode(node)!,
+            document.sourceRangeForAttribute(node, 'href')!, node));
       }
     });
     return imports;

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -34,7 +34,7 @@ export function declarationPropertyHandlers(
   return {
     is(node: estree.Node) {
       if (node.type === 'Literal') {
-        declaration.tagName = node.value.toString();
+        declaration.tagName = '' + node.value;
       }
     },
     properties(node: estree.Node) {
@@ -53,7 +53,7 @@ export function declarationPropertyHandlers(
         }
         declaration.behaviorAssignments.push({
           name: behaviorName,
-          sourceRange: document.sourceRangeForNode(element),
+          sourceRange: document.sourceRangeForNode(element)!,
         });
       }
     },

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -105,14 +105,19 @@ export function annotateBehavior(scannedBehavior: ScannedBehavior):
  */
 export function annotateEvent(annotation: jsdoc.Annotation): ScannedEvent {
   const eventTag = jsdoc.getTag(annotation, 'event');
+  let name: string;
+  if (eventTag && eventTag.description) {
+    name = (eventTag.description || '').match(/^\S*/)![0];
+  } else {
+    name = 'N/A';
+  }
   const scannedEvent: ScannedEvent = {
-    name: (eventTag && eventTag.description) ?
-        (eventTag.description || '').match(/^\S*/)[0] :
-        'N/A',
-    description: eventTag.description || annotation.description,
+    name: name,
+    description: (eventTag && eventTag.description) || annotation.description,
     jsdoc: annotation,
-    sourceRange: null,
-    astNode: null
+    sourceRange: undefined,
+    astNode: null,
+    warnings: [],
   };
 
   const tags = (annotation && annotation.tags || []);
@@ -153,7 +158,7 @@ function annotateProperty(
   // @type JSDoc wins
   feature.type = jsdoc.getTag(feature.jsdoc, 'type', 'type') || feature.type;
 
-  if (feature.type.match(/^function/i)) {
+  if (feature.type && feature.type.match(/^function/i)) {
     _annotateFunctionProperty(<ScannedFunction><any>feature);
   }
 
@@ -221,7 +226,7 @@ export function featureElement(features: ScannedPolymerCoreFeature[]):
         'The properties reflected here are the combined view of all ' +
         'features found in this library. There may be more properties ' +
         'added via other libraries, as well.',
-    sourceRange: null
+    sourceRange: undefined
   });
 }
 
@@ -284,7 +289,7 @@ export function parsePseudoElements(comments: string[]):
         jsdoc: {description: parsedJsdoc.description, tags: parsedJsdoc.tags},
         properties: [],
         description: parsedJsdoc.description,
-        sourceRange: null
+        sourceRange: undefined
       });
       annotateElementHeader(element);
       elements.push(element);

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -18,20 +18,23 @@ import {ASTNode} from 'parse5';
 import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
 import {HtmlScanner} from '../html/html-scanner';
 import {Feature, getAttachedCommentText, Resolvable, SourceRange} from '../model/model';
+import {Warning} from '../warning/warning';
 
 const p = dom5.predicates;
 
 const isDomModule = p.hasTagName('dom-module');
 
 export class ScannedDomModule implements Resolvable {
-  id?: string;
+  id: string|null;
   node: ASTNode;
   comment?: string;
   sourceRange: SourceRange;
   astNode: dom5.Node;
+  warnings = [] as Warning[];
 
   constructor(
-      id: string, node: ASTNode, sourceRange: SourceRange, ast: dom5.Node) {
+      id: string|null, node: ASTNode, sourceRange: SourceRange,
+      ast: dom5.Node) {
     this.id = id;
     this.node = node;
     this.comment = getAttachedCommentText(node);
@@ -41,7 +44,8 @@ export class ScannedDomModule implements Resolvable {
 
   resolve() {
     return new DomModule(
-        this.node, this.id, this.comment, this.sourceRange, this.astNode);
+        this.node, this.id, this.comment, this.sourceRange, this.astNode,
+        this.warnings);
   }
 }
 
@@ -49,21 +53,24 @@ export class DomModule implements Feature {
   kinds = new Set(['dom-module']);
   identifiers = new Set<string>();
   node: ASTNode;
-  id: string|undefined;
-  comment: string|undefined;
+  id: string|null;
+  comment?: string;
   sourceRange: SourceRange;
   astNode: dom5.Node;
+  warnings: Warning[];
+
   constructor(
-      node: ASTNode, id: string, comment: string, sourceRange: SourceRange,
-      ast: dom5.Node) {
+      node: ASTNode, id: string|null, comment: string|undefined,
+      sourceRange: SourceRange, ast: dom5.Node, warnings: Warning[]) {
     this.node = node;
     this.id = id;
     this.comment = comment;
-    if (this.id) {
+    if (id) {
       this.identifiers.add(id);
     }
     this.sourceRange = sourceRange;
     this.astNode = ast;
+    this.warnings = warnings;
   }
 }
 
@@ -78,7 +85,7 @@ export class DomModuleScanner implements HtmlScanner {
       if (isDomModule(node)) {
         domModules.push(new ScannedDomModule(
             dom5.getAttribute(node, 'id'), node,
-            document.sourceRangeForNode(node), node));
+            document.sourceRangeForNode(node)!, node));
       }
     });
     return domModules;

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -30,7 +30,7 @@ export class ScannedDomModule implements Resolvable {
   comment?: string;
   sourceRange: SourceRange;
   astNode: dom5.Node;
-  warnings = [] as Warning[];
+  warnings: Warning[] = [];
 
   constructor(
       id: string|null, node: ASTNode, sourceRange: SourceRange,

--- a/src/polymer/feature-scanner.ts
+++ b/src/polymer/feature-scanner.ts
@@ -18,8 +18,8 @@ import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 
-import {ScannedPolymerCoreFeature} from './polymer-core-feature';
 import {toScannedPolymerProperty} from './js-utils';
+import {ScannedPolymerCoreFeature} from './polymer-core-feature';
 
 export function featureScanner(document: JavaScriptDocument) {
   /** The features we've found. */
@@ -28,7 +28,7 @@ export function featureScanner(document: JavaScriptDocument) {
   function _extractDesc(
       feature: ScannedPolymerCoreFeature, _node: estree.CallExpression,
       parent: estree.Node) {
-    feature.description = esutil.getAttachedComment(parent);
+    feature.description = esutil.getAttachedComment(parent) || '';
   }
 
   function _extractProperties(
@@ -46,7 +46,7 @@ export function featureScanner(document: JavaScriptDocument) {
     }
 
     const polymerProps = featureNode.properties.map(
-        (p) => toScannedPolymerProperty(p, document.sourceRangeForNode(p)));
+        (p) => toScannedPolymerProperty(p, document.sourceRangeForNode(p)!));
     for (const prop of polymerProps) {
       feature.addProperty(prop);
     }

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -66,7 +66,7 @@ export interface Options {
   events?: ScannedEvent[];
 
   abstract?: boolean;
-  sourceRange: SourceRange;
+  sourceRange: SourceRange|undefined;
 }
 
 /**
@@ -120,7 +120,8 @@ export class ScannedPolymerElement extends ScannedElement {
         name: `${attributeName}-changed`,
         description: `Fired when the \`${prop.name}\` property changes.`,
         sourceRange: prop.sourceRange,
-        astNode: prop.astNode
+        astNode: prop.astNode,
+        warnings: []
       });
     }
   }
@@ -193,9 +194,10 @@ function resolveElement(
       scannedElement.events,
       behaviors.map(b => ({name: b.className, vals: b.events})));
 
-  const domModule = document.getOnlyAtId('dom-module', scannedElement.tagName);
+  const domModule =
+      document.getOnlyAtId('dom-module', scannedElement.tagName || '');
   if (domModule) {
-    clone.description = scannedElement.description || domModule.comment;
+    clone.description = scannedElement.description || domModule.comment || '';
     clone.domModule = domModule.node;
   }
 

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -137,7 +137,7 @@ suite('Analyzer', () => {
           const behaviorJsDocument = inlineDocuments[0];
           const subBehavior = behaviorJsDocument.getOnlyAtId(
               'behavior', 'MyNamespace.SubBehavior');
-          assert.equal(subBehavior.className, 'MyNamespace.SubBehavior');
+          assert.equal(subBehavior!.className, 'MyNamespace.SubBehavior');
         });
 
     test(
@@ -157,7 +157,7 @@ suite('Analyzer', () => {
           // The inline document can find the container's imported features
           const subBehavior =
               inlineJsDocument.getOnlyAtId('behavior', 'TestBehavior');
-          assert.equal(subBehavior.className, 'TestBehavior');
+          assert.equal(subBehavior!.className, 'TestBehavior');
         });
 
     test(
@@ -175,7 +175,7 @@ suite('Analyzer', () => {
           // The inline document can find the container's imported features
           const subBehavior =
               scriptDocument.getOnlyAtId('behavior', 'TestBehavior');
-          assert.equal(subBehavior.className, 'TestBehavior');
+          assert.equal(subBehavior!.className, 'TestBehavior');
         });
 
 
@@ -210,7 +210,7 @@ suite('Analyzer', () => {
           const behaviorJsDocument = inlineDocuments[0];
           const subBehavior = behaviorJsDocument.getOnlyAtId(
               'behavior', 'MyNamespace.SubBehavior');
-          assert.equal(subBehavior.className, 'MyNamespace.SubBehavior');
+          assert.equal(subBehavior!.className, 'MyNamespace.SubBehavior');
         });
 
     test('returns a Document with warnings for malformed files', async() => {
@@ -256,31 +256,31 @@ suite('Analyzer', () => {
       const inlineOnly =
           root.getOnlyAtId('document', 'static/dependencies/inline-only.html');
       assert.deepEqual(
-          Array.from(inlineOnly.getByKind('document'))
+          Array.from(inlineOnly!.getByKind('document'))
               .map((d) => d.parsedDocument.type),
           ['html', 'js', 'css']);
 
       const leaf =
           root.getOnlyAtId('document', 'static/dependencies/leaf.html');
-      assert.deepEqual(Array.from(leaf.getByKind('document')), [leaf]);
+      assert.deepEqual(Array.from(leaf!.getByKind('document')), [leaf]);
 
       const inlineAndImports = root.getOnlyAtId(
           'document', 'static/dependencies/inline-and-imports.html');
       assert.deepEqual(
-          Array.from(inlineAndImports.getByKind('document'))
+          Array.from(inlineAndImports!.getByKind('document'))
               .map((d) => d.parsedDocument.type),
           ['html', 'js', 'html', 'html', 'css']);
       const inFolder = root.getOnlyAtId(
           'document', 'static/dependencies/subfolder/in-folder.html');
       assert.deepEqual(
-          Array.from(inFolder.getByKind('document')).map(d => d.url), [
+          Array.from(inFolder!.getByKind('document')).map(d => d.url), [
             'static/dependencies/subfolder/in-folder.html',
             'static/dependencies/subfolder/subfolder-sibling.html'
           ]);
 
       // check de-duplication
       assert.equal(
-          inlineAndImports.getOnlyAtId(
+          inlineAndImports!.getOnlyAtId(
               'document', 'static/dependencies/subfolder/in-folder.html'),
           inFolder);
     });

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -61,7 +61,7 @@ suite('JavaScriptParser', () => {
       let document = parser.parse(file, '/static/js-elements.js');
       let ast = document.ast;
       let element1 = ast.body[0];
-      let comment = esutil.getAttachedComment(element1);
+      let comment = esutil.getAttachedComment(element1)!;
       assert.isTrue(comment.indexOf('test-element') !== -1);
     });
 

--- a/src/test/javascript/jsdoc_test.ts
+++ b/src/test/javascript/jsdoc_test.ts
@@ -39,7 +39,7 @@ suite('jsdoc', function() {
       assert.deepEqual(parsed, {
         description: '',
         tags: [
-          {tag: 'atag', description: null, name: undefined, type: null},
+          {tag: 'atag', description: null, name: null, type: null},
         ],
       });
     });
@@ -49,7 +49,7 @@ suite('jsdoc', function() {
       assert.deepEqual(parsed, {
         description: '',
         tags: [
-          {tag: 'do', description: 'stuff', name: undefined, type: null},
+          {tag: 'do', description: 'stuff', name: null, type: null},
         ],
       });
     });
@@ -59,7 +59,7 @@ suite('jsdoc', function() {
       assert.deepEqual(parsed, {
         description: '',
         tags: [
-          {tag: 'do', description: 'a thing', name: undefined, type: null},
+          {tag: 'do', description: 'a thing', name: null, type: null},
         ],
       });
     });

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -57,25 +57,25 @@ suite('BehaviorScanner', () => {
 
   test('Supports behaviors at local assignments', () => {
     assert(behaviors.has('SimpleBehavior'));
-    assert.equal(behaviors.get('SimpleBehavior').properties[0].name, 'simple');
+    assert.equal(behaviors.get('SimpleBehavior')!.properties[0].name, 'simple');
   });
 
   test('Supports behaviors with renamed paths', () => {
     assert(behaviors.has('AwesomeBehavior'));
-    assert(behaviors.get('AwesomeBehavior')
-               .properties.some((prop) => prop.name === 'custom'));
+    assert(behaviors.get('AwesomeBehavior')!.properties.some(
+        (prop) => prop.name === 'custom'));
   });
 
   test('Supports behaviors On.Property.Paths', () => {
     assert(behaviors.has('Really.Really.Deep.Behavior'));
     assert.equal(
-        behaviors.get('Really.Really.Deep.Behavior').properties[0].name,
+        behaviors.get('Really.Really.Deep.Behavior')!.properties[0].name,
         'deep');
   });
 
   test('Supports property array on behaviors', () => {
     let defaultValue: any;
-    behaviors.get('AwesomeBehavior').properties.forEach((prop) => {
+    behaviors.get('AwesomeBehavior')!.properties.forEach((prop) => {
       if (prop.name === 'a') {
         defaultValue = prop.default;
       }
@@ -86,9 +86,9 @@ suite('BehaviorScanner', () => {
   test('Supports chained behaviors', function() {
     assert(behaviors.has('CustomBehaviorList'));
     const childBehaviors =
-        behaviors.get('CustomBehaviorList').behaviorAssignments;
+        behaviors.get('CustomBehaviorList')!.behaviorAssignments;
     const deepChainedBehaviors =
-        behaviors.get('Really.Really.Deep.Behavior').behaviorAssignments;
+        behaviors.get('Really.Really.Deep.Behavior')!.behaviorAssignments;
     assert.deepEqual(
         childBehaviors.map((b: ScannedBehaviorAssignment) => b.name), [
           'SimpleBehavior', 'CustomNamedBehavior', 'Really.Really.Deep.Behavior'

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -20,25 +20,27 @@ import * as path from 'path';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ScannedFeature, ScannedElement} from '../../model/model';
+import {ScannedElement, ScannedFeature} from '../../model/model';
 import {Polymer2ElementScanner} from '../../polymer/polymer2-element-scanner';
 
 function compareTagNames(a: {tagName?: string}, b: {tagName?: string}): number {
   const tagNameA = a && a.tagName;
   const tagNameB = b && b.tagName;
 
-  if (tagNameA == null) return (tagNameB == null) ? 0 : -1;
-  if (tagNameB == null) return 1;
+  if (tagNameA == null)
+    return (tagNameB == null) ? 0 : -1;
+  if (tagNameB == null)
+    return 1;
   return tagNameA.localeCompare(tagNameB);
 };
 
 suite('Polymer2ElementScanner', () => {
 
   let document: JavaScriptDocument;
-  let elements: Map<string, ScannedElement>;
+  let elements: Map<string|undefined, ScannedElement>;
   let elementsList: ScannedElement[];
 
-  suiteSetup(async () => {
+  suiteSetup(async() => {
     let parser = new JavaScriptParser({sourceType: 'script'});
     let file = fs.readFileSync(
         path.resolve(__dirname, '../static/polymer2/test-element.js'), 'utf8');
@@ -49,8 +51,8 @@ suite('Polymer2ElementScanner', () => {
 
     const features: ScannedFeature[] = await scanner.scan(document, visit);
     elements = new Map();
-    elementsList = <ScannedElement[]>features.filter(
-        (e) => e instanceof ScannedElement);
+    elementsList =
+        <ScannedElement[]>features.filter((e) => e instanceof ScannedElement);
     for (let element of elementsList) {
       elements.set(element.tagName, element);
     }
@@ -58,48 +60,41 @@ suite('Polymer2ElementScanner', () => {
 
   test('Finds elements', () => {
     const sortedElements = elementsList.sort(compareTagNames);
-    const elementData = sortedElements.map((e) => ({
-      tagName: e.tagName,
-      className: e.className,
-      superClass: e.superClass,
-      properties: e.properties.map((p) => ({
-        name: p.name,
-      })),
-      attributes: e.attributes.map((a) => ({
-        name: a.name,
-      })),
-    }));
+    const elementData =
+        sortedElements.map((e) => ({
+                             tagName: e.tagName,
+                             className: e.className,
+                             superClass: e.superClass,
+                             properties: e.properties.map((p) => ({
+                                                            name: p.name,
+                                                          })),
+                             attributes: e.attributes.map((a) => ({
+                                                            name: a.name,
+                                                          })),
+                           }));
 
     assert.deepEqual(elementData, [
       {
         tagName: undefined,
         className: 'BaseElement',
         superClass: 'Polymer.Element',
-        properties: [
-          {
-            name: 'foo',
-          }
-        ],
-        attributes: [
-          {
-            name: 'foo',
-          }
-        ],
+        properties: [{
+          name: 'foo',
+        }],
+        attributes: [{
+          name: 'foo',
+        }],
       },
       {
         tagName: 'test-element',
         className: 'TestElement',
         superClass: 'Polymer.Element',
-        properties: [
-          {
-            name: 'foo',
-          }
-        ],
-        attributes: [
-          {
-            name: 'foo',
-          }
-        ],
+        properties: [{
+          name: 'foo',
+        }],
+        attributes: [{
+          name: 'foo',
+        }],
       }
     ].sort(compareTagNames));
   });

--- a/src/test/url-loader/multi-url-resolver_test.ts
+++ b/src/test/url-loader/multi-url-resolver_test.ts
@@ -20,7 +20,7 @@ import {UrlResolver} from '../../url-loader/url-resolver';
 class MockResolver implements UrlResolver {
   canResolveCount: number;
   resolveCount: number;
-  constructor(private _resolution: string) {
+  constructor(private _resolution: string|null) {
     this.resetCounts();
   }
 
@@ -33,12 +33,15 @@ class MockResolver implements UrlResolver {
     return this._resolution != null;
   }
   resolve(): string {
+    if (this._resolution == null) {
+      throw new Error('tried to resolve to a null resolution!');
+    }
     this.resolveCount++;
     return this._resolution;
   }
 }
 
-const mockResolverArray = (resolutions: Array<string>) => {
+const mockResolverArray = (resolutions: Array<string|null>) => {
   return resolutions.map((resolution): MockResolver => {
     return new MockResolver(resolution);
   });

--- a/src/test/vanilla-custom-elements/element-scanner_test.ts
+++ b/src/test/vanilla-custom-elements/element-scanner_test.ts
@@ -28,7 +28,7 @@ chai.use(require('chai-subset'));
 
 suite('VanillaElementScanner', () => {
 
-  const elements = new Map<string, ScannedElement>();
+  const elements = new Map<string|undefined, ScannedElement>();
   let document: JavaScriptDocument;
   let elementsList: ScannedElement[];
 
@@ -71,7 +71,7 @@ suite('VanillaElementScanner', () => {
   });
 
   test('Extracts attributes from observedAttributes', () => {
-    const element = elements.get('vanilla-with-observed-attributes');
+    const element = elements.get('vanilla-with-observed-attributes')!;
     assert.containSubset(element.attributes, [
       {
         description: 'When given the element is totally inactive',
@@ -117,7 +117,7 @@ suite('VanillaElementScanner', () => {
   test('Extracts description from jsdoc', () => {
     const element = elements.get('vanilla-with-observed-attributes');
     assert.equal(
-        element.description,
+        element!.description,
         'This is a description of WithObservedAttributes.');
   });
 });

--- a/src/warning/warning-filter.ts
+++ b/src/warning/warning-filter.ts
@@ -26,21 +26,24 @@ export interface Options {
   minimumSeverity: Severity;
 }
 
-const defaultFilterOptions: Options = {
-  warningCodesToIgnore: new Set(),
-  minimumSeverity: Severity.INFO
-};
-
 export class WarningFilter {
-  constructor(private _options: Options) {
-    this._options = Object.assign({}, defaultFilterOptions, this._options);
+  warningCodesToIgnore = new Set<string>();
+  minimumSeverity = Severity.INFO;
+
+  constructor(_options: Options) {
+    if (_options.warningCodesToIgnore) {
+      this.warningCodesToIgnore = _options.warningCodesToIgnore;
+    }
+    if (_options.minimumSeverity != null) {
+      this.minimumSeverity = _options.minimumSeverity;
+    }
   }
 
   shouldIgnore(warning: Warning) {
-    if (this._options.warningCodesToIgnore.has(warning.code)) {
+    if (this.warningCodesToIgnore.has(warning.code)) {
       return true;
     }
-    if (warning.severity > this._options.minimumSeverity) {
+    if (warning.severity > this.minimumSeverity) {
       return true;
     }
     return false;

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -34,11 +34,12 @@ const defaultPrinterOptions = {
 
 export class WarningPrinter {
   _chalk: chalk.Chalk;
+  private _options: Options;
 
-  constructor(
-      private _outStream: NodeJS.WritableStream, private _options?: Options) {
-    this._options = Object.assign({}, defaultPrinterOptions, _options);
-    this._chalk = new chalk.constructor({enabled: this._options.color});
+  constructor(private _outStream: NodeJS.WritableStream, _options?: Options) {
+    this._options =
+        Object.assign({}, defaultPrinterOptions, _options) as Options;
+    this._chalk = new chalk.constructor({enabled: !!this._options.color});
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitThis": true,
+        "strictNullChecks": true,
         "removeComments": false,
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true,


### PR DESCRIPTION
Also, put an array of warnings on all features and scanned features so
that instead of bailing out or throwing we can instead shove a warning
someplace that may be useful in future.

Was otherwise rather straightforward. Caught several bugs. Should have done this a long time
ago I think.