### PR TITLE
remove unneccesary node_modules/.bin path from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "initBench": "if [ ! -d bower_components ]; then bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi",
     "benchmark": "npm run build && npm run initBench && node lib/perf/parse-all-benchmark.js",
     "test:watch": "watchy -w src/ -- npm run quicktest --loglevel=silent",
-    "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i",
+    "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
     "prepublish": "tsc && npm test"
   },
   "devDependencies": {


### PR DESCRIPTION
node_modules/.bin is added to the npm run PATH automatically. (The runs for me without clang-format installed)

/cc @rictic 