### PR TITLE
handle SequenceExpression nodes in behavior parsing

### DIFF
--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -323,6 +323,16 @@ suite('Analyzer', () => {
       await analyzer.analyze('static/caching/file2.html');
     });
 
+    test('can analyze behaviors documented in SequenceExpressions', async() => {
+      const document =
+          await analyzer.analyze('static/minified-javascript/index.html');
+      assert.equal(document.getWarnings(true).length, 0);
+      assert.equal(document.getByKind('behavior').size, 2);
+      assert.isObject(document.getOnlyAtId('behavior', 'Polymer.TestBehavior'));
+      assert.isObject(
+          document.getOnlyAtId('behavior', 'Polymer.SimpleBehavior'));
+    });
+
   });
 
   // TODO: reconsider whether we should test these private methods.

--- a/src/test/static/minified-javascript/index.html
+++ b/src/test/static/minified-javascript/index.html
@@ -1,0 +1,7 @@
+<link rel="import" href="minified-behavior.html">
+<script>
+Polymer({
+  is: 'minified-javascript.test-element',
+  behaviors: [Polymer.TestBehavior],
+});
+</script>

--- a/src/test/static/minified-javascript/minified-behavior.html
+++ b/src/test/static/minified-javascript/minified-behavior.html
@@ -1,0 +1,16 @@
+<html>
+
+<head><script>/** @polymerBehavior */
+Polymer.SimpleBehavior={simple:!0};
+/**
+   * @polymerBehavior Polymer.TestBehavior
+   */
+Polymer.TestBehaviorImpl={properties:{foo:{type: Number,value: 10,notify: true}},ready:function(){this.playAnimation("entry")}},/**
+   * Part 2
+   * @polymerBehavior
+   */
+Polymer.TestBehavior=[Polymer.TestBehaviorImpl,SimpleBehavior];</script></head>
+
+<body></body>
+
+</html>


### PR DESCRIPTION
Fixes #379

This fix lets our behavior scanner understand Sequence expressions (ex: `EXPRESSION, EXPRESSION, EXPRESSION;`) while scanning. Users will run into this problem if they do either of these two things:

1. **Use a strange coding style that involves lots of SequenceExpressions.** Unknown if this is actually anyone, and if there are it would be fair to just not support them.
2. **Minify/Preprocess their code before analysis.** This will be less common once we start analyzing apps before minification in the CLI, but there are still reasonable cases where this could occur (using JSX, CoffeeScript, other languages/features that may not get support right away in the analyzer).

As I opened this issue I was 50-50 on whether this was a useful fix, but as I wrote out (2.) above I can now see how this actually a useful fix. @rictic I'll let you make the ultimate call on merging this, but I think it's worth it as long as the code itself (where we patch the comments) doesn't feel like too much of a hack to you.

/cc @justinfagnani @usergenic 