### PR TITLE
"behavior not found" errors are now WarningCarryingExceptions

### DIFF
--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -20,6 +20,22 @@ import {Document, Event, Feature, Property, Resolvable, ScannedEvent, ScannedPro
 
 export {Visitor} from '../javascript/estree-visitor';
 
+/**
+ * A scanned behavior assignment of a Polymer element. This is only a
+ * reference to the behavior and not the actual behavior definition itself.
+ *
+ * ex:
+ *   Polymer({
+ *     is: 'custom-element',
+ *     behaviors: [Polymer.SomeBehavior]
+ *                 ^^^^^^^^^^^^^^^^^^^^
+ *   });
+ */
+export interface ScannedBehaviorAssignment {
+  name: string;
+  sourceRange: SourceRange;
+}
+
 export interface ScannedAttribute {
   name: string;
   sourceRange: SourceRange;

--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -20,22 +20,6 @@ import {Document, Event, Feature, Property, Resolvable, ScannedEvent, ScannedPro
 
 export {Visitor} from '../javascript/estree-visitor';
 
-/**
- * A scanned behavior assignment of a Polymer element. This is only a
- * reference to the behavior and not the actual behavior definition itself.
- *
- * ex:
- *   Polymer({
- *     is: 'custom-element',
- *     behaviors: [Polymer.SomeBehavior]
- *                 ^^^^^^^^^^^^^^^^^^^^
- *   });
- */
-export interface ScannedBehaviorAssignment {
-  name: string;
-  sourceRange: SourceRange;
-}
-
 export interface ScannedAttribute {
   name: string;
   sourceRange: SourceRange;

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -215,9 +215,10 @@ class BehaviorVisitor implements Visitor {
         behavior.addProperty(property);
       }
       behavior.observers = behavior.observers.concat(newBehavior.observers);
-      behavior.behaviors = (behavior.behaviors)
-                               .concat(newBehavior.behaviors)
-                               .filter(isBehaviorImpl);
+      behavior.behaviorAssignments =
+          (behavior.behaviorAssignments)
+              .concat(newBehavior.behaviorAssignments)
+              .filter(isBehaviorImpl);
       return behavior;
     }
     return newBehavior;
@@ -243,7 +244,7 @@ class BehaviorVisitor implements Visitor {
         }
       }
       if (chained.length > 0) {
-        this.currentBehavior.behaviors = chained;
+        this.currentBehavior.behaviorAssignments = chained;
       }
     }
   }

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -20,6 +20,7 @@ import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
+import {ScannedBehaviorAssignment} from '../model/model';
 
 import {ScannedBehavior} from './behavior';
 import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
