### PR TITLE
Rewrite code for mapping source positions to HTML ASTs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,19 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "clang-format.style": "file",
-  "clang-format.formatOnSave": true,
+  "editor.formatOnSave": true,
+  "editor.formatOnType": true,
   "search.exclude": {
     "node_modules/": true,
     "lib/": true
   },
-  "json.schemas": [{
-    "fileMatch": [
-      "elements.json"
-    ],
-    "url": "./lib/analysis.schema.json"
-  }],
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "elements.json"
+      ],
+      "url": "./lib/analysis.schema.json"
+    }
+  ],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -84,7 +84,7 @@ export class ParsedCssDocument extends ParsedDocument<shady.Node, Visitor> {
     throw new Error('Not implemented');
   }
 
-  _sourceRangeForNode(_node: shady.Node): SourceRange {
+  protected _sourceRangeForNode(_node: shady.Node): SourceRange {
     throw new Error('Not implemented');
   }
 

--- a/src/editor-service/ast-from-source-position.ts
+++ b/src/editor-service/ast-from-source-position.ts
@@ -239,9 +239,15 @@ function comparePositionAndRange(
 function _findLocationInChildren(
     node: parse5.ASTNode, position: SourcePosition,
     document: ParsedHtmlDocument) {
-  // TODO: if node is a template, dive into its contents
   for (const child of node.childNodes || []) {
     const result = _getLocationInfoForPosition(child, position, document);
+    if (result) {
+      return result;
+    }
+  }
+  if (node.tagName === 'template') {
+    const content = parse5.treeAdapters.default.getTemplateContent(node);
+    const result = _getLocationInfoForPosition(content, position, document);
     if (result) {
       return result;
     }

--- a/src/editor-service/ast-from-source-position.ts
+++ b/src/editor-service/ast-from-source-position.ts
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as parse5 from 'parse5';
+
+import {ParsedHtmlDocument} from '../html/html-document';
+import {SourceRange} from '../model/model';
+
+import {SourcePosition} from './editor-service';
+
+
+export type LocationResult = LocatedAttribute | LocatedAttributeValue |
+    LocatedTag | LocatedEndTag | LocatedInText | LocatedInScript |
+    LocatedInStyle | LocatedInComment;
+/** In the tagname of a start tag. */
+export interface LocatedTag {
+  kind: 'tagName';
+  element: parse5.ASTNode;
+}
+/** In an end tag. */
+export interface LocatedEndTag {
+  kind: 'endTag';
+  element: parse5.ASTNode;
+}
+/** In the attributes section of a start tag. Maybe in an attribute name. */
+export interface LocatedAttribute {
+  kind: 'attribute';
+  attribute: string|null;
+  element: parse5.ASTNode;
+}
+/** In the value of an attribute of a start tag. */
+export interface LocatedAttributeValue {
+  kind: 'attributeValue';
+  attribute: string;
+  element: parse5.ASTNode;
+}
+/** In a text node. */
+export interface LocatedInText {
+  kind: 'text';
+  textNode?: parse5.ASTNode;
+}
+/** In the text of a <script> */
+export interface LocatedInScript {
+  kind: 'scriptTagContents';
+  textNode?: parse5.ASTNode;
+}
+/** In the text of a <style> */
+export interface LocatedInStyle {
+  kind: 'styleTagContents';
+  textNode?: parse5.ASTNode;
+}
+/** In a comment. */
+export interface LocatedInComment {
+  kind: 'comment';
+  commentNode: parse5.ASTNode;
+}
+export function getLocationInfoForPosition(
+    document: ParsedHtmlDocument, position: SourcePosition): LocationResult {
+  const location =
+      _getLocationInfoForPosition(document.ast, position, document);
+  if (!location) {
+    return {kind: 'text'};
+  }
+  return location;
+}
+function _getLocationInfoForPosition(
+    node: parse5.ASTNode, position: SourcePosition,
+    document: ParsedHtmlDocument): undefined|LocationResult {
+  const sourceRange = document.sourceRangeForNode(node);
+  const location = node.__location;
+  if (!(sourceRange && location)) {
+    return _findLocationInChildren(node, position, document);
+  }
+
+  if (!isPositionInsideRange(position, sourceRange)) {
+    // definitively not in this node or any of its children
+    return;
+  }
+
+  const locationInChildren = _findLocationInChildren(node, position, document);
+  if (locationInChildren) {
+    return locationInChildren;
+  }
+
+  /**
+   * TODO(rictic): upstream the fact that regular locations can have attrs
+   * sometimes.
+   */
+  const attrs: parse5.AttributesLocationInfo =
+      (isElementLocationInfo(location) && location.startTag.attrs) ||
+      location['attrs'] || {};
+
+  for (const attrName in attrs) {
+    const range = document.sourceRangeForAttribute(node, attrName);
+    if (isPositionInsideRange(position, range)) {
+      if (isPositionInsideRange(
+              position,
+              document.sourceRangeForAttributeValue(node, attrName))) {
+        return {kind: 'attributeValue', attribute: attrName, element: node};
+      }
+      return {kind: 'attribute', attribute: attrName, element: node};
+    }
+  }
+
+  const startTagRange = document.sourceRangeForStartTag(node);
+  const endTagRange = document.sourceRangeForEndTag(node);
+
+  // If we're in the end tag... we're in the end tag.
+  if (isPositionInsideRange(position, endTagRange, false)) {
+    return {kind: 'endTag', element: node};
+  }
+
+  if (startTagRange && isPositionInsideRange(position, startTagRange, false)) {
+    if (position.line === startTagRange.start.line) {
+      // If the cursor is in the "<my-elem" part of the start tag.
+      if (position.column <=
+          startTagRange.start.column + (node.tagName || '').length + 1) {
+        return {kind: 'tagName', element: node};
+      }
+    }
+    // Otherwise we're in the start tag, but not in the tag name or any
+    // particular attribute, but definitely in the attributes section.
+    return {kind: 'attribute', attribute: null, element: node};
+  }
+
+  // The edges of a comment aren't part of the comment.
+  if (parse5.treeAdapters.default.isCommentNode(node) &&
+      isPositionInsideRange(position, sourceRange, false)) {
+    return {kind: 'comment', commentNode: node};
+  }
+
+  if (parse5.treeAdapters.default.isTextNode(node)) {
+    const parent = node.parentNode;
+    if (parent && parent.tagName === 'script') {
+      return {kind: 'scriptTagContents', textNode: node};
+    }
+    if (parent && parent.tagName === 'style') {
+      return {kind: 'styleTagContents', textNode: node};
+    }
+    return {kind: 'text', textNode: node};
+  }
+
+
+  if (isPositionInsideRange(position, sourceRange, false)) {
+    /**
+     * This is tricky. Consider the position inside an empty element, i.e.
+     * here:
+     *    <script>|</script>.
+     *
+     * You can be between the start and end tags, but there won't be a text
+     * node to attach to, but if you started typeing, there would be, so we
+     * want to treat you as though you are.
+     */
+    if (startTagRange && endTagRange &&
+        comparePositionAndRange(position, startTagRange, false) > 0 &&
+        comparePositionAndRange(position, endTagRange, false) < 0) {
+      if (node.tagName === 'script') {
+        return {kind: 'scriptTagContents'};
+      }
+      if (node.tagName === 'style') {
+        return {kind: 'styleTagContents'};
+      }
+      return {kind: 'text'};
+    }
+
+    /**
+     * Ok, we're in this node, we're not in any of its children, but we're not
+     * obviously in any attribute, tagname, start tag, or end tag. We might be
+     * part of a unclosed tag in a mostly empty document. parse5 doesn't give
+     * us much explicit signal in this case, but we can kinda infer it from the
+     * tagName.
+     */
+    if (node.tagName) {
+      if (position.column <=
+          sourceRange.start.column + node.tagName.length + 1) {
+        return {kind: 'tagName', element: node};
+      }
+      return {kind: 'attribute', element: node, attribute: null};
+    }
+  }
+}
+
+/**
+ * If the position is inside the range, returns 0. If it comes before the range,
+ * it returns -1. If it comes after the range, it returns 1.
+ */
+function comparePositionAndRange(
+    position: SourcePosition, range: SourceRange, includeEdges?: boolean) {
+  // Usually we want to include the edges of a range as part
+  // of the thing, but sometimes, e.g. for start and end tags,
+  // we'd rather not.
+  if (includeEdges == null) {
+    includeEdges = true;
+  }
+  if (includeEdges == null) {
+    includeEdges = true;
+  }
+  if (position.line < range.start.line) {
+    return -1;
+  }
+  if (position.line > range.end.line) {
+    return 1;
+  }
+  if (position.line === range.start.line) {
+    if (includeEdges) {
+      if (position.column < range.start.column) {
+        return -1;
+      }
+    } else {
+      if (position.column <= range.start.column) {
+        return -1;
+      }
+    }
+  }
+  if (position.line === range.end.line) {
+    if (includeEdges) {
+      if (position.column > range.end.column) {
+        return 1;
+      }
+    } else {
+      if (position.column >= range.end.column) {
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+function _findLocationInChildren(
+    node: parse5.ASTNode, position: SourcePosition,
+    document: ParsedHtmlDocument) {
+  // TODO: if node is a template, dive into its contents
+  for (const child of node.childNodes || []) {
+    const result = _getLocationInfoForPosition(child, position, document);
+    if (result) {
+      return result;
+    }
+  }
+}
+
+function isPositionInsideRange(
+    position: SourcePosition, range: SourceRange|undefined,
+    includeEdges?: boolean) {
+  if (!range) {
+    return false;
+  }
+  return comparePositionAndRange(position, range, includeEdges) === 0;
+}
+
+function isElementLocationInfo(location: parse5.LocationInfo|
+                               parse5.ElementLocationInfo):
+    location is parse5.ElementLocationInfo {
+  return location['startTag'] && location['endTag'];
+}

--- a/src/editor-service/ast-from-source-position.ts
+++ b/src/editor-service/ast-from-source-position.ts
@@ -64,6 +64,16 @@ export interface LocatedInComment {
   kind: 'comment';
   commentNode: parse5.ASTNode;
 }
+
+/**
+ * Given a position and an HTML document, try to describe what new text typed
+ * at the given position would be.
+ *
+ * Where possible we try to return the ASTNode describing that position, but
+ * sometimes there does not actually exist one. (for a simple case, the empty
+ * string should be interpreted as a text node, but there is no text node in
+ * an empty document, but there would be after the first character was typed).
+ */
 export function getLocationInfoForPosition(
     document: ParsedHtmlDocument, position: SourcePosition): LocationResult {
   const location =

--- a/src/editor-service/editor-service.ts
+++ b/src/editor-service/editor-service.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -12,13 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as parse5 from 'parse5';
-
 import {Analyzer, Options as AnalyzerOptions} from '../analyzer';
 import {ParsedHtmlDocument} from '../html/html-document';
 import {Document, Element, Property, ScannedProperty, SourceRange} from '../model/model';
 import {Warning, WarningCarryingException} from '../warning/warning';
 
+import {getLocationInfoForPosition} from './ast-from-source-position';
 import {AttributeCompletion, EditorService, SourcePosition, TypeaheadCompletion} from './editor-service';
 
 export class LocalEditorService extends EditorService {
@@ -171,104 +170,11 @@ export class LocalEditorService extends EditorService {
     if (!(parsedDocument instanceof ParsedHtmlDocument)) {
       return;
     }
-    return getLocationInfoForPosition(parsedDocument.ast, position);
+    return getLocationInfoForPosition(parsedDocument, position);
   }
 }
 
 
-type LocationResult = LocatedAttribute|LocatedTag|LocatedEndTag|LocatedInText;
-interface LocatedAttribute {
-  kind: 'attribute';
-  attribute: string|null;
-  element: parse5.ASTNode;
-}
-interface LocatedTag {
-  kind: 'tagName';
-  element: parse5.ASTNode;
-}
-interface LocatedEndTag {
-  kind: 'endTag';
-  element: parse5.ASTNode;
-}
-interface LocatedInText {
-  kind: 'text';
-}
-function getLocationInfoForPosition(
-    node: parse5.ASTNode, position: SourcePosition): LocationResult {
-  const location = _getLocationInfoForPosition(node, position);
-  if (!location) {
-    return {kind: 'text'};
-  }
-  return location;
-}
-function _getLocationInfoForPosition(
-    node: parse5.ASTNode, position: SourcePosition): undefined|LocationResult {
-  if (node.__location) {
-    const location = node.__location;
-    if (isElementLocationInfo(location)) {
-      // Early exit examining this node if the position we're interested in
-      // is beyond the end tag of the element.
-      if (location.endTag.line - 1 < position.line) {
-        return;
-      }
-      if (isPositionInsideLocation(position, location.startTag)) {
-        // Ok we're definitely in this start tag, now the question is whether
-        // we're in an attribute or the tag itself.
-        if (position.column <
-            location.startTag.col + node.nodeName.length + 1) {
-          return {kind: 'tagName', element: node};
-        }
-        for (const attrName in location.startTag.attrs) {
-          const attributeLocation = location.startTag.attrs[attrName];
-          if (isPositionInsideLocation(position, attributeLocation)) {
-            return {kind: 'attribute', attribute: attrName, element: node};
-          }
-        }
-        // We're in the attributes section, but not over any particular
-        // attribute.
-        return {kind: 'attribute', attribute: null, element: node};
-      }
-      if (isPositionInsideLocation(position, location.endTag)) {
-        return {kind: 'endTag', element: node};
-      }
-    } else if (node.nodeName && isPositionInsideLocation(position, location)) {
-      if (position.column < location.col + node.nodeName.length + 1) {
-        return {kind: 'tagName', element: node};
-      }
-      return {kind: 'attribute', attribute: null, element: node};
-    }
-  }
-  for (const child of node.childNodes || []) {
-    const result = _getLocationInfoForPosition(child, position);
-    if (result) {
-      return result;
-    }
-  }
-}
-
-function isPositionInsideLocation(
-    position: SourcePosition, location: parse5.LocationInfo): boolean {
-  // wrong line
-  if (location.line - 1 !== position.line) {
-    return false;
-  }
-  // position is before this location starts
-  if (position.column < location.col) {
-    return false;
-  }
-  // position is after this location ends
-  if (position.column >
-      location.col + (location.endOffset - location.startOffset)) {
-    return false;
-  }
-  return true;
-}
-
-function isElementLocationInfo(location: parse5.LocationInfo|
-                               parse5.ElementLocationInfo):
-    location is parse5.ElementLocationInfo {
-  return location['startTag'] && location['endTag'];
-}
 
 function isProperty(d: any): d is(ScannedProperty | Property) {
   return 'type' in d;

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -132,7 +132,7 @@ export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
     });
   }
 
-  _sourceRangeForNode(node: Node): SourceRange|undefined {
+  protected _sourceRangeForNode(node: Node): SourceRange|undefined {
     if (!node || !node.loc) {
       return;
     }

--- a/src/json/json-document.ts
+++ b/src/json/json-document.ts
@@ -51,7 +51,7 @@ export class ParsedJsonDocument extends ParsedDocument<Json, Visitor> {
     this.visit([{visit: callback}]);
   }
 
-  _sourceRangeForNode(_node: Json): SourceRange {
+  protected _sourceRangeForNode(_node: Json): SourceRange {
     throw new Error('Not Implemented.');
   }
 

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -60,7 +60,7 @@ export abstract class ParsedDocument<A, V> {
     return correctSourceRange(baseSource, this._locationOffset);
   };
 
-  abstract _sourceRangeForNode(node: A): SourceRange|undefined;
+  protected abstract _sourceRangeForNode(node: A): SourceRange|undefined;
 
   /**
    * Convert `this.ast` back into a string document.

--- a/src/test/editor-service/ast-from-source-position_test.ts
+++ b/src/test/editor-service/ast-from-source-position_test.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+
+import {getLocationInfoForPosition} from '../../editor-service/ast-from-source-position';
+import {SourcePosition} from '../../editor-service/editor-service';
+import {HtmlParser} from '../../html/html-parser';
+
+suite('getLocationInfoForPosition', () => {
+  const parser = new HtmlParser();
+
+  test('works for an empty string', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('');
+    assert.equal(allKindsSpaceSeparated, 'text');
+  });
+
+  test('works when just starting a tag', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t');
+    // We assume that you're starting to write an html tag in a text node, so
+    // this works.
+    assert.equal(allKindsSpaceSeparated, 'text text text');
+  });
+
+  test('works with a closed tag', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t></t>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName text endTag endTag endTag text');
+  });
+
+  test('works with an unclosed tag', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t>');
+    assert.equal(allKindsSpaceSeparated, 'text tagName tagName text');
+  });
+
+  test('works for a closed tag with empty attributes section', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t ></t>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute text endTag endTag endTag text');
+  });
+
+  test('works for an unclosed tag with empty attributes section', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t >');
+    assert.equal(allKindsSpaceSeparated, 'text tagName tagName attribute text');
+  });
+
+  test('works for a closed tag with a boolean attribute', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a></t>');
+    assert.equal(
+        allKindsSpaceSeparated, 'text tagName tagName attribute attribute ' +
+            'text endTag endTag endTag text');
+  });
+
+  test('works for an unclosed tag with a boolean attribute', () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute text');
+  });
+
+  test('works with an empty attribute value in a closed tag', () => {
+    let allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=></t>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute attributeValue text ' +
+            'endTag endTag endTag text');
+
+    allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=""></t>');
+    assert.equal(
+        allKindsSpaceSeparated, 'text tagName tagName attribute attribute ' +
+            'attributeValue attributeValue attributeValue text ' +
+            'endTag endTag endTag text');
+
+    allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=\'\'></t>');
+    assert.equal(
+        allKindsSpaceSeparated, 'text tagName tagName attribute attribute ' +
+            'attributeValue attributeValue attributeValue text ' +
+            'endTag endTag endTag text');
+  });
+
+  test('works with an empty attribute value in an unclosed tag', () => {
+    let allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute attributeValue text');
+
+    allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a="">');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute attributeValue attributeValue attributeValue text');
+
+    allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=\'\'>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute attributeValue attributeValue attributeValue text');
+  });
+
+  test(`works with a closed tag with text content`, () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t> </t>');
+    assert.equal(
+        allKindsSpaceSeparated,
+        'text tagName tagName text text endTag endTag endTag text');
+  });
+
+  test(`works with an unclosed tag with text content`, () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t> ');
+    assert.equal(allKindsSpaceSeparated, 'text tagName tagName text text');
+  });
+
+  test(`it can tell when it's inside a comment`, () => {
+    const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<!-- foo -->');
+    assert.match(allKindsSpaceSeparated, /^text (comment ){11}text$/);
+  });
+
+  test(`it can tell when it's inside a script tag`, () => {
+    let allKindsSpaceSeparated =
+        getAllKindsSpaceSeparated('<script> </script>');
+    assert.match(
+        allKindsSpaceSeparated,
+        /^text (tagName ){7}scriptTagContents scriptTagContents (endTag ){8}text$/);
+
+    allKindsSpaceSeparated = getAllKindsSpaceSeparated('<script></script>');
+    assert.match(
+        allKindsSpaceSeparated,
+        /^text (tagName ){7}scriptTagContents (endTag ){8}text$/);
+  });
+
+  test(`it can tell when it's inside a style tag`, () => {
+    let allKindsSpaceSeparated = getAllKindsSpaceSeparated('<style> </style>');
+    assert.match(
+        allKindsSpaceSeparated,
+        /^text (tagName ){6}(styleTagContents ){2}(endTag ){7}text$/);
+
+    allKindsSpaceSeparated = getAllKindsSpaceSeparated('<style></style>');
+    assert.match(
+        allKindsSpaceSeparated,
+        /^text (tagName ){6}styleTagContents (endTag ){7}text$/);
+  });
+
+  /**
+   * Return a space separated string of the `kind` for every location in the
+   * given html text.
+   *
+   * For small documents you can just assert against this string. For larger
+   * documents you can write a regexp to express your assertion.
+   */
+  function getAllKindsSpaceSeparated(text: string) {
+    const doc = parser.parse(text, 'uninteresting file name.html');
+    return getEveryPosition(text)
+        .map(pos => getLocationInfoForPosition(doc, pos).kind)
+        .join(' ');
+  }
+});
+
+function getEveryPosition(source: string): SourcePosition[] {
+  const results: SourcePosition[] = [];
+  let lineNum = 0;
+  for (const line of source.split('\n')) {
+    let columnNum = 0;
+    for (const _ of line) {
+      _.big;  // TODO(rictic): tsc complains about unused _
+      results.push({line: lineNum, column: columnNum});
+      columnNum++;
+    }
+    results.push({line: lineNum, column: columnNum});
+    lineNum++;
+  }
+  return results;
+}

--- a/src/test/editor-service/ast-from-source-position_test.ts
+++ b/src/test/editor-service/ast-from-source-position_test.ts
@@ -119,12 +119,12 @@ suite('getLocationInfoForPosition', () => {
     assert.equal(allKindsSpaceSeparated, 'text tagName tagName text text');
   });
 
-  test(`it can tell when it's inside a comment`, () => {
+  test(`works with comments`, () => {
     const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<!-- foo -->');
     assert.match(allKindsSpaceSeparated, /^text (comment ){11}text$/);
   });
 
-  test(`it can tell when it's inside a script tag`, () => {
+  test(`works with script tags`, () => {
     let allKindsSpaceSeparated =
         getAllKindsSpaceSeparated('<script> </script>');
     assert.match(
@@ -137,7 +137,7 @@ suite('getLocationInfoForPosition', () => {
         /^text (tagName ){7}scriptTagContents (endTag ){8}text$/);
   });
 
-  test(`it can tell when it's inside a style tag`, () => {
+  test(`works with style tags`, () => {
     let allKindsSpaceSeparated = getAllKindsSpaceSeparated('<style> </style>');
     assert.match(
         allKindsSpaceSeparated,
@@ -147,6 +147,14 @@ suite('getLocationInfoForPosition', () => {
     assert.match(
         allKindsSpaceSeparated,
         /^text (tagName ){6}styleTagContents (endTag ){7}text$/);
+  });
+
+  test(`it can handle the contents of a template tag`, () => {
+    let allKindsSpaceSeparated =
+        getAllKindsSpaceSeparated('<template><t a=""> </t></template>');
+    assert.match(
+        allKindsSpaceSeparated,
+        /^text (tagName ){9}text (tagName ){2}(attribute ){2}(attributeValue ){3}(text ){2}(endTag ){3}text (endTag ){10}text$/);
   });
 
   /**

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -353,6 +353,15 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
               indexFile, localAttributePosition),
           attributeTypeahead);
     });
+
+    test(`Don't give HTML completions inside of script tags.`, async() => {
+      await editorService.fileChanged(
+          indexFile, '<script>\n\n</script>\n' + indexContents);
+      const completions = await editorService.getTypeaheadCompletionsAtPosition(
+          indexFile, {line: 1, column: 0});
+      assert.deepEqual(completions, undefined);
+    });
+
   });
 
   suite('getWarningsForFile', function() {

--- a/src/test/html/html-document_test.ts
+++ b/src/test/html/html-document_test.ts
@@ -114,6 +114,19 @@ suite('ParsedHtmlDocument', () => {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`);
     });
 
+    let testName =
+        'works for unclosed tags with attributes and no text content';
+    test(testName, async() => {
+      let url = 'unclosed-tag-attributes.html';
+      const document = parser.parse(await analyzer.load(url), url);
+
+      const tag = dom5.query(document.ast, dom5.predicates.hasTagName('tag'))!;
+      assert.deepEqual(
+          await getUnderlinedText(document.sourceRangeForNode(tag)), `
+<tag attr>
+~~~~~~~~~~`);
+    });
+
     test('works for void elements', async() => {
       const linkTags =
           dom5.queryAll(document.ast, dom5.predicates.hasTagName('link'));
@@ -448,13 +461,11 @@ suite('ParsedHtmlDocument', () => {
         dom5.queryAll(document.ast, dom5.predicates.hasTagName('complex-tag'));
     assert.equal(complexTags.length, 1);
 
-    test('works for boolean attributes', async() => {
+    test('returns undefined for boolean attributes', async() => {
       assert.deepEqual(
-          await getUnderlinedText(document.sourceRangeForAttributeValue(
-              complexTags[0]!, 'boolean-attr')),
-          `
-    <complex-tag boolean-attr
-                 ~~~~~~~~~~~~`);
+          document.sourceRangeForAttributeValue(
+              complexTags[0]!, 'boolean-attr'),
+          undefined);
     });
 
     test('works for one line string attributes', async() => {

--- a/src/test/static/unclosed-tag-attributes.html
+++ b/src/test/static/unclosed-tag-attributes.html
@@ -1,0 +1,1 @@
+<tag attr>


### PR DESCRIPTION
This fixes a bunch of bugs, including Polymer/atom-plugin#7 Polymer/atom-plugin#8 and Polymer/atom-plugin#9 as well as a *lot* of subtle edge cases that we weren't getting right.

There's probably more work to be done here, I didn't test any multiline use cases here, though I'm hoping that since this builds on #347 that most of that stuff should Just Work.

Also I made some methods protected that should have been (they were only ever intended to be defined or called by subclasses anyways).

/cc @TimvdLippe