### PR TITLE
Teach warning printer to print multi line warnings.

### DIFF
--- a/src/test/warning/warning-printer_test.ts
+++ b/src/test/warning/warning-printer_test.ts
@@ -33,6 +33,17 @@ const dumbNameWarning: Warning = {
   }
 };
 
+const goodJobWarning: Warning = {
+  message: 'Good job with this observedAttributes getter.',
+  code: 'cool-observed-attributes',
+  severity: Severity.INFO,
+  sourceRange: {
+    file: 'vanilla-elements.js',
+    start: {line: 22, column: 2},
+    end: {line: 29, column: 3}
+  }
+};
+
 const staticTestDir = path.join(__dirname, '../static');
 
 suite('WarningPrinter', () => {
@@ -49,7 +60,7 @@ suite('WarningPrinter', () => {
 
   test('can handle printing no warnings', async() => {
     await printer.printWarnings([]);
-    assert.equal(output.toString(), '');
+    assert.deepEqual(output.toString(), '');
   });
 
   test('can format and print a basic warning', async() => {
@@ -61,7 +72,7 @@ class ClassDeclaration extends HTMLElement {}
 
 vanilla-elements.js(0,6) warning [dumb-element-name] - This is a dumb name for an element.
 `;
-    assert.equal(actual, expected);
+    assert.deepEqual(actual, expected);
   });
 
   test('can format and print one-line warnings', async() => {
@@ -71,7 +82,7 @@ vanilla-elements.js(0,6) warning [dumb-element-name] - This is a dumb name for a
     const actual = output.toString();
     const expected =
         `vanilla-elements.js(0,6) warning [dumb-element-name] - This is a dumb name for an element.\n`;
-    assert.equal(actual, expected);
+    assert.deepEqual(actual, expected);
   });
 
   test('it adds color if configured to do so', async() => {
@@ -85,6 +96,32 @@ class ClassDeclaration extends HTMLElement {}
 
 vanilla-elements.js(0,6) \u001b[33mwarning\u001b[39m [dumb-element-name] - This is a dumb name for an element.
 `;
-    assert.equal(actual, expected);
+    assert.deepEqual(actual, expected);
+  });
+
+  test('it can print a multiline range', async() => {
+    await printer.printWarnings([goodJobWarning]);
+    const actual = output.toString();
+    const expected = `
+  static get observedAttributes() {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    return [
+~~~~~~~~~~~~
+      /** @type {boolean} When given the element is totally inactive */
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      'disabled',
+~~~~~~~~~~~~~~~~~
+      /** @type {boolean} When given the element is expanded */
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      'open', 'foo', 'bar'
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ];
+~~~~~~
+  }
+~~~
+
+vanilla-elements.js(22,2) info [cool-observed-attributes] - Good job with this observedAttributes getter.
+`;
+    assert.deepEqual(actual, expected);
   });
 });

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -57,12 +57,8 @@ export class WarningPrinter {
 
     if (this._options.verbosity === 'full') {
       this._outStream.write('\n');
-      const lineText = await this._getTextOfLine(range.start.line, range.file);
-      this._outStream.write(`${lineText}\n`);
-      const colorFunction = this._severityToColorFunction(warning.severity);
-      const underlineText = getUnderlineText(lineText, range);
-      this._outStream.write(`${colorFunction(underlineText)}\n`);
-      this._outStream.write('\n');
+      this._outStream.write(
+          await this.getUnderlinedText(range, warning.severity) + '\n\n');
     }
 
     this._outStream.write(
@@ -87,6 +83,24 @@ export class WarningPrinter {
     }
   }
 
+  async getUnderlinedText(range: SourceRange, severity?: Severity) {
+    const colorFunction = severity == null ?
+        (v: string) => v :
+        this._severityToColorFunction(severity);
+
+    const lines = await this._getLinesOfText(
+        range.start.line, range.end.line, range.file);
+    const outputLines: string[] = [];
+    let lineNum = range.start.line;
+    for (const line of lines) {
+      outputLines.push(line);
+      outputLines.push(
+          colorFunction(getSquiggleUnderline(line, lineNum, range)));
+      lineNum++;
+    }
+    return outputLines.join('\n');
+  }
+
   private _severityToColorFunction(severity: Severity) {
     switch (severity) {
       case Severity.ERROR:
@@ -97,27 +111,40 @@ export class WarningPrinter {
         return this._chalk.green;
       default:
         const never: never = severity;
-        throw new Error(`Unknown severity value - ${never
-                        } - encountered while printing warning.`);
+        throw new Error(
+            `Unknown severity value - ${never}` +
+            ` - encountered while printing warning.`);
     }
   }
 
-  private async _getTextOfLine(line: number, localPath: string) {
+  private async _getLinesOfText(
+      startLine: number, endLine: number, localPath: string) {
     const contents = await this._options.analyzer.load(localPath);
-    return contents.split('\n')[line];
+    return contents.split('\n').slice(startLine, endLine + 1);
   }
 }
 
-function getUnderlineText(lineText: string, sourceRange: SourceRange) {
-  const startColumn = sourceRange.start.column;
-  const endColumn = sourceRange.end.line === sourceRange.start.line ?
-      sourceRange.end.column :
-      lineText.length;
-  let underline = ' '.repeat(startColumn);
-  underline += '~';
-  if (startColumn === endColumn) {
-    return underline;
+function getSquiggleUnderline(
+    lineText: string, lineNum: number, sourceRange: SourceRange) {
+  // We're on a middle line of a multiline range. Squiggle the entire line.
+  if (lineNum !== sourceRange.start.line && lineNum !== sourceRange.end.line) {
+    return '~'.repeat(lineText.length);
   }
-  underline += '~'.repeat(endColumn - (startColumn + 1));
-  return underline;
+  // The tricky case. Might be the start of a multiline range, or it might just
+  // be a one-line range.
+  if (lineNum === sourceRange.start.line) {
+    const startColumn = sourceRange.start.column;
+    const endColumn = sourceRange.end.line === sourceRange.start.line ?
+        sourceRange.end.column :
+        lineText.length;
+    const prefix = ' '.repeat(startColumn);
+    if (startColumn === endColumn) {
+      return prefix + '~';  // always draw at least one squiggle
+    }
+    return prefix + '~'.repeat(endColumn - startColumn);
+  }
+
+  // We're on the end line of a multiline range. Just squiggle up to the end
+  // column.
+  return '~'.repeat(sourceRange.end.column);
 }


### PR DESCRIPTION
This will let us print better lint errors, and it also proves useful in an upcoming set of tests.