@@ -190,9 +191,9 @@ class BehaviorVisitor implements Visitor {
    * to same behavior. See iron-multi-selectable for example.
    */
   mergeBehavior(newBehavior: ScannedBehavior): ScannedBehavior {
-    const isBehaviorImpl = (b: string) => {
+    const isBehaviorImpl = (b: ScannedBehaviorAssignment) => {
       // filter out BehaviorImpl
-      return b.indexOf(newBehavior.className) === -1;
+      return b.name.indexOf(newBehavior.className) === -1;
     };
     for (const behavior of this.behaviors) {
       if (newBehavior.className !== behavior.className) {
@@ -231,12 +232,15 @@ class BehaviorVisitor implements Visitor {
     // Polymer.IronSelectableBehavior]
     // We add these to behaviors array
     const expression = behaviorExpression(node);
-    const chained: string[] = [];
+    const chained: Array<ScannedBehaviorAssignment> = [];
     if (expression && expression.type === 'ArrayExpression') {
       for (const element of expression.elements) {
         const behaviorName = astValue.getIdentifierName(element);
         if (behaviorName) {
-          chained.push(behaviorName);
+          chained.push({
+            name: behaviorName,
+            sourceRange: this.document.sourceRangeForNode(element)
+          });
         }
       }
       if (chained.length > 0) {

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -20,9 +20,8 @@ import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
-import {ScannedBehaviorAssignment} from '../model/model';
 
-import {ScannedBehavior} from './behavior';
+import {ScannedBehavior, ScannedBehaviorAssignment} from './behavior';
 import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
 import * as docs from './docs';
 import {toScannedPolymerProperty} from './js-utils';

--- a/src/polymer/behavior.ts
+++ b/src/polymer/behavior.ts
@@ -12,8 +12,25 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document} from '../model/model';
+import {Document, SourceRange} from '../model/model';
 import {Options as ElementOptions, PolymerElement, ScannedPolymerElement} from '../polymer/polymer-element';
+
+/**
+ * A scanned behavior assignment of a Polymer element. This is only a
+ * reference to the behavior and not the actual behavior definition itself.
+ *
+ * Example:
+ *
+ *   Polymer({
+ *     is: 'custom-element',
+ *     behaviors: [Polymer.SomeBehavior]
+ *                 ^^^^^^^^^^^^^^^^^^^^
+ *   });
+ */
+export interface ScannedBehaviorAssignment {
+  name: string;
+  sourceRange: SourceRange;
+}
 
 export interface Options extends ElementOptions {}
 

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -51,7 +51,7 @@ export function declarationPropertyHandlers(
         if (behaviorName === undefined) {
           behaviorName = astValue.CANT_CONVERT;
         }
-        declaration.behaviors.push({
+        declaration.behaviorAssignments.push({
           name: behaviorName,
           sourceRange: document.sourceRangeForNode(element),
         });

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -51,7 +51,10 @@ export function declarationPropertyHandlers(
         if (behaviorName === undefined) {
           behaviorName = astValue.CANT_CONVERT;
         }
-        declaration.behaviors.push(behaviorName);
+        declaration.behaviors.push({
+          name: behaviorName,
+          sourceRange: document.sourceRangeForNode(element),
+        });
       }
     },
     observers(node: estree.Node) {

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -112,7 +112,7 @@ class ElementVisitor implements Visitor {
       const argument = <estree.ArrayExpression>returnStatement.argument;
       if (propDesc.name === 'behaviors') {
         argument.elements.forEach((elementNode) => {
-          this.element.behaviors.push({
+          this.element.behaviorAssignments.push({
             name: astValue.getIdentifierName(elementNode),
             sourceRange: this.document.sourceRangeForNode(prop)
           });

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -112,7 +112,10 @@ class ElementVisitor implements Visitor {
       const argument = <estree.ArrayExpression>returnStatement.argument;
       if (propDesc.name === 'behaviors') {
         argument.elements.forEach((elementNode) => {
-          this.element.behaviors.push(astValue.getIdentifierName(elementNode));
+          this.element.behaviors.push({
+            name: astValue.getIdentifierName(elementNode),
+            sourceRange: this.document.sourceRangeForNode(prop)
+          });
         });
       } else {
         argument.elements.forEach((elementObject: estree.Literal) => {

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -78,7 +78,7 @@ export class ScannedPolymerElement extends ScannedElement {
     javascriptNode: estree.Expression | estree.SpreadElement,
     expression: LiteralValue
   }[] = [];
-  behaviors: ScannedBehaviorAssignment[] = [];
+  behaviorAssignments: ScannedBehaviorAssignment[] = [];
   // FIXME(rictic): domModule and scriptElement aren't known at a file local
   //     level. Remove them here, they should only exist on PolymerElement.
   domModule?: dom5.Node;
@@ -137,7 +137,7 @@ export class PolymerElement extends Element {
     javascriptNode: estree.Expression | estree.SpreadElement,
     expression: LiteralValue
   }[];
-  behaviors: ScannedBehaviorAssignment[];
+  behaviorAssignments: ScannedBehaviorAssignment[];
   domModule?: dom5.Node;
   scriptElement?: dom5.Node;
 
@@ -146,7 +146,7 @@ export class PolymerElement extends Element {
   constructor() {
     super();
     this.kinds = new Set(['element', 'polymer-element']);
-    this.behaviors = [];
+    this.behaviorAssignments = [];
   }
 
   emitPropertyMetadata(property: PolymerProperty) {
@@ -181,8 +181,8 @@ function resolveElement(
   // Copy over all properties better. Maybe exclude known properties not copied?
   const clone: PolymerElement =
       Object.assign(new PolymerElement(), scannedElement);
-  const behaviors = Array.from(
-      getFlattenedAndResolvedBehaviors(scannedElement.behaviors, document));
+  const behaviors = Array.from(getFlattenedAndResolvedBehaviors(
+      scannedElement.behaviorAssignments, document));
   clone.properties = mergeByName(
       scannedElement.properties,
       behaviors.map(b => ({name: b.className, vals: b.properties})));
@@ -203,16 +203,17 @@ function resolveElement(
 }
 
 function getFlattenedAndResolvedBehaviors(
-    behaviors: ScannedBehaviorAssignment[], document: Document) {
+    behaviorAssignments: ScannedBehaviorAssignment[], document: Document) {
   const resolvedBehaviors = new Set<Behavior>();
-  _getFlattenedAndResolvedBehaviors(behaviors, document, resolvedBehaviors);
+  _getFlattenedAndResolvedBehaviors(
+      behaviorAssignments, document, resolvedBehaviors);
   return resolvedBehaviors;
 }
 
 function _getFlattenedAndResolvedBehaviors(
-    behaviors: ScannedBehaviorAssignment[], document: Document,
+    behaviorAssignments: ScannedBehaviorAssignment[], document: Document,
     resolvedBehaviors: Set<Behavior>) {
-  for (const behavior of behaviors) {
+  for (const behavior of behaviorAssignments) {
     // TODO(rictic): once we have a system for passing warnings through, this
     //     could be a mild warning and we could just take the last one in the
     //     array, which should be the most recently defined one.
@@ -232,7 +233,7 @@ function _getFlattenedAndResolvedBehaviors(
     }
     resolvedBehaviors.add(foundBehavior);
     _getFlattenedAndResolvedBehaviors(
-        foundBehavior.behaviors, document, resolvedBehaviors);
+        foundBehavior.behaviorAssignments, document, resolvedBehaviors);
   }
 }
 

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -16,10 +16,10 @@ import * as dom5 from 'dom5';
 import * as estree from 'estree';
 
 import * as jsdoc from '../javascript/jsdoc';
-import {Document, Element, LiteralValue, Property, ScannedAttribute, ScannedBehaviorAssignment, ScannedElement, ScannedEvent, ScannedProperty, SourceRange} from '../model/model';
+import {Document, Element, LiteralValue, Property, ScannedAttribute, ScannedElement, ScannedEvent, ScannedProperty, SourceRange} from '../model/model';
 import {Severity, WarningCarryingException} from '../warning/warning';
 
-import {Behavior} from './behavior';
+import {Behavior, ScannedBehaviorAssignment} from './behavior';
 
 export interface BasePolymerProperty {
   published?: boolean;
@@ -219,7 +219,7 @@ function _getFlattenedAndResolvedBehaviors(
     const foundBehavior = document.getOnlyAtId('behavior', behavior.name);
     if (!foundBehavior) {
       throw new WarningCarryingException({
-        message: `In ${document && document.url}: Unable to resolve behavior ` +
+        message: `Unable to resolve behavior ` +
             `\`${behavior.name}\`. Did you import it? Is it annotated with ` +
             `@polymerBehavior?`,
         severity: Severity.ERROR,

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -94,8 +94,8 @@ suite('Analyzer', () => {
         assert.instanceOf(err, WarningCarryingException);
         const warning: Warning = err.warning;
         assert.equal(
-            err.message, 'In static/html-missing-behaviors.html: ' +
-                'Unable to resolve behavior `Polymer.ExpectedMissingBehavior`. ' +
+            err.message,
+            'Unable to resolve behavior `Polymer.ExpectedMissingBehavior`. ' +
                 'Did you import it? Is it annotated with @polymerBehavior?');
         assert.deepEqual(warning.sourceRange, {
           file: 'static/html-missing-behaviors.html',

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -435,7 +435,8 @@ suite('Analyzer', () => {
           elements.map(e => e.tagName), ['test-seed', 'test-element']);
       const testSeed = elements[0];
 
-      assert.deepEqual(testSeed.behaviors, ['Behavior1', 'Behavior2']);
+      assert.deepEqual(
+          testSeed.behaviorAssignments, ['Behavior1', 'Behavior2']);
       assert.equal(testSeed.tagName, 'test-seed');
 
       assert.equal(testSeed.observers.length, 2);

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -30,6 +30,7 @@ import {ParsedCssDocument} from '../css/css-document';
 import {Document, ScannedImport, ScannedInlineDocument} from '../model/model';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {UrlResolver} from '../url-loader/url-resolver';
+import {Warning, WarningCarryingException} from '../warning/warning';
 
 import {invertPromise} from './test-utils';
 
@@ -82,6 +83,32 @@ suite('Analyzer', () => {
       assert.deepEqual(
           behaviors.map(b => b.className),
           ['MyNamespace.SubBehavior', 'MyNamespace.SimpleBehavior']);
+    });
+
+    // TODO(fks) 09-28-2016: Fix off-by-one error in warning sourceRange line
+    // numbers.
+    test('throws when cant find behavior', async() => {
+      try {
+        await analyzer.analyze('static/html-missing-behaviors.html');
+      } catch (err) {
+        assert.instanceOf(err, WarningCarryingException);
+        const warning: Warning = err.warning;
+        assert.equal(
+            err.message, 'In static/html-missing-behaviors.html: ' +
+                'Unable to resolve behavior `Polymer.ExpectedMissingBehavior`. ' +
+                'Did you import it? Is it annotated with @polymerBehavior?');
+        assert.deepEqual(warning.sourceRange, {
+          file: 'static/html-missing-behaviors.html',
+          start: {
+            line: 23,  // Actual Expected: 24
+            column: 8,
+          },
+          end: {
+            line: 23,  // Actual Expected: 24
+            column: 39,
+          }
+        });
+      }
     });
 
     test(

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -17,6 +17,7 @@ import {assert} from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 
+
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
@@ -85,12 +86,12 @@ suite('BehaviorScanner', () => {
   test('Supports chained behaviors', function() {
     assert(behaviors.has('CustomBehaviorList'));
     const childBehaviors = behaviors.get('CustomBehaviorList').behaviors;
-    assert.deepEqual(childBehaviors, [
+    const deepChainedBehaviors =
+        behaviors.get('Really.Really.Deep.Behavior').behaviors;
+    assert.deepEqual(childBehaviors.map((b) => b.name), [
       'SimpleBehavior', 'CustomNamedBehavior', 'Really.Really.Deep.Behavior'
     ]);
-    assert.deepEqual(
-        behaviors.get('Really.Really.Deep.Behavior').behaviors,
-        ['Do.Re.Mi.Fa']);
+    assert.deepEqual(deepChainedBehaviors.map((b) => b.name), ['Do.Re.Mi.Fa']);
   });
 
 });

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ScannedBehavior} from '../../polymer/behavior';
+import {ScannedBehavior, ScannedBehaviorAssignment} from '../../polymer/behavior';
 import {BehaviorScanner} from '../../polymer/behavior-scanner';
 
 suite('BehaviorScanner', () => {
@@ -85,13 +85,17 @@ suite('BehaviorScanner', () => {
 
   test('Supports chained behaviors', function() {
     assert(behaviors.has('CustomBehaviorList'));
-    const childBehaviors = behaviors.get('CustomBehaviorList').behaviors;
+    const childBehaviors =
+        behaviors.get('CustomBehaviorList').behaviorAssignments;
     const deepChainedBehaviors =
-        behaviors.get('Really.Really.Deep.Behavior').behaviors;
-    assert.deepEqual(childBehaviors.map((b) => b.name), [
-      'SimpleBehavior', 'CustomNamedBehavior', 'Really.Really.Deep.Behavior'
-    ]);
-    assert.deepEqual(deepChainedBehaviors.map((b) => b.name), ['Do.Re.Mi.Fa']);
+        behaviors.get('Really.Really.Deep.Behavior').behaviorAssignments;
+    assert.deepEqual(
+        childBehaviors.map((b: ScannedBehaviorAssignment) => b.name), [
+          'SimpleBehavior', 'CustomNamedBehavior', 'Really.Really.Deep.Behavior'
+        ]);
+    assert.deepEqual(
+        deepChainedBehaviors.map((b: ScannedBehaviorAssignment) => b.name),
+        ['Do.Re.Mi.Fa']);
   });
 
 });

--- a/src/test/static/html-missing-behaviors.html
+++ b/src/test/static/html-missing-behaviors.html
@@ -1,0 +1,28 @@
+<!--
+@license
+Copyright (c) 2016 The GDG Spain Authors. All rights reserved.
+This code may only be used under the MIT style license found at http://gdg.es/LICENSE.txt
+-->
+
+<dom-module id="el-missing-behaviors">
+
+  <template>
+
+    <a href="https://example.com/"
+        target="_blank"
+        title="Multi-line anchor tag">
+      <span>Foobar</span>
+    </a>
+
+  </template>
+
+  <script>
+    Polymer({
+      is: 'el-missing-behaviors',
+
+      behaviors: [
+        Polymer.ExpectedMissingBehavior
+      ]
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
This shouldn't conflict with #330 but an additional PR will be needed so that we can push this warning onto the document itself, instead of throwing a `WarningCarryingException`.

/cc @rictic @justinfagnani 

