### PR TITLE
document.getWarnings()

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -290,9 +290,9 @@ export class Document implements Feature {
     if (deep == null) {
       deep = true;
     }
-    warnings.push(...this.warnings);
+    warnings.push.apply(warnings, this.warnings);
     for (const feature of this.getFeatures(deep)) {
-      warnings.push(...feature.warnings);
+      warnings.push.apply(warnings, feature.warnings);
     }
     return warnings;
   }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -146,6 +146,17 @@ export class Document implements Feature {
     this._doneResolving = true;
   }
 
+  /**
+   * Adds and indexes a feature to this documentled before resolve().
+   */
+  _addFeature(feature: Feature) {
+    if (this._doneResolving) {
+      throw new Error('_addFeature can not be called after _resolve()');
+    }
+    this._indexFeature(feature);
+    this._localFeatures.add(feature);
+  }
+
   getByKind(kind: 'element'): Set<Element>;
   getByKind(kind: 'polymer-element'): Set<PolymerElement>;
   getByKind(kind: 'behavior'): Set<Behavior>;
@@ -267,17 +278,6 @@ export class Document implements Feature {
     }
   }
 
-  /**
-   * Adds and indexes a feature to this documentled before resolve().
-   */
-  _addFeature(feature: Feature) {
-    if (this._doneResolving) {
-      throw new Error('_addFeature can not be called after _resolve()');
-    }
-    this._indexFeature(feature);
-    this._localFeatures.add(feature);
-  }
-
   toString(): string {
     return this._toString(new Set()).join('\n');
   }
