### PR TITLE
Fix duplicate warnings

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -291,7 +291,7 @@ export class Document implements Feature {
     warnings.push.apply(warnings, this.warnings);
     for (const feature of this.getFeatures(deep)) {
       for (const warning of feature.warnings) {
-        if (!warnings.includes(warning)) {
+        if (warnings.indexOf(warning) === -1) {
           warnings.push(warning);
         }
       }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -284,19 +284,16 @@ export class Document implements Feature {
    * via imports in this document.
    */
   getWarnings(deep?: boolean): Warning[] {
-    const warnings: Warning[] = [];
+    const warnings: Set<Warning> = new Set(this.warnings);
     if (deep == null) {
       deep = false;
     }
-    warnings.push.apply(warnings, this.warnings);
     for (const feature of this.getFeatures(deep)) {
       for (const warning of feature.warnings) {
-        if (warnings.indexOf(warning) === -1) {
-          warnings.push(warning);
-        }
+        warnings.add(warning);
       }
     }
-    return warnings;
+    return Array.from(warnings);
   }
 
   toString(): string {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -290,7 +290,11 @@ export class Document implements Feature {
     }
     warnings.push.apply(warnings, this.warnings);
     for (const feature of this.getFeatures(deep)) {
-      warnings.push.apply(warnings, feature.warnings);
+      for (const warning of feature.warnings) {
+        if (!warnings.includes(warning)) {
+          warnings.push(warning);
+        }
+      }
     }
     return warnings;
   }

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -378,6 +378,9 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
       fileContents = `${badImport}\n\n${indexContents}`;
       await editorService.fileChanged(indexFile, fileContents);
       const warnings = await editorService.getWarningsForFile(indexFile);
+      assert.equal(
+          warnings.filter(
+              (warning) => warning.code === 'could-not-load').length, 1);
       assert.containSubset(
           warnings, [{code: 'could-not-load', severity: Severity.ERROR}]);
       assert.deepEqual(await getUnderlinedText(warnings[0]), `


### PR DESCRIPTION
`Document#getWarnings()` was returning duplicate warnings because of the way `this.warnings` and `feature.getWarnings()` apparently contained the same items.  I just put a guard against pushing existing warnings into the result array.  Separated commits so there's one that proves the dup.