### PR TITLE
A few miscellaneous warning improvements.

### DIFF
--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -41,7 +41,8 @@ const isLazyImportNode = p.AND(
  * Scans for <link rel="import"> and <link rel="lazy-import">
  */
 export class HtmlImportScanner implements HtmlScanner {
-  constructor(private _lazyEdges?: Map<string, string[]>) {}
+  constructor(private _lazyEdges?: Map<string, string[]>) {
+  }
 
   async scan(
       document: ParsedHtmlDocument,
@@ -62,14 +63,14 @@ export class HtmlImportScanner implements HtmlScanner {
       const importUrl = resolveUrl(document.url, href);
       imports.push(new ScannedImport(
           type, importUrl, document.sourceRangeForNode(node)!,
-          document.sourceRangeForAttribute(node, 'href')!, node));
+          document.sourceRangeForAttributeValue(node, 'href')!, node));
     });
     if (this._lazyEdges) {
       const edges = this._lazyEdges.get(document.url);
       if (edges) {
         for (const edge of edges) {
           imports.push(new ScannedImport(
-            'lazy-html-import', edge, undefined, undefined, null));
+              'lazy-html-import', edge, undefined, undefined, null));
         }
       }
     }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -44,7 +44,7 @@ export class HtmlScriptScanner implements HtmlScanner {
           const importUrl = resolveUrl(document.url, src);
           features.push(new ScannedScriptTagImport(
               'html-script', importUrl, document.sourceRangeForNode(node)!,
-              document.sourceRangeForAttribute(node, 'src')!, node));
+              document.sourceRangeForAttributeValue(node, 'src')!, node));
         } else {
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const attachedCommentText = getAttachedCommentText(node) || '';

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -47,7 +47,7 @@ export class HtmlStyleScanner implements HtmlScanner {
           const importUrl = resolveUrl(document.url, href);
           features.push(new ScannedImport(
               'html-style', importUrl, document.sourceRangeForNode(node)!,
-              document.sourceRangeForAttribute(node, 'href')!, node));
+              document.sourceRangeForAttributeValue(node, 'href')!, node));
         } else {
           const contents = dom5.getTextContent(node);
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -39,7 +39,7 @@ export class CssImportScanner implements HtmlScanner {
         const importUrl = resolveUrl(document.url, href);
         imports.push(new ScannedImport(
             'css-import', importUrl, document.sourceRangeForNode(node)!,
-            document.sourceRangeForAttribute(node, 'href')!, node));
+            document.sourceRangeForAttributeValue(node, 'href')!, node));
       }
     });
     return imports;

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -224,7 +224,7 @@ function _getFlattenedAndResolvedBehaviors(
               `\`${behavior.name}\`. Did you import it? Is it annotated with ` +
               `@polymerBehavior?`,
           severity: Severity.ERROR,
-          code: 'parse-error',
+          code: 'unknown-polymer-behavior',
           sourceRange: behavior.sourceRange
         });
       }

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -96,7 +96,7 @@ suite('Analyzer', () => {
                   'Unable to resolve behavior `Polymer.ExpectedMissingBehavior`. ' +
                   'Did you import it? Is it annotated with @polymerBehavior?',
               severity: 0,
-              code: 'parse-error',
+              code: 'unknown-polymer-behavior',
               sourceRange: {
                 file: 'static/html-missing-behaviors.html',
                 start: {

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -16,12 +16,14 @@ import {assert} from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import {Analyzer} from '../../analyzer';
 import {AttributesCompletion, EditorService, ElementCompletion} from '../../editor-service/editor-service';
 import {LocalEditorService} from '../../editor-service/local-editor-service';
 import {RemoteEditorService} from '../../editor-service/remote-editor-service';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {Severity, Warning} from '../../warning/warning';
+import {WarningPrinter} from '../../warning/warning-printer';
 import {invertPromise} from '../test-utils';
 
 function editorTests(editorFactory: (basedir: string) => EditorService) {
@@ -354,6 +356,17 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   });
 
   suite('getWarningsForFile', function() {
+    let fileContents = '';
+    const loader = {
+      canLoad: () => true,
+      load: () => Promise.resolve(fileContents)
+    };
+    const warningPrinter = new WarningPrinter(
+        null as any, {analyzer: new Analyzer({urlLoader: loader})});
+
+    async function getUnderlinedText(warning: Warning) {
+      return '\n' + await warningPrinter.getUnderlinedText(warning.sourceRange);
+    }
 
     test('For a good document we get no warnings', async() => {
       await editorService.fileChanged(indexFile, indexContents);
@@ -362,18 +375,14 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
 
     test(`Warn on imports of files that aren't found.`, async() => {
       const badImport = `<link rel="import" href="./does-not-exist.html">`;
-      await editorService.fileChanged(
-          indexFile, `${badImport}\n\n${indexContents}`);
+      fileContents = `${badImport}\n\n${indexContents}`;
+      await editorService.fileChanged(indexFile, fileContents);
       const warnings = await editorService.getWarningsForFile(indexFile);
-      assert.containSubset(warnings, <Warning[]>[{
-                             code: 'could-not-load',
-                             severity: Severity.ERROR,
-                             sourceRange: {
-                               file: 'editor-service/index.html',
-                               start: {line: 0, column: 19},
-                               end: {line: 0, column: 47}
-                             }
-                           }]);
+      assert.containSubset(
+          warnings, [{code: 'could-not-load', severity: Severity.ERROR}]);
+      assert.deepEqual(await getUnderlinedText(warnings[0]), `
+<link rel="import" href="./does-not-exist.html">
+                        ~~~~~~~~~~~~~~~~~~~~~~~`);
       assert.match(
           warnings[0].message,
           /Unable to load import:.*no such file or directory/);
@@ -381,8 +390,8 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
 
     test(`Warn on imports of files that don't parse.`, async() => {
       const badImport = `<script src="../js-parse-error.js"></script>`;
-      await editorService.fileChanged(
-          indexFile, `${badImport}\n\n${indexContents}`);
+      fileContents = `${badImport}\n\n${indexContents}`;
+      await editorService.fileChanged(indexFile, fileContents);
       const warnings = await editorService.getWarningsForFile(indexFile);
       assert.containSubset(
           warnings, <Warning[]>[{
@@ -391,10 +400,11 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
             severity: Severity.ERROR,
             sourceRange: {
               file: 'editor-service/index.html',
-              start: {line: 0, column: 8},
-              end: {line: 0, column: 34}
             }
           }]);
+      assert.deepEqual(await getUnderlinedText(warnings[0]), `
+<script src="../js-parse-error.js"></script>
+            ~~~~~~~~~~~~~~~~~~~~~~`);
     });
 
     test(`Don't warn on imports of files with no known parser`, async() => {
@@ -407,18 +417,19 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
 
     test(`Warn on syntax errors in inline javascript documents`, async() => {
       const badScript = `\n<script>var var var var var let const;</script>`;
-      await editorService.fileChanged(indexFile, badScript);
+      fileContents = badScript;
+      await editorService.fileChanged(indexFile, fileContents);
       const warnings = await editorService.getWarningsForFile(indexFile);
-      assert.containSubset(warnings, <Warning[]>[{
-                             code: 'parse-error',
-                             severity: Severity.ERROR,
-                             message: 'Unexpected token var',
-                             sourceRange: {
-                               file: 'editor-service/index.html',
-                               start: {line: 1, column: 13},
-                               end: {line: 1, column: 13}
-                             }
-                           }]);
+      assert.containSubset(
+          warnings, <Warning[]>[{
+            code: 'parse-error',
+            severity: Severity.ERROR,
+            message: 'Unexpected token var',
+            sourceRange: {file: 'editor-service/index.html'}
+          }]);
+      assert.deepEqual(await getUnderlinedText(warnings[0]), `
+<script>var var var var var let const;</script>
+             ~`);
     });
 
     test(
@@ -449,59 +460,6 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
                       }
                     }]);
         });
-  });
-
-  suite('getWarnings', function() {
-
-    test('For a good document we get no warnings', async() => {
-      await editorService.fileChanged(indexFile, indexContents);
-      assert.deepEqual(await editorService.getWarningsForFile(indexFile), []);
-    });
-
-    test(`Warn on imports of files that aren't found.`, async() => {
-      const badImport = `<link rel="import" href="./does-not-exist.html">`;
-      await editorService.fileChanged(
-          indexFile, `${badImport}\n\n${indexContents}`);
-      const warnings = await editorService.getWarningsForFile(indexFile);
-      assert.containSubset(warnings, <Warning[]>[{
-                             code: 'could-not-load',
-                             severity: Severity.ERROR,
-                             sourceRange: {
-                               file: 'editor-service/index.html',
-                               start: {line: 0, column: 19},
-                               end: {line: 0, column: 47}
-                             }
-                           }]);
-      assert.match(
-          warnings[0].message,
-          /Unable to load import:.*no such file or directory/);
-    });
-
-    test(`Warn on imports of files that don't parse.`, async() => {
-      const badImport = `<script src="../js-parse-error.js"></script>`;
-      await editorService.fileChanged(
-          indexFile, `${badImport}\n\n${indexContents}`);
-      const warnings = await editorService.getWarningsForFile(indexFile);
-      assert.containSubset(
-          warnings, <Warning[]>[{
-            code: 'could-not-load',
-            severity: Severity.ERROR,
-            message: 'Unable to load import: Unexpected token ,',
-            sourceRange: {
-              file: 'editor-service/index.html',
-              start: {line: 0, column: 8},
-              end: {line: 0, column: 34}
-            }
-          }]);
-    });
-
-    test(`Don't warn on imports of files with no known parser`, async() => {
-      const badImport = `<script src="./foo.unknown_extension"></script>`;
-      await editorService.fileChanged(
-          indexFile, `${badImport}\n\n${indexContents}`);
-      assert.containSubset(
-          await editorService.getWarningsForFile(indexFile), []);
-    });
   });
 }
 


### PR DESCRIPTION
* for import errors, underline just the url
* fix the error code for behavior-not-found
* use getUnderlinedText to test source ranges in getWarningsForFile