@@ -297,8 +297,7 @@ export class Document implements Feature {
       } else {
         let subResult = localFeature.toString();
         if (subResult === '[object Object]') {
-          subResult =
-              `<${localFeature.constructor.name} kinds="${Array
+          subResult = `<${localFeature.constructor.name} kinds="${Array
                   .from(localFeature.kinds)
                   .join(', ')}" ids="${Array.from(localFeature.identifiers)
                   .join(',')}">}`;

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -247,8 +247,8 @@ export class Document implements Feature {
   }
 
   /**
-   * Get features for this document. If `deep` is true, also get features for
-   * all documents reachable from imports in this document.
+   * Get features for all documents reachable via imports in this document.
+   * If `deep` is false, only return features in this document.
    */
   getFeatures(deep?: boolean): Set<Feature> {
     if (deep == null) {
@@ -279,8 +279,8 @@ export class Document implements Feature {
   }
 
   /**
-   * Get warnings for this document. If `deep` is true, also get warnings for
-   * all documents reachable from imports in this document.
+   * Get warnings for all documents and features reachable via imports in this
+   * document. If `deep` is false, only return warnings in this document.
    */
   getWarnings(deep?: boolean): Warning[] {
     const warnings: Warning[] = [];

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -54,7 +54,7 @@ export class Document implements Feature {
   kinds: Set<string> = new Set(['document']);
   identifiers: Set<string> = new Set();
   analyzer: Analyzer;
-  warnings: Warning[] = [];
+  warnings: Warning[];
 
   private _localFeatures = new Set<Feature>();
   private _scannedDocument: ScannedDocument;
@@ -88,7 +88,7 @@ export class Document implements Feature {
       this.identifiers.add(this.url);
     }
     this.kinds.add(`${this.parsedDocument.type}-document`);
-    // this._resolve();
+    this.warnings = base.warnings.slice();
   }
 
   get url(): string {
@@ -105,10 +105,6 @@ export class Document implements Feature {
 
   get sourceRange(): SourceRange|undefined {
     return this._scannedDocument.sourceRange;
-  }
-
-  get _warnings(): Warning[] {
-    return this._scannedDocument.warnings;
   }
 
   get resolved(): boolean {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -88,7 +88,7 @@ export class Document implements Feature {
       this.identifiers.add(this.url);
     }
     this.kinds.add(`${this.parsedDocument.type}-document`);
-    this.warnings = base.warnings.slice();
+    this.warnings = Array.from(base.warnings);
   }
 
   get url(): string {
@@ -279,13 +279,14 @@ export class Document implements Feature {
   }
 
   /**
-   * Get warnings for all documents and features reachable via imports in this
-   * document. If `deep` is false, only return warnings in this document.
+   * Get warnings for this document and all local features of this document. If
+   * `deep` is true, return warnings for all documents and features reachable
+   * via imports in this document.
    */
   getWarnings(deep?: boolean): Warning[] {
     const warnings: Warning[] = [];
     if (deep == null) {
-      deep = true;
+      deep = false;
     }
     warnings.push.apply(warnings, this.warnings);
     for (const feature of this.getFeatures(deep)) {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -250,6 +250,11 @@ export class Document implements Feature {
     return result;
   }
 
+  /**
+   * Return all local features contained within the document as well as features
+   * detected by following through all imports. If the deep argument is set to
+   * false, only return local features.
+   */
   getFeatures(deep?: boolean): Set<Feature> {
     if (deep == null) {
       deep = true;
@@ -276,6 +281,24 @@ export class Document implements Feature {
         }
       }
     }
+  }
+
+  /**
+   * Return all warnings on local features contained within the document as well
+   * as warnings on features detected by following through all imports. If the
+   * deep argument is set to false, only return warnings found on local
+   * features.
+   */
+  getWarnings(deep?: boolean): Warning[] {
+    const warnings: Warning[] = [];
+    if (deep == null) {
+      deep = true;
+    }
+    warnings.push(...this.warnings);
+    for (const feature of this.getFeatures(deep)) {
+      warnings.push(...feature.warnings);
+    }
+    return warnings;
   }
 
   toString(): string {
@@ -307,11 +330,6 @@ export class Document implements Feature {
     }
 
     return result;
-  }
-
-  getWarnings(): Warning[] {
-    // TODO(rictic): crawl (local?) features and grab their warnings too.
-    return this._warnings;
   }
 
   stringify(): string {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -247,9 +247,8 @@ export class Document implements Feature {
   }
 
   /**
-   * Return all local features contained within the document as well as features
-   * detected by following through all imports. If the deep argument is set to
-   * false, only return local features.
+   * Get features for this document. If `deep` is true, also get features for
+   * all documents reachable from imports in this document.
    */
   getFeatures(deep?: boolean): Set<Feature> {
     if (deep == null) {
@@ -280,10 +279,8 @@ export class Document implements Feature {
   }
 
   /**
-   * Return all warnings on local features contained within the document as well
-   * as warnings on features detected by following through all imports. If the
-   * deep argument is set to false, only return warnings found on local
-   * features.
+   * Get warnings for this document. If `deep` is true, also get warnings for
+   * all documents reachable from imports in this document.
    */
   getWarnings(deep?: boolean): Warning[] {
     const warnings: Warning[] = [];

--- a/src/polymer/behavior.ts
+++ b/src/polymer/behavior.ts
@@ -40,9 +40,14 @@ export interface Options extends ElementOptions {}
 export class ScannedBehavior extends ScannedPolymerElement {
   tagName: undefined;
   className: string;
+
   constructor(options: Options) {
     super(options);
   }
+
+  // TODO(fks) 10-03-2016: Resolve & flatten dependent behaviors before
+  // resolving the ScannedBehavior itself. Add missing behaviors as warnings on
+  // _document.
   resolve(_document: Document) {
     return Object.assign(new Behavior(), this);
   }

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -216,19 +216,18 @@ function _getFlattenedAndResolvedBehaviors(
     behaviorAssignments: ScannedBehaviorAssignment[], document: Document,
     resolvedBehaviors: Set<Behavior>) {
   for (const behavior of behaviorAssignments) {
-    // TODO(rictic): once we have a system for passing warnings through, this
-    //     could be a mild warning and we could just take the last one in the
-    //     array, which should be the most recently defined one.
     const foundBehavior = document.getOnlyAtId('behavior', behavior.name);
     if (!foundBehavior) {
-      document.warnings.push({
-        message: `Unable to resolve behavior ` +
-            `\`${behavior.name}\`. Did you import it? Is it annotated with ` +
-            `@polymerBehavior?`,
-        severity: Severity.ERROR,
-        code: 'parse-error',
-        sourceRange: behavior.sourceRange
-      });
+      if (behavior.sourceRange.file === document.url) {
+        document.warnings.push({
+          message: `Unable to resolve behavior ` +
+              `\`${behavior.name}\`. Did you import it? Is it annotated with ` +
+              `@polymerBehavior?`,
+          severity: Severity.ERROR,
+          code: 'parse-error',
+          sourceRange: behavior.sourceRange
+        });
+      }
       continue;
     }
     if (resolvedBehaviors.has(foundBehavior)) {

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -17,7 +17,7 @@ import * as estree from 'estree';
 
 import * as jsdoc from '../javascript/jsdoc';
 import {Document, Element, LiteralValue, Property, ScannedAttribute, ScannedElement, ScannedEvent, ScannedProperty, SourceRange} from '../model/model';
-import {Severity, WarningCarryingException} from '../warning/warning';
+import {Severity} from '../warning/warning';
 
 import {Behavior, ScannedBehaviorAssignment} from './behavior';
 
@@ -221,7 +221,7 @@ function _getFlattenedAndResolvedBehaviors(
     //     array, which should be the most recently defined one.
     const foundBehavior = document.getOnlyAtId('behavior', behavior.name);
     if (!foundBehavior) {
-      throw new WarningCarryingException({
+      document.warnings.push({
         message: `Unable to resolve behavior ` +
             `\`${behavior.name}\`. Did you import it? Is it annotated with ` +
             `@polymerBehavior?`,
@@ -229,6 +229,7 @@ function _getFlattenedAndResolvedBehaviors(
         code: 'parse-error',
         sourceRange: behavior.sourceRange
       });
+      continue;
     }
     if (resolvedBehaviors.has(foundBehavior)) {
       continue;

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -30,7 +30,6 @@ import {ParsedCssDocument} from '../css/css-document';
 import {Document, ScannedImport, ScannedInlineDocument} from '../model/model';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {UrlResolver} from '../url-loader/url-resolver';
-// import {Warning, WarningCarryingException} from '../warning/warning';
 
 import {invertPromise} from './test-utils';
 

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -30,7 +30,7 @@ import {ParsedCssDocument} from '../css/css-document';
 import {Document, ScannedImport, ScannedInlineDocument} from '../model/model';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {UrlResolver} from '../url-loader/url-resolver';
-import {Warning, WarningCarryingException} from '../warning/warning';
+// import {Warning, WarningCarryingException} from '../warning/warning';
 
 import {invertPromise} from './test-utils';
 
@@ -85,30 +85,30 @@ suite('Analyzer', () => {
           ['MyNamespace.SubBehavior', 'MyNamespace.SimpleBehavior']);
     });
 
-    // TODO(fks) 09-28-2016: Fix off-by-one error in warning sourceRange line
-    // numbers.
     test('throws when cant find behavior', async() => {
-      try {
-        await analyzer.analyze('static/html-missing-behaviors.html');
-      } catch (err) {
-        assert.instanceOf(err, WarningCarryingException);
-        const warning: Warning = err.warning;
-        assert.equal(
-            err.message,
-            'Unable to resolve behavior `Polymer.ExpectedMissingBehavior`. ' +
-                'Did you import it? Is it annotated with @polymerBehavior?');
-        assert.deepEqual(warning.sourceRange, {
-          file: 'static/html-missing-behaviors.html',
-          start: {
-            line: 23,  // Actual Expected: 24
-            column: 8,
-          },
-          end: {
-            line: 23,  // Actual Expected: 24
-            column: 39,
+      let document =
+          await analyzer.analyze('static/html-missing-behaviors.html');
+      let warnings = document.getWarnings();
+      assert.deepEqual(warnings, [
+        {
+          message:
+              'Unable to resolve behavior `Polymer.ExpectedMissingBehavior`. ' +
+              'Did you import it? Is it annotated with @polymerBehavior?',
+          severity: 0,
+          code: 'parse-error',
+          sourceRange: {
+            file: 'static/html-missing-behaviors.html',
+            start: {
+              line: 23,
+              column: 8,
+            },
+            end: {
+              line: 23,
+              column: 39,
+            }
           }
-        });
-      }
+        }
+      ]);
     });
 
     test(

--- a/src/test/static/chained-missing-behavior/chained.html
+++ b/src/test/static/chained-missing-behavior/chained.html
@@ -1,0 +1,4 @@
+<script>
+  /** @polymerBehavior */
+  const ChainedBehavior = {behaviors: [NotFoundBehavior]};
+</script>

--- a/src/test/static/chained-missing-behavior/index.html
+++ b/src/test/static/chained-missing-behavior/index.html
@@ -1,0 +1,4 @@
+<link rel="import" href="chained.html">
+<script>
+  Polymer({is: 'index-el', behaviors: [ChainedBehavior]});
+</script>


### PR DESCRIPTION
`document.getWarnings()` will now return all warnings on both the document and features within the document. It takes an optional `deep` argument which can be used to filter out warnings on non-local features. This behaves similar to `document.getFeatures().`

This grants our editor plugins, build pipeline, and others a single interface for getting warnings from a given document.

/cc @justinfagnani @rictic @usergenic @garlicnation 

