### PR TITLE
Element reference scanner

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -31,6 +31,7 @@ import {BehaviorScanner} from './polymer/behavior-scanner';
 import {CssImportScanner} from './polymer/css-import-scanner';
 import {DomModuleScanner} from './polymer/dom-module-scanner';
 import {PolymerElementScanner} from './polymer/polymer-element-scanner';
+import {HtmlElementReferenceScanner} from './html/html-element-reference-scanner';
 import {scan} from './scanning/scan';
 import {Scanner} from './scanning/scanner';
 import {UrlLoader} from './url-loader/url-loader';
@@ -96,7 +97,8 @@ export class Analyzer {
         'html',
         [
           new HtmlImportScanner(lazyEdges), new HtmlScriptScanner(),
-          new HtmlStyleScanner(), new DomModuleScanner(), new CssImportScanner()
+          new HtmlStyleScanner(), new DomModuleScanner(), new CssImportScanner(),
+          new HtmlElementReferenceScanner()
         ]
       ],
       [

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -31,7 +31,7 @@ import {BehaviorScanner} from './polymer/behavior-scanner';
 import {CssImportScanner} from './polymer/css-import-scanner';
 import {DomModuleScanner} from './polymer/dom-module-scanner';
 import {PolymerElementScanner} from './polymer/polymer-element-scanner';
-import {HtmlElementReferenceScanner} from './html/html-element-reference-scanner';
+import {HtmlCustomElementReferenceScanner} from './html/html-element-reference-scanner';
 import {scan} from './scanning/scan';
 import {Scanner} from './scanning/scanner';
 import {UrlLoader} from './url-loader/url-loader';
@@ -98,7 +98,7 @@ export class Analyzer {
         [
           new HtmlImportScanner(lazyEdges), new HtmlScriptScanner(),
           new HtmlStyleScanner(), new DomModuleScanner(), new CssImportScanner(),
-          new HtmlElementReferenceScanner()
+          new HtmlCustomElementReferenceScanner()
         ]
       ],
       [

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -1,55 +1,9 @@
 import {HtmlScanner} from './html-scanner';
 import {ParsedHtmlDocument, HtmlVisitor} from './html-document';
-import {Resolvable, SourceRange, Feature} from '../model/model';
-import {Warning} from '../warning/warning';
 import * as dom5 from 'dom5';
+import {ScannedElementReference} from '../model/element-reference';
 
 const isCustomElement = dom5.predicates.hasMatchingTagName(/(.+-)+.+/);
-
-export interface Attribute {
-  name: string;
-  sourceRange: SourceRange|undefined;
-  value?: string;
-}
-
-export class ElementReference implements Feature {
-  tagName?: string;
-  attributes: Attribute[] = [];
-  sourceRange: SourceRange;
-  astNode: dom5.Node;
-  warnings: Warning[];
-  kinds: Set<string> = new Set(['element-reference']);
-
-  get identifiers(): Set<string> {
-    const result: Set<string> = new Set();
-    if (this.tagName) {
-      result.add(this.tagName);
-    }
-    return result;
-  }
-}
-
-export class ScannedElementReference implements Resolvable {
-  tagName?: string;
-  attributes: Attribute[] = [];
-  sourceRange: SourceRange;
-  astNode: dom5.Node;
-  warnings: Warning[];
-
-  constructor(
-    tagName: string, sourceRange: SourceRange,
-    ast: dom5.Node) {
-      this.tagName = tagName;
-      this.sourceRange = sourceRange;
-      this.astNode = ast;
-  }
-
-  resolve(): ElementReference {
-    const ref = new ElementReference();
-    Object.assign(ref, this);
-    return ref;
-  }
-}
 
 export class HtmlElementReferenceScanner implements HtmlScanner {
   async scan(

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -19,7 +19,7 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
             document.sourceRangeForNode(node)!,
             node);
 
-          if(node.attrs) {
+          if (node.attrs) {
             for (const attr of node.attrs) {
               element.attributes.push({
                 name: attr.name,

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -6,7 +6,7 @@ import * as dom5 from 'dom5';
 
 const isCustomElement = dom5.predicates.hasMatchingTagName(/(.+-)+.+/);
 
-export interface ScannedAttribute {
+export interface Attribute {
   name: string;
   sourceRange: SourceRange|undefined;
   value?: string;
@@ -14,7 +14,7 @@ export interface ScannedAttribute {
 
 export class ElementReference implements Feature {
   tagName?: string;
-  attributes: ScannedAttribute[] = [];
+  attributes: Attribute[] = [];
   sourceRange: SourceRange;
   astNode: dom5.Node;
   warnings: Warning[];
@@ -31,7 +31,7 @@ export class ElementReference implements Feature {
 
 export class ScannedElementReference implements Resolvable {
   tagName?: string;
-  attributes: ScannedAttribute[] = [];
+  attributes: Attribute[] = [];
   sourceRange: SourceRange;
   astNode: dom5.Node;
   warnings: Warning[];
@@ -59,7 +59,6 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
       let elements: ScannedElementReference[] = [];
 
       await visit((node) => {
-        console.log(node.nodeName, isCustomElement(node));
         if (isCustomElement(node) && node.nodeName !== 'dom-module') {
           elements.push(new ScannedElementReference(
             node.nodeName,

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -19,14 +19,16 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
             document.sourceRangeForNode(node)!,
             node);
 
-          for (const attr of node.attrs) {
-            element.attributes.push({
-              name: attr.name,
-              value: attr.value,
-              sourceRange: document.sourceRangeForAttribute(node, attr.name),
-              nameSourceRange: document.sourceRangeForAttributeName(node, attr.name),
-              valueSourceRange: document.sourceRangeForAttributeValue(node, attr.name)
-            });
+          if(node.attrs) {
+            for (const attr of node.attrs) {
+              element.attributes.push({
+                name: attr.name,
+                value: attr.value,
+                sourceRange: document.sourceRangeForAttribute(node, attr.name),
+                nameSourceRange: document.sourceRangeForAttributeName(node, attr.name),
+                valueSourceRange: document.sourceRangeForAttributeValue(node, attr.name)
+              });
+            }
           }
 
           elements.push(element);

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -1,0 +1,73 @@
+import {HtmlScanner} from './html-scanner';
+import {ParsedHtmlDocument, HtmlVisitor} from './html-document';
+import {Resolvable, SourceRange, Feature} from '../model/model';
+import {Warning} from '../warning/warning';
+import * as dom5 from 'dom5';
+
+const isCustomElement = dom5.predicates.hasMatchingTagName(/(.+-)+.+/);
+
+export interface ScannedAttribute {
+  name: string;
+  sourceRange: SourceRange|undefined;
+  value?: string;
+}
+
+export class ElementReference implements Feature {
+  tagName?: string;
+  attributes: ScannedAttribute[] = [];
+  sourceRange: SourceRange;
+  astNode: dom5.Node;
+  warnings: Warning[];
+  kinds: Set<string> = new Set(['element-reference']);
+
+  get identifiers(): Set<string> {
+    const result: Set<string> = new Set();
+    if (this.tagName) {
+      result.add(this.tagName);
+    }
+    return result;
+  }
+}
+
+export class ScannedElementReference implements Resolvable {
+  tagName?: string;
+  attributes: ScannedAttribute[] = [];
+  sourceRange: SourceRange;
+  astNode: dom5.Node;
+  warnings: Warning[];
+
+  constructor(
+    tagName: string, sourceRange: SourceRange,
+    ast: dom5.Node) {
+      this.tagName = tagName;
+      this.sourceRange = sourceRange;
+      this.astNode = ast;
+  }
+
+  resolve(): ElementReference {
+    const ref = new ElementReference();
+    Object.assign(ref, this);
+    return ref;
+  }
+}
+
+export class HtmlElementReferenceScanner implements HtmlScanner {
+  async scan(
+    document: ParsedHtmlDocument,
+    visit: (visitor: HtmlVisitor) => Promise<void>):
+    Promise<ScannedElementReference[]> {
+      let elements: ScannedElementReference[] = [];
+
+      await visit((node) => {
+        console.log(node.nodeName, isCustomElement(node));
+        if (isCustomElement(node) && node.nodeName !== 'dom-module') {
+          elements.push(new ScannedElementReference(
+            node.nodeName,
+            document.sourceRangeForNode(node)!,
+            node));
+        }
+      });
+
+      return elements;
+    }
+}

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -13,11 +13,23 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
       let elements: ScannedElementReference[] = [];
 
       await visit((node) => {
-        if (isCustomElement(node) && node.nodeName !== 'dom-module') {
-          elements.push(new ScannedElementReference(
-            node.nodeName,
+        if (node.tagName && isCustomElement(node) && node.nodeName !== 'dom-module') {
+          const element = new ScannedElementReference(
+            node.tagName,
             document.sourceRangeForNode(node)!,
-            node));
+            node);
+
+          for (const attr of node.attrs) {
+            element.attributes.push({
+              name: attr.name,
+              value: attr.value,
+              sourceRange: document.sourceRangeForAttribute(node, attr.name),
+              nameSourceRange: document.sourceRangeForAttributeName(node, attr.name),
+              valueSourceRange: document.sourceRangeForAttributeValue(node, attr.name)
+            });
+          }
+
+          elements.push(element);
         }
       });
 

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -1,40 +1,52 @@
-import {HtmlScanner} from './html-scanner';
-import {ParsedHtmlDocument, HtmlVisitor} from './html-document';
 import * as dom5 from 'dom5';
+import {ASTNode} from 'parse5';
 import {ScannedElementReference} from '../model/element-reference';
+import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
+import {HtmlScanner} from './html-scanner';
 
 const isCustomElement = dom5.predicates.hasMatchingTagName(/(.+-)+.+/);
 
 export class HtmlElementReferenceScanner implements HtmlScanner {
+  matches(node: ASTNode): boolean {
+    return !!node;
+  }
+
   async scan(
-    document: ParsedHtmlDocument,
-    visit: (visitor: HtmlVisitor) => Promise<void>):
-    Promise<ScannedElementReference[]> {
-      let elements: ScannedElementReference[] = [];
+      document: ParsedHtmlDocument,
+      visit: (visitor: HtmlVisitor) => Promise<void>):
+      Promise<ScannedElementReference[]> {
+    let elements: ScannedElementReference[] = [];
 
-      await visit((node) => {
-        if (node.tagName && isCustomElement(node) && node.nodeName !== 'dom-module') {
-          const element = new ScannedElementReference(
-            node.tagName,
-            document.sourceRangeForNode(node)!,
-            node);
+    await visit((node) => {
+      if (node.tagName && this.matches(node)) {
+        const element = new ScannedElementReference(
+            node.tagName, document.sourceRangeForNode(node)!, node);
 
-          if (node.attrs) {
-            for (const attr of node.attrs) {
-              element.attributes.push({
-                name: attr.name,
-                value: attr.value,
-                sourceRange: document.sourceRangeForAttribute(node, attr.name),
-                nameSourceRange: document.sourceRangeForAttributeName(node, attr.name),
-                valueSourceRange: document.sourceRangeForAttributeValue(node, attr.name)
-              });
-            }
+        if (node.attrs) {
+          for (const attr of node.attrs) {
+            element.attributes.push({
+              name: attr.name,
+              value: attr.value,
+              sourceRange: document.sourceRangeForAttribute(node, attr.name),
+              nameSourceRange:
+                  document.sourceRangeForAttributeName(node, attr.name),
+              valueSourceRange:
+                  document.sourceRangeForAttributeValue(node, attr.name)
+            });
           }
-
-          elements.push(element);
         }
-      });
 
-      return elements;
-    }
+        elements.push(element);
+      }
+    });
+
+    return elements;
+  }
+}
+
+export class HtmlCustomElementReferenceScanner extends
+    HtmlElementReferenceScanner {
+  matches(node: ASTNode): boolean {
+    return isCustomElement(node) && node.nodeName !== 'dom-module';
+  }
 }

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -41,9 +41,9 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
             element.attributes.push({
               name: attr.name,
               value: attr.value,
-              sourceRange: document.sourceRangeForAttribute(node, attr.name),
+              sourceRange: document.sourceRangeForAttribute(node, attr.name)!,
               nameSourceRange:
-                  document.sourceRangeForAttributeName(node, attr.name),
+                  document.sourceRangeForAttributeName(node, attr.name)!,
               valueSourceRange:
                   document.sourceRangeForAttributeValue(node, attr.name)
             });

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -20,6 +20,12 @@ import {HtmlScanner} from './html-scanner';
 
 const isCustomElement = dom5.predicates.hasMatchingTagName(/(.+-)+.+/);
 
+/**
+ * Scans for HTML element references/uses in a given document.
+ * All elements will be detected, including anything in <head>.
+ * This scanner will not be loaded by default, but the custom
+ * element extension of it will be.
+ */
 export class HtmlElementReferenceScanner implements HtmlScanner {
   matches(node: ASTNode): boolean {
     return !!node;
@@ -58,6 +64,11 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
   }
 }
 
+/**
+ * Scans for custom element references/uses.
+ * All custom elements will be detected except <dom-module>.
+ * This is a default scanner.
+ */
 export class HtmlCustomElementReferenceScanner extends
     HtmlElementReferenceScanner {
   matches(node: ASTNode): boolean {

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -1,3 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 import * as dom5 from 'dom5';
 import {ASTNode} from 'parse5';
 import {ScannedElementReference} from '../model/element-reference';

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -5,11 +5,13 @@ import * as dom5 from 'dom5';
 export interface Attribute {
   name: string;
   sourceRange: SourceRange|undefined;
+  nameSourceRange: SourceRange|undefined;
+  valueSourceRange: SourceRange|undefined;
   value?: string;
 }
 
 export class ElementReference implements Feature {
-  tagName?: string;
+  tagName: string;
   attributes: Attribute[] = [];
   sourceRange: SourceRange;
   astNode: dom5.Node;
@@ -17,16 +19,12 @@ export class ElementReference implements Feature {
   kinds: Set<string> = new Set(['element-reference']);
 
   get identifiers(): Set<string> {
-    const result: Set<string> = new Set();
-    if (this.tagName) {
-      result.add(this.tagName);
-    }
-    return result;
+    return new Set([this.tagName]);
   }
 }
 
 export class ScannedElementReference implements Resolvable {
-  tagName?: string;
+  tagName: string;
   attributes: Attribute[] = [];
   sourceRange: SourceRange;
   astNode: dom5.Node;

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -1,0 +1,49 @@
+import {Resolvable, SourceRange, Feature} from '../model/model';
+import {Warning} from '../warning/warning';
+import * as dom5 from 'dom5';
+
+export interface Attribute {
+  name: string;
+  sourceRange: SourceRange|undefined;
+  value?: string;
+}
+
+export class ElementReference implements Feature {
+  tagName?: string;
+  attributes: Attribute[] = [];
+  sourceRange: SourceRange;
+  astNode: dom5.Node;
+  warnings: Warning[];
+  kinds: Set<string> = new Set(['element-reference']);
+
+  get identifiers(): Set<string> {
+    const result: Set<string> = new Set();
+    if (this.tagName) {
+      result.add(this.tagName);
+    }
+    return result;
+  }
+}
+
+export class ScannedElementReference implements Resolvable {
+  tagName?: string;
+  attributes: Attribute[] = [];
+  sourceRange: SourceRange;
+  astNode: dom5.Node;
+  warnings: Warning[];
+
+  constructor(
+    tagName: string, sourceRange: SourceRange,
+    ast: dom5.Node) {
+      this.tagName = tagName;
+      this.sourceRange = sourceRange;
+      this.astNode = ast;
+  }
+
+  resolve(): ElementReference {
+    const ref = new ElementReference();
+    Object.assign(ref, this);
+    return ref;
+  }
+}
+

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -12,9 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Resolvable, SourceRange, Feature} from '../model/model';
-import {Warning} from '../warning/warning';
 import * as dom5 from 'dom5';
+
+import {Feature, Resolvable, SourceRange} from '../model/model';
+import {Warning} from '../warning/warning';
 
 export interface Attribute {
   name: string;
@@ -44,12 +45,10 @@ export class ScannedElementReference implements Resolvable {
   astNode: dom5.Node;
   warnings: Warning[] = [];
 
-  constructor(
-    tagName: string, sourceRange: SourceRange,
-    ast: dom5.Node) {
-      this.tagName = tagName;
-      this.sourceRange = sourceRange;
-      this.astNode = ast;
+  constructor(tagName: string, sourceRange: SourceRange, ast: dom5.Node) {
+    this.tagName = tagName;
+    this.sourceRange = sourceRange;
+    this.astNode = ast;
   }
 
   resolve(): ElementReference {
@@ -58,4 +57,3 @@ export class ScannedElementReference implements Resolvable {
     return ref;
   }
 }
-

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -1,3 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 import {Resolvable, SourceRange, Feature} from '../model/model';
 import {Warning} from '../warning/warning';
 import * as dom5 from 'dom5';

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -18,8 +18,8 @@ import * as dom5 from 'dom5';
 
 export interface Attribute {
   name: string;
-  sourceRange: SourceRange|undefined;
-  nameSourceRange: SourceRange|undefined;
+  sourceRange: SourceRange;
+  nameSourceRange: SourceRange;
   valueSourceRange: SourceRange|undefined;
   value?: string;
 }

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -15,7 +15,7 @@ export class ElementReference implements Feature {
   attributes: Attribute[] = [];
   sourceRange: SourceRange;
   astNode: dom5.Node;
-  warnings: Warning[];
+  warnings: Warning[] = [];
   kinds: Set<string> = new Set(['element-reference']);
 
   get identifiers(): Set<string> {
@@ -28,7 +28,7 @@ export class ScannedElementReference implements Resolvable {
   attributes: Attribute[] = [];
   sourceRange: SourceRange;
   astNode: dom5.Node;
-  warnings: Warning[];
+  warnings: Warning[] = [];
 
   constructor(
     tagName: string, sourceRange: SourceRange,

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -1,0 +1,42 @@
+import {assert} from 'chai';
+import {HtmlVisitor} from '../../html/html-document';
+import {HtmlParser} from '../../html/html-parser';
+import {HtmlElementReferenceScanner} from '../../html/html-element-reference-scanner';
+import {ScannedElementReference} from '../../model/element-reference';
+
+suite('HtmlElementReferenceScanner', () => {
+
+  suite('scan()', () => {
+    let scanner: HtmlElementReferenceScanner;
+
+    setup(() => {
+      scanner = new HtmlElementReferenceScanner();
+    });
+
+    test('finds custom element references', async() => {
+      let contents = `<html><body>
+          <div>Foo</div>
+          <x-foo></x-foo>
+          <div>
+            <x-bar></x-bar>
+          </div>
+          <h1>Bar</h1>
+        </body></html>`;
+      const document = new HtmlParser().parse(contents, 'test-document.html');
+      let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const features = await scanner.scan(document, visit);
+      assert.equal(features.length, 2);
+      assert.instanceOf(features[0], ScannedElementReference);
+      assert.instanceOf(features[1], ScannedElementReference);
+
+      const feature0 = <ScannedElementReference>features[0];
+      assert.equal(feature0.tagName, 'x-foo');
+
+      const feature1 = <ScannedElementReference>features[1];
+      assert.equal(feature1.tagName, 'x-bar');
+    });
+
+  });
+
+});

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -16,7 +16,7 @@ suite('HtmlElementReferenceScanner', () => {
     test('finds custom element references', async() => {
       let contents = `<html><body>
           <div>Foo</div>
-          <x-foo></x-foo>
+          <x-foo a=5 b="test" c></x-foo>
           <div>
             <x-bar></x-bar>
           </div>
@@ -26,15 +26,57 @@ suite('HtmlElementReferenceScanner', () => {
       let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
       const features = await scanner.scan(document, visit);
+
       assert.equal(features.length, 2);
+
       assert.instanceOf(features[0], ScannedElementReference);
       assert.instanceOf(features[1], ScannedElementReference);
 
-      const feature0 = <ScannedElementReference>features[0];
-      assert.equal(feature0.tagName, 'x-foo');
+      assert.deepEqual(features.map(f => f.tagName), ['x-foo', 'x-bar']);
 
-      const feature1 = <ScannedElementReference>features[1];
-      assert.equal(feature1.tagName, 'x-bar');
+      assert.deepEqual(features[0].attributes.map(a => [a.name, a.value]), [
+        ['a', '5'],
+        ['b', 'test'],
+        ['c', '']
+      ]);
+
+      assert.deepEqual(features[0].attributes[0], {
+        name: 'a',
+        nameSourceRange: {
+          end: {
+            column: 18,
+            line: 2
+          },
+          file: 'test-document.html',
+          start: {
+            column: 17,
+            line: 2
+          }
+        },
+        sourceRange: {
+          end: {
+            column: 20,
+            line: 2
+          },
+          file: 'test-document.html',
+          start: {
+            column: 17,
+            line: 2
+          }
+        },
+        value: '5',
+        valueSourceRange: {
+          end: {
+            column: 20,
+            line: 2
+          },
+          file: 'test-document.html',
+          start: {
+            column: 19,
+            line: 2
+          }
+        }
+      });
     });
 
   });

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -20,7 +20,7 @@ suite('HtmlElementReferenceScanner', () => {
       null as any, {analyzer: new Analyzer({urlLoader: loader})});
 
     async function getUnderlinedText(sourceRange: SourceRange|undefined) {
-      if(!sourceRange) {
+      if (!sourceRange) {
         return 'No source range produced';
       }
       return '\n' + await warningPrinter.getUnderlinedText(sourceRange);

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -3,18 +3,35 @@ import {HtmlVisitor} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {HtmlElementReferenceScanner} from '../../html/html-element-reference-scanner';
 import {ScannedElementReference} from '../../model/element-reference';
+import {WarningPrinter} from '../../warning/warning-printer';
+import {Analyzer} from '../../analyzer';
+import {SourceRange} from '../../model/model';
 
 suite('HtmlElementReferenceScanner', () => {
 
   suite('scan()', () => {
     let scanner: HtmlElementReferenceScanner;
+    let contents = '';
+    const loader = {
+      canLoad: () => true,
+      load: () => Promise.resolve(contents)
+    };
+    const warningPrinter = new WarningPrinter(
+      null as any, {analyzer: new Analyzer({urlLoader: loader})});
+
+    async function getUnderlinedText(sourceRange: SourceRange|undefined) {
+      if(!sourceRange) {
+        return 'No source range produced';
+      }
+      return '\n' + await warningPrinter.getUnderlinedText(sourceRange);
+    }
 
     setup(() => {
       scanner = new HtmlElementReferenceScanner();
     });
 
     test('finds custom element references', async() => {
-      let contents = `<html><body>
+      contents = `<html><body>
           <div>Foo</div>
           <x-foo a=5 b="test" c></x-foo>
           <div>
@@ -22,6 +39,7 @@ suite('HtmlElementReferenceScanner', () => {
           </div>
           <h1>Bar</h1>
         </body></html>`;
+
       const document = new HtmlParser().parse(contents, 'test-document.html');
       let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
@@ -40,43 +58,73 @@ suite('HtmlElementReferenceScanner', () => {
         ['c', '']
       ]);
 
-      assert.deepEqual(features[0].attributes[0], {
-        name: 'a',
-        nameSourceRange: {
-          end: {
-            column: 18,
-            line: 2
-          },
-          file: 'test-document.html',
-          start: {
-            column: 17,
-            line: 2
-          }
-        },
-        sourceRange: {
-          end: {
-            column: 20,
-            line: 2
-          },
-          file: 'test-document.html',
-          start: {
-            column: 17,
-            line: 2
-          }
-        },
-        value: '5',
-        valueSourceRange: {
-          end: {
-            column: 20,
-            line: 2
-          },
-          file: 'test-document.html',
-          start: {
-            column: 19,
-            line: 2
-          }
-        }
-      });
+      const sourceRanges = await Promise.all(features.map(async f => await getUnderlinedText(f.sourceRange)));
+
+      assert.deepEqual(sourceRanges, [
+        `
+          <x-foo a=5 b="test" c></x-foo>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+        `
+            <x-bar></x-bar>
+            ~~~~~~~~~~~~~~~`
+      ]);
+
+      const attrRanges = await Promise.all(features.map(
+        async f => await Promise.all(f.attributes.map(
+          async a => await getUnderlinedText(a.sourceRange)))));
+
+      assert.deepEqual(attrRanges, [
+        [
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                 ~~~`,
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                     ~~~~~~~~`,
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                              ~`
+        ],
+        []
+      ]);
+
+      const attrNameRanges = await Promise.all(features.map(
+        async f => await Promise.all(f.attributes.map(
+          async a => await getUnderlinedText(a.nameSourceRange)))));
+
+      assert.deepEqual(attrNameRanges, [
+        [
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                 ~`,
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                     ~`,
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                              ~`
+        ],
+        []
+      ]);
+
+      const attrValueRanges = await Promise.all(features.map(
+        async f => await Promise.all(f.attributes.map(
+          async a => await getUnderlinedText(a.valueSourceRange)))));
+
+      assert.deepEqual(attrValueRanges, [
+        [
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                   ~`,
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                       ~~~~~~`,
+          `
+          <x-foo a=5 b="test" c></x-foo>
+                              ~`
+        ],
+        []
+      ]);
     });
 
   });

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -1,3 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 import {assert} from 'chai';
 
 import {Analyzer} from '../../analyzer';

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -82,8 +82,13 @@ suite('HtmlImportScanner', () => {
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
       const features = await scanner.scan(document, visit);
-      assert.deepEqual(features.map(f => f.type), ['html-import', 'lazy-html-import', 'lazy-html-import', 'lazy-html-import']);
-      assert.deepEqual(features.map(f => f.url), ['polymer.html', 'lazy1.html', 'lazy2.html', 'lazy3.html']);
+      assert.deepEqual(features.map(f => f.type), [
+        'html-import', 'lazy-html-import', 'lazy-html-import',
+        'lazy-html-import'
+      ]);
+      assert.deepEqual(
+          features.map(f => f.url),
+          ['polymer.html', 'lazy1.html', 'lazy2.html', 'lazy3.html']);
     });
 
   });


### PR DESCRIPTION
This is far from complete but looking for feedback.

Essentially, this scanner will find custom element references (tags in the HTML document). This is a fairly useful scanner for something like polymer-linter to retrieve a full list of referenced custom elements.

I'm still getting my head around much of the analyser so forgive me if I make any obvious mistakes and such...

## Feedback/Questions

**What is the best way to populate `attributes` with the tag's attributes from parse5?**

I would like to populate the `attributes` property of `ElementReference` but I haven't quite figured out where I should do that, yet.

**Should the classes be prefixed with `Custom` and a base implementation added?**

Currently, we confusingly call it `ElementReference` but it is actually specific to _custom_ elements. Maybe we should have an `ElementReferenceScanner` to find _all_ elements, and a `CustomElementReferenceScanner` which extends it to find only _custom_ elements?

Or simply prefix it all with `Custom` and have no inherited base, because maybe we don't ever expect to find every single HTML element.

**Currently `<template>` content isn't traversed, so I'm unable to test it**

I was told by @rictic that this is soon to be fixed in parse5, so will leave it for now.