### PR TITLE
better support of lazy imports

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -284,9 +284,11 @@ export class Analyzer {
             // TODO(garlicnation): Move this logic into model/document. During
             // the recursive feature walk, features from lazy imports
             // should be marked.
+            const scannedImport = this._scanImport(scannedDependency, warnings);
             if (scannedDependency.type !== 'lazy-html-import') {
-              return this._scanImport(scannedDependency, warnings);
+              return scannedImport;
             }
+            await scannedImport;
             return null;
           } else {
             throw new Error(`Unexpected dependency type: ${scannedDependency}`);

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -272,6 +272,9 @@ export class Document implements Feature {
           (feature as Document)._getFeatures(result, visited, deep);
         }
         if (feature.kinds.has('import')) {
+          if ((feature as Import).type === 'lazy-html-import') {
+            continue;
+          }
           (feature as Import).document._getFeatures(result, visited, deep);
         }
       }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -27,7 +27,7 @@ import {Resolvable} from './resolvable';
  * @template N The AST node type
  */
 export class ScannedImport implements Resolvable {
-  type: 'html-import'|'html-script'|'html-style'|'js-import'|string;
+  type: 'html-import'|'lazy-html-import'|'html-script'|'html-style'|'js-import'|string;
 
   /**
    * URL of the import, relative to the document containing the import.
@@ -68,7 +68,7 @@ export class ScannedImport implements Resolvable {
 }
 
 export class Import implements Feature {
-  type: 'html-import'|'html-script'|'html-style'|string;
+  type: 'html-import'|'lazy-html-import'|'html-script'|'html-style'|string;
   url: string;
   document: Document;
   identifiers = new Set();


### PR DESCRIPTION
Avoid returning features defined in lazy imports.

This is suboptimal. The better solution would be for lazy imports to "color" features that are transitively loaded through them, but I'm unsure of what that would look like.
