### PR TITLE
Scan A-Frame components; scanners return warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   * Warn when there's a problem mixing behaviors into other behaviors, the same way that we warn when mixing behaviors into elements.
 
 * Fix some bugs with recursive and mutually recursive imports.
+* Fixed a class of race conditions and cache invalidation errors that can occur when there are concurrent analysis runs and edits to files.
 
 ## [2.0.0-alpha.17] - 2016-10-28 - [minor]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+* Initial support for parsing [A-Frame](https://aframe.io/) components, starting with warning about incorrect component registrations.
+
 ### Fixed
 * [Polymer] A number of fixes around warnings when resolving behaviors
   * Warn, don't throw when a behavior is declared twice.

--- a/src/a-frame/component-scanner.ts
+++ b/src/a-frame/component-scanner.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as estree from 'estree';
+
+import * as astValue from '../javascript/ast-value';
+import {Visitor} from '../javascript/estree-visitor';
+import {JavaScriptDocument} from '../javascript/javascript-document';
+import {JavaScriptScanner} from '../javascript/javascript-scanner';
+import {ScannedFeature} from '../model/model';
+import {SourceRange} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
+import {Severity, Warning} from '../warning/warning';
+
+export interface Options {
+  name: string;
+  sourceRange: SourceRange;
+  astNode: estree.Node;
+  warnings: Warning[];
+}
+
+export class ScannedComponent implements ScannedFeature {
+  name: string;
+  sourceRange: SourceRange;
+  astNode: estree.Node;
+  warnings: Warning[];
+
+  constructor(constructionOptions: Options) {
+    this.name = constructionOptions.name;
+    this.sourceRange = constructionOptions.sourceRange;
+    this.astNode = constructionOptions.astNode;
+    this.warnings = constructionOptions.warnings;
+  }
+}
+
+export class ComponentScanner implements JavaScriptScanner {
+  warnings: Warning[] = [];
+  async scan(
+      document: JavaScriptDocument,
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScanResult> {
+    let visitor = new ComponentFinder(document);
+    await visit(visitor);
+    this.warnings = visitor.warnings;
+    return {
+      features: Array.from(visitor.components),
+      warnings: visitor.warnings
+    };
+  }
+}
+
+class ComponentFinder implements Visitor {
+  /** The behaviors we've found. */
+  components = new Set<ScannedComponent>();
+
+  document: JavaScriptDocument;
+  warnings: Warning[] = [];
+  constructor(document: JavaScriptDocument) {
+    this.document = document;
+  }
+
+  enterCallExpression(node: estree.CallExpression, _parent: estree.Node) {
+    if (node.type !== 'CallExpression') {
+      return;
+    }
+    const calleeName = astValue.getIdentifierName(node.callee);
+    if (!calleeName) {
+      return;
+    }
+    if (calleeName === 'AFRAME.registerComponent') {
+      const component = this.scanComponent(node);
+      if (component) {
+        this.components.add(component);
+      }
+    }
+  }
+
+  private scanComponent(call: estree.CallExpression): ScannedComponent|void {
+    const registerArguments = call.arguments;
+    if (registerArguments.length !== 2) {
+      this.warnings.push({
+        code: 'aframe.register.num-args',
+        severity: Severity.ERROR,
+        message:
+            'AFRAME.registerComponent takes two arguments, the name and the definition.',
+        sourceRange: this.document.sourceRangeForNode(call)!
+      });
+      return;
+    }
+    const nameExpr = registerArguments[0];
+    const definition = registerArguments[1];
+    const name = astValue.expressionToValue(nameExpr);
+    if (name == null) {
+      this.warnings.push({
+        code: 'aframe.register.cant-static-name',
+        severity: Severity.WARNING,
+        message:
+            'Unable to statically determine the component name from the first argument to AFRAME.registerComponent',
+        sourceRange: this.document.sourceRangeForNode(nameExpr)!
+      });
+      return;
+    }
+    const nameType = typeof name;
+    if (nameType !== 'string') {
+      this.warnings.push({
+        code: 'aframe.register.name-must-be-string',
+        severity: Severity.WARNING,
+        message: 'The registered component name must be a string.',
+        sourceRange: this.document.sourceRangeForNode(nameExpr)!
+      });
+      return;
+    }
+
+    return new ScannedComponent({
+      name: name as string,
+      sourceRange: this.document.sourceRangeForNode(definition)!,
+      astNode: definition,
+      warnings: []
+    });
+  }
+}

--- a/src/analysis-cache.ts
+++ b/src/analysis-cache.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Document, Import, InlineDocument, ScannedDocument} from './model/model';
+import {ParsedDocument} from './parser/document';
+
+export class AnalysisCache {
+  parsedDocumentPromises = new Map<string, Promise<ParsedDocument<any, any>>>();
+  scannedDocumentPromises = new Map<string, Promise<ScannedDocument>>();
+  analyzedDocumentPromises = new Map<string, Promise<Document>>();
+
+  scannedDocuments = new Map<string, ScannedDocument>();
+  analyzedDocuments = new Map<string, Document>();
+
+  /**
+   * Returns a copy of this cache, with the given path and all of its transitive
+   * dependants invalidated.
+   */
+  onPathChanged(path: string, dependants: Iterable<string>): AnalysisCache {
+    const newCache = this._clone();
+    newCache.parsedDocumentPromises.delete(path);
+    newCache.scannedDocumentPromises.delete(path);
+    newCache.scannedDocuments.delete(path);
+    newCache.analyzedDocuments.delete(path);
+
+    // Analyzed documents need to be treated more carefully, because they have
+    // relationships with other documents. So first we remove all documents
+    // which transitively import the changed document.
+    for (const invalidatedPath of dependants) {
+      newCache.analyzedDocuments.delete(invalidatedPath);
+    }
+    // Then we clear out the analyzed document promises, which could have
+    // in-progress results that don't cohere with the state of the new cache.
+    // Only populate the new analyzed promise cache with results that are
+    // definite, and not invalidated.
+    newCache.analyzedDocumentPromises.clear();
+    for (const keyValue of newCache.analyzedDocuments) {
+      newCache.analyzedDocumentPromises.set(
+          keyValue[0], Promise.resolve(keyValue[1]));
+    }
+
+    return newCache;
+  }
+
+  private _clone(): AnalysisCache {
+    const newCache = new AnalysisCache();
+    this._copyMapInto(
+        this.parsedDocumentPromises, newCache.parsedDocumentPromises);
+    this._copyMapInto(
+        this.scannedDocumentPromises, newCache.scannedDocumentPromises);
+    this._copyMapInto(
+        this.analyzedDocumentPromises, newCache.analyzedDocumentPromises);
+    this._copyMapInto(this.scannedDocuments, newCache.scannedDocuments);
+    this._copyMapInto(this.analyzedDocuments, newCache.analyzedDocuments);
+    return newCache;
+  }
+
+  private _copyMapInto<K, V>(from: Map<K, V>, into: Map<K, V>) {
+    for (const kv of from) {
+      into.set(kv[0], kv[1]);
+    }
+  }
+}
+
+/**
+ * Trawl the import graph and return the paths of (transitive) dependants on
+ * the given path.
+ *
+ * This should eventually live somewhere like Document, but we really need
+ * something like a Project, which encapsulates all of the known Documents
+ * inside a basedir, and which has the same interface as Document. That is the
+ * object that the AnalysisCache needs to know the results of calling
+ * getImportersOf.
+ */
+export function getImportersOf(
+    path: string, documents: Iterable<Document>): Set<string> {
+  const invertedIndex = _buildInvertedIndex(documents);
+  const visited = new Set<string>();
+  const toVisit = new Set<string>([path]);
+  while (toVisit.size > 0) {
+    const path = toVisit.keys().next().value!;
+    toVisit.delete(path);
+    visited.add(path);
+    const importers = invertedIndex.get(path);
+    if (!importers) {
+      continue;
+    }
+    for (const importer of importers) {
+      if (!visited.has(importer)) {
+        toVisit.add(importer);
+      }
+    }
+  }
+  return visited;
+}
+
+function _buildInvertedIndex(docs: Iterable<Document>):
+    Map<string, Set<string>> {
+  const invertedIndex = new Map<string, Set<string>>();
+  for (const doc of docs) {
+    _addFeaturesToInvertedIndex(doc, invertedIndex);
+  }
+  return invertedIndex;
+}
+
+function _addFeaturesToInvertedIndex(
+    doc: Document, invertedIndex: Map<string, Set<string>>) {
+  for (const feature of doc.getFeatures(false)) {
+    if (feature.kinds.has('import')) {
+      const imported = (feature as Import).url;
+      if (!invertedIndex.has(imported)) {
+        invertedIndex.set(imported, new Set());
+      }
+      invertedIndex.get(imported)!.add(doc.url);
+    }
+    if (feature.kinds.has('inline-document') && feature !== doc) {
+      _addFeaturesToInvertedIndex((feature as InlineDocument), invertedIndex);
+    }
+  }
+}

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -14,7 +14,10 @@
 
 import * as dom5 from 'dom5';
 import {ASTNode} from 'parse5';
+
 import {ScannedElementReference} from '../model/element-reference';
+import {ScanResult} from '../scanning/scanner';
+
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
 
@@ -33,8 +36,7 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
 
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedElementReference[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>): Promise<ScanResult> {
     let elements: ScannedElementReference[] = [];
 
     await visit((node) => {
@@ -60,7 +62,7 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
       }
     });
 
-    return elements;
+    return {features: elements, warnings: []};
   }
 }
 

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -16,6 +16,7 @@ import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
 import {ScannedImport} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
@@ -51,8 +52,7 @@ export class HtmlImportScanner implements HtmlScanner {
 
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedImport[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>): Promise<ScanResult> {
     const imports: ScannedImport[] = [];
 
     await visit((node) => {
@@ -82,6 +82,6 @@ export class HtmlImportScanner implements HtmlScanner {
         }
       }
     }
-    return imports;
+    return {features: imports, warnings: []};
   }
 }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -15,7 +15,8 @@
 import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
-import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedFeature, ScannedImport, ScannedInlineDocument} from '../model/model';
+import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedImport, ScannedInlineDocument} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
@@ -34,8 +35,7 @@ const isJsScriptNode = p.AND(
 export class HtmlScriptScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedFeature[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>): Promise<ScanResult> {
     const features: (ScannedImport|ScannedInlineDocument)[] = [];
 
     const myVisitor: HtmlVisitor = (node) => {
@@ -67,6 +67,6 @@ export class HtmlScriptScanner implements HtmlScanner {
 
     await visit(myVisitor);
 
-    return features;
+    return {features, warnings: []};
   }
 }

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -15,7 +15,8 @@
 import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
-import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedFeature, ScannedImport, ScannedInlineDocument} from '../model/model';
+import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedImport, ScannedInlineDocument} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
@@ -36,8 +37,7 @@ const isStyleNode = p.OR(isStyleElement, isStyleLink);
 export class HtmlStyleScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedFeature[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>): Promise<ScanResult> {
     const features: (ScannedImport|ScannedInlineDocument)[] = [];
 
     await visit(async(node) => {
@@ -67,6 +67,6 @@ export class HtmlStyleScanner implements HtmlScanner {
       }
     });
 
-    return features;
+    return {features, warnings: []};
   }
 }

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -19,11 +19,12 @@ import {Visitor} from '../javascript/estree-visitor';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import {ScannedImport} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 export class JavaScriptImportScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedImport[]> {
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScanResult> {
     const imports: ScannedImport[] = [];
 
     await visit({
@@ -42,7 +43,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
             node));
       }
     });
-    return imports;
+    return {features: imports, warnings: []};
   }
 }
 

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Analyzer} from '../analyzer';
+import {AnalyzerCacheContext} from '../analyzer';
 import {ParsedDocument} from '../parser/document';
 import {Behavior} from '../polymer/behavior';
 import {DomModule} from '../polymer/dom-module-scanner';
@@ -53,7 +53,7 @@ export class ScannedDocument {
 export class Document implements Feature {
   kinds: Set<string> = new Set(['document']);
   identifiers: Set<string> = new Set();
-  analyzer: Analyzer;
+  analyzer: AnalyzerCacheContext;
   warnings: Warning[];
 
   private _localFeatures = new Set<Feature>();
@@ -74,7 +74,7 @@ export class Document implements Feature {
    */
   private _doneResolving = false;
 
-  constructor(base: ScannedDocument, analyzer: Analyzer) {
+  constructor(base: ScannedDocument, analyzer: AnalyzerCacheContext) {
     if (base == null) {
       throw new Error('base is null');
     }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -61,7 +61,7 @@ export class ScannedImport implements Resolvable {
   resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
     if (!importedDocument) {
-      throw new Error(`no imported document with url ${this.url}`);
+      // throw new Error(`no imported document with url ${this.url}`);
     }
     return importedDocument && new Import(
                                    this.url,

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -60,14 +60,17 @@ export class ScannedImport implements Resolvable {
 
   resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
-    return importedDocument && new Import(
-                                   this.url,
-                                   this.type,
-                                   importedDocument,
-                                   this.sourceRange,
-                                   this.urlSourceRange,
-                                   this.astNode,
-                                   this.warnings);
+    if (!importedDocument) {
+      throw new Error(`no imported document with url ${this.url}`);
+    }
+    return new Import(
+        this.url,
+        this.type,
+        importedDocument,
+        this.sourceRange,
+        this.urlSourceRange,
+        this.astNode,
+        this.warnings);
   }
 }
 

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -60,9 +60,6 @@ export class ScannedImport implements Resolvable {
 
   resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
-    if (!importedDocument) {
-      // throw new Error(`no imported document with url ${this.url}`);
-    }
     return importedDocument && new Import(
                                    this.url,
                                    this.type,

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -30,7 +30,7 @@ export class ScannedImport implements Resolvable {
   type: 'html-import'|'html-script'|'html-style'|'js-import'|string;
 
   /**
-   * URL of the import, relative to the document containing the import.
+   * URL of the import, relative to the base directory.
    */
   url: string;
 
@@ -63,14 +63,14 @@ export class ScannedImport implements Resolvable {
     if (!importedDocument) {
       throw new Error(`no imported document with url ${this.url}`);
     }
-    return new Import(
-        this.url,
-        this.type,
-        importedDocument,
-        this.sourceRange,
-        this.urlSourceRange,
-        this.astNode,
-        this.warnings);
+    return importedDocument && new Import(
+                                   this.url,
+                                   this.type,
+                                   importedDocument,
+                                   this.sourceRange,
+                                   this.urlSourceRange,
+                                   this.astNode,
+                                   this.warnings);
   }
 }
 

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -53,8 +53,12 @@ export class ScannedInlineDocument implements ScannedFeature, Resolvable {
   astNode: dom5.Node;
 
   constructor(
-      type: string, contents: string, locationOffset: LocationOffset,
-      attachedComment: string, sourceRange: SourceRange, ast: dom5.Node) {
+      type: string,
+      contents: string,
+      locationOffset: LocationOffset,
+      attachedComment: string,
+      sourceRange: SourceRange,
+      ast: dom5.Node) {
     this.type = type;
     this.contents = contents;
     this.locationOffset = locationOffset;
@@ -77,6 +81,7 @@ export class ScannedInlineDocument implements ScannedFeature, Resolvable {
 export class InlineDocument extends Document {
   constructor(base: ScannedDocument, containerDocument: Document) {
     super(base, containerDocument.analyzer);
+    this.kinds.add('inline-document');
     this._addFeature(containerDocument);
   }
 }

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -20,6 +20,7 @@ import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
+import {ScanResult} from '../scanning/scanner';
 import {Severity} from '../warning/warning';
 
 import {ScannedBehavior, ScannedBehaviorAssignment} from './behavior';
@@ -52,10 +53,10 @@ const templatizer = 'Polymer.Templatizer';
 export class BehaviorScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedBehavior[]> {
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScanResult> {
     let visitor = new BehaviorVisitor(document);
     await visit(visitor);
-    return Array.from(visitor.behaviors);
+    return {features: Array.from(visitor.behaviors), warnings: []};
   }
 }
 

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -18,6 +18,7 @@ import {resolve as resolveUrl} from 'url';
 import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
 import {HtmlScanner} from '../html/html-scanner';
 import {ScannedImport} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 const p = dom5.predicates;
 
@@ -31,8 +32,7 @@ const isCssImportNode = p.AND(
 export class CssImportScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedImport[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>): Promise<ScanResult> {
     const imports: ScannedImport[] = [];
 
     await visit((node) => {
@@ -47,6 +47,6 @@ export class CssImportScanner implements HtmlScanner {
             node));
       }
     });
-    return imports;
+    return {features: imports, warnings: []};
   }
 }

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -18,6 +18,7 @@ import {ASTNode} from 'parse5';
 import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
 import {HtmlScanner} from '../html/html-scanner';
 import {Feature, getAttachedCommentText, Resolvable, SourceRange} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 import {Warning} from '../warning/warning';
 
 const p = dom5.predicates;
@@ -81,8 +82,7 @@ export class DomModule implements Feature {
 export class DomModuleScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedDomModule[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>): Promise<ScanResult> {
     let domModules: ScannedDomModule[] = [];
 
     await visit((node) => {
@@ -94,6 +94,6 @@ export class DomModuleScanner implements HtmlScanner {
             node));
       }
     });
-    return domModules;
+    return {features: domModules, warnings: []};
   }
 }

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -20,6 +20,7 @@ import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
+import {ScanResult} from '../scanning/scanner';
 import {Severity, WarningCarryingException} from '../warning/warning';
 
 import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
@@ -29,11 +30,14 @@ import {ScannedPolymerElement, ScannedPolymerProperty} from './polymer-element';
 
 export class PolymerElementScanner implements JavaScriptScanner {
   async scan(
-      document: JavaScriptDocument, visit: (visitor: Visitor) => Promise<void>):
-      Promise<ScannedPolymerElement[]> {
+      document: JavaScriptDocument,
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScanResult> {
     const visitor = new ElementVisitor(document);
     await visit(visitor);
-    return visitor.features;
+    return {
+      features: visitor.features,
+      warnings: [],
+    };
   }
 }
 

--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -23,6 +23,7 @@ import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
 import {ScannedElement, ScannedFeature} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 import {analyzeProperties} from './analyze-properties';
 import {Options as PolymerElementOptions, ScannedPolymerElement, ScannedPolymerProperty} from './polymer-element';
@@ -35,10 +36,10 @@ export interface ScannedAttribute extends ScannedFeature {
 export class Polymer2ElementScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedElement[]> {
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScanResult> {
     let visitor = new ElementVisitor(document);
     await visit(visitor);
-    return visitor.getRegisteredElements();
+    return {features: visitor.getRegisteredElements(), warnings: []};
   }
 }
 

--- a/src/scanning/scanner.ts
+++ b/src/scanning/scanner.ts
@@ -15,10 +15,15 @@
 import {Analyzer} from '../analyzer';
 import {ScannedFeature} from '../model/model';
 import {ParsedDocument} from '../parser/document';
+import {Warning} from '../warning/warning';
+
+export interface ScanResult {
+  features: ScannedFeature[];
+  warnings: Warning[];
+}
 
 export interface Scanner<D extends ParsedDocument<A, V>, A, V> {
-  scan(document: D, visit: (visitor: V) => Promise<void>):
-      Promise<ScannedFeature[]>;
+  scan(document: D, visit: (visitor: V) => Promise<void>): Promise<ScanResult>;
 }
 
 export interface ScannerConstructor {

--- a/src/test/a-frame/component-scanner_test.ts
+++ b/src/test/a-frame/component-scanner_test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+
+import {assert} from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {ComponentScanner, ScannedComponent} from '../../a-frame/component-scanner';
+import {Analyzer} from '../../analyzer';
+import {Visitor} from '../../javascript/estree-visitor';
+import {JavaScriptDocument} from '../../javascript/javascript-document';
+import {JavaScriptParser} from '../../javascript/javascript-parser';
+import {Severity, Warning} from '../../warning/warning';
+import {WarningPrinter} from '../../warning/warning-printer';
+
+suite('A-Frame Component Scanner', () => {
+
+  let document: JavaScriptDocument;
+  let components: Map<string, ScannedComponent>;
+  let componentsList: ScannedComponent[];
+  let warnings: Warning[];
+
+  const fileName = 'static/a-frame/components.js';
+  const contents =
+      fs.readFileSync(path.resolve(__dirname, '../', fileName), 'utf8');
+  ;
+  const loader = {canLoad: () => true, load: () => Promise.resolve(contents)};
+  const warningPrinter = new WarningPrinter(
+      null as any, {analyzer: new Analyzer({urlLoader: loader})});
+
+  async function getUnderlinedText(warning: Warning) {
+    return '\n' + await warningPrinter.getUnderlinedText(warning.sourceRange);
+  }
+
+
+  suiteSetup(async() => {
+    const parser = new JavaScriptParser({sourceType: 'script'});
+
+    document = parser.parse(contents, 'static/a-frame/components.js');
+    const scanner = new ComponentScanner();
+    const visit = (visitor: Visitor) =>
+        Promise.resolve(document.visit([visitor]));
+
+    const result = await scanner.scan(document, visit);
+    const features = result.features;
+    warnings = result.warnings;
+    components = new Map();
+    componentsList = <ScannedComponent[]>features.filter(
+        (e) => e instanceof ScannedComponent);
+    for (const component of componentsList) {
+      components.set(component.name, component);
+    }
+  });
+
+  test('Finds component registrations', () => {
+    assert.deepEqual(
+        componentsList.map(b => b.name).sort(), ['aabb-collider'].sort());
+  });
+
+  test('Warns on bad component registrations', async() => {
+    assert.containSubset(warnings, [
+      {code: 'aframe.register.num-args', severity: Severity.ERROR},
+      {code: 'aframe.register.num-args', severity: Severity.ERROR},
+      {code: 'aframe.register.num-args', severity: Severity.ERROR},
+      {code: 'aframe.register.cant-static-name', severity: Severity.WARNING}, {
+        code: 'aframe.register.name-must-be-string',
+        severity: Severity.WARNING
+      }
+    ]);
+
+    const underlines =
+        await Promise.all(warnings.map(w => getUnderlinedText(w)));
+    assert.deepEqual(underlines, [
+      `
+AFRAME.registerComponent();
+~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+AFRAME.registerComponent('no-definition');
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+AFRAME.registerComponent('too-many-args', {}, {});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+    Math.random() > 0.5 ? 'not-statically-analyzable' : 'definitely-not', {});
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+AFRAME.registerComponent(10, {});
+                         ~~`
+    ]);
+  });
+});

--- a/src/test/analysis-cache_test.ts
+++ b/src/test/analysis-cache_test.ts
@@ -132,15 +132,6 @@ suite('getImportersOf', () => {
     const docs = Array.from(
         analyzer['_cacheContext']['_cache']['analyzedDocuments'].values());
     const scannedDocs = docs.map(d => d['_scannedDocument']);
-    console.log(docs.map(d => d.url));
-    console.log(scannedDocs.map(d => d.url));
-    console.log(Array.from(
-        analyzer['_cacheContext']['_cache']['parsedDocumentPromises'].keys()));
-    console.log(Array.from(
-        analyzer['_cacheContext']['_cache']['scannedDocumentPromises'].keys()));
-    console.log(Array.from(
-        analyzer['_cacheContext']['_cache']['analyzedDocumentPromises']
-            .keys()));
 
     const urlResolver = (url: string) => url;
     expectedDependants.sort();
@@ -162,18 +153,17 @@ suite('getImportersOf', () => {
 
   test('it works with a simple tree of dependencies', async() => {
     await analyzer.analyze('dependencies/root.html');
-    //   await assertImportersOf(
-    //     'dependencies/root.html', ['dependencies/root.html']);
-    // console.log('first assert done ');
+    await assertImportersOf(
+        'dependencies/root.html', ['dependencies/root.html']);
+
     await assertImportersOf(
         'dependencies/leaf.html',
         ['dependencies/leaf.html', 'dependencies/root.html']);
-    // await assertImportersOf('dependencies/subfolder/subfolder-sibling.html',
-    // [
-    //   'dependencies/subfolder/subfolder-sibling.html',
-    //   'dependencies/subfolder/in-folder.html',
-    //   'dependencies/inline-and-imports.html',
-    //   'dependencies/root.html'
-    // ]);
+    await assertImportersOf('dependencies/subfolder/subfolder-sibling.html', [
+      'dependencies/subfolder/subfolder-sibling.html',
+      'dependencies/subfolder/in-folder.html',
+      'dependencies/inline-and-imports.html',
+      'dependencies/root.html'
+    ]);
   });
 });

--- a/src/test/analysis-cache_test.ts
+++ b/src/test/analysis-cache_test.ts
@@ -31,6 +31,7 @@ suite('AnalysisCache', () => {
         path, Promise.resolve(`scanned ${path} promise` as any));
     cache.analyzedDocumentPromises.set(
         path, Promise.resolve(`analyzed ${path} promise` as any));
+    cache.dependenciesScanned.set(path, Promise.resolve());
     cache.scannedDocuments.set(path, `scanned ${path}` as any);
     cache.analyzedDocuments.set(path, `analyzed ${path}` as any);
   }
@@ -41,6 +42,7 @@ suite('AnalysisCache', () => {
     assert.equal(
         await cache.scannedDocumentPromises.get(path),
         `scanned ${path} promise`);
+    assert.equal(await cache.dependenciesScanned.get(path), undefined);
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.equal(cache.analyzedDocuments.get(path), `analyzed ${path}`);
@@ -49,6 +51,7 @@ suite('AnalysisCache', () => {
   function assertNotHasDocument(cache: AnalysisCache, path: string) {
     assert.isFalse(cache.parsedDocumentPromises.has(path));
     assert.isFalse(cache.scannedDocumentPromises.has(path));
+    assert.isFalse(cache.dependenciesScanned.has(path));
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.isFalse(cache.scannedDocuments.has(path));
     assert.isFalse(cache.analyzedDocuments.has(path));
@@ -64,6 +67,7 @@ suite('AnalysisCache', () => {
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.isFalse(cache.analyzedDocuments.has(path));
     assert.isFalse(cache.analyzedDocumentPromises.has(path));
+    assert.isFalse(cache.dependenciesScanned.has(path));
   }
 
   test('it invalidates a path when asked to', async() => {
@@ -123,33 +127,53 @@ suite('getImportersOf', () => {
         {urlLoader: new FSUrlLoader(path.join(__dirname, 'static'))});
   });
 
-  test('it works with a basic document with no dependencies', async() => {
-    const document = await analyzer.analyze('dependencies/leaf.html');
+  async function assertImportersOf(path: string, expectedDependants: string[]) {
+    await analyzer.analyze(path);
+    const docs = Array.from(
+        analyzer['_cacheContext']['_cache']['analyzedDocuments'].values());
+    const scannedDocs = docs.map(d => d['_scannedDocument']);
+    console.log(docs.map(d => d.url));
+    console.log(scannedDocs.map(d => d.url));
+    console.log(Array.from(
+        analyzer['_cacheContext']['_cache']['parsedDocumentPromises'].keys()));
+    console.log(Array.from(
+        analyzer['_cacheContext']['_cache']['scannedDocumentPromises'].keys()));
+    console.log(Array.from(
+        analyzer['_cacheContext']['_cache']['analyzedDocumentPromises']
+            .keys()));
+
+    const urlResolver = (url: string) => url;
+    expectedDependants.sort();
     assert.deepEqual(
-        Array.from(getImportersOf(
-            'dependencies/leaf.html', document.getByKind('document'))),
-        ['dependencies/leaf.html']);
+        Array.from(getImportersOf(path, docs, scannedDocs, urlResolver)).sort(),
+        expectedDependants,
+        'with both docs and scanned docs');
+    // Also works with no documents, just scanned documents.
+    assert.deepEqual(
+        Array.from(getImportersOf(path, [], scannedDocs, urlResolver)).sort(),
+        expectedDependants,
+        'with just scanned docs');
+  }
+
+  test('it works with a basic document with no dependencies', async() => {
+    await assertImportersOf(
+        'dependencies/leaf.html', ['dependencies/leaf.html']);
   });
 
   test('it works with a simple tree of dependencies', async() => {
-    const documents = (await analyzer.analyze('dependencies/root.html'))
-                          .getByKind('document');
-    assert.deepEqual(
-        Array.from(getImportersOf('dependencies/root.html', documents)),
-        ['dependencies/root.html']);
-    assert.deepEqual(
-        Array.from(getImportersOf('dependencies/leaf.html', documents)).sort(),
+    await analyzer.analyze('dependencies/root.html');
+    //   await assertImportersOf(
+    //     'dependencies/root.html', ['dependencies/root.html']);
+    // console.log('first assert done ');
+    await assertImportersOf(
+        'dependencies/leaf.html',
         ['dependencies/leaf.html', 'dependencies/root.html']);
-    assert.deepEqual(
-        Array
-            .from(getImportersOf(
-                'dependencies/subfolder/subfolder-sibling.html', documents))
-            .sort(),
-        [
-          'dependencies/subfolder/subfolder-sibling.html',
-          'dependencies/subfolder/in-folder.html',
-          'dependencies/inline-and-imports.html',
-          'dependencies/root.html'
-        ].sort());
+    // await assertImportersOf('dependencies/subfolder/subfolder-sibling.html',
+    // [
+    //   'dependencies/subfolder/subfolder-sibling.html',
+    //   'dependencies/subfolder/in-folder.html',
+    //   'dependencies/inline-and-imports.html',
+    //   'dependencies/root.html'
+    // ]);
   });
 });

--- a/src/test/analysis-cache_test.ts
+++ b/src/test/analysis-cache_test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as path from 'path';
+
+import {AnalysisCache, getImportersOf} from '../analysis-cache';
+import {Analyzer} from '../analyzer';
+import {FSUrlLoader} from '../url-loader/fs-url-loader';
+
+suite('AnalysisCache', () => {
+  test('it can be constructed', () => {
+    new AnalysisCache();
+  });
+
+  function addFakeDocumentToCache(cache: AnalysisCache, path: string) {
+    cache.parsedDocumentPromises.set(
+        path, Promise.resolve(`parsed ${path} promise` as any));
+    cache.scannedDocumentPromises.set(
+        path, Promise.resolve(`scanned ${path} promise` as any));
+    cache.analyzedDocumentPromises.set(
+        path, Promise.resolve(`analyzed ${path} promise` as any));
+    cache.scannedDocuments.set(path, `scanned ${path}` as any);
+    cache.analyzedDocuments.set(path, `analyzed ${path}` as any);
+  }
+
+  async function assertHasDocument(cache: AnalysisCache, path: string) {
+    assert.equal(
+        await cache.parsedDocumentPromises.get(path), `parsed ${path} promise`);
+    assert.equal(
+        await cache.scannedDocumentPromises.get(path),
+        `scanned ${path} promise`);
+    // caller must assert on cache.analyzedDocumentPromises themselves
+    assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
+    assert.equal(cache.analyzedDocuments.get(path), `analyzed ${path}`);
+  }
+
+  function assertNotHasDocument(cache: AnalysisCache, path: string) {
+    assert.isFalse(cache.parsedDocumentPromises.has(path));
+    assert.isFalse(cache.scannedDocumentPromises.has(path));
+    // caller must assert on cache.analyzedDocumentPromises themselves
+    assert.isFalse(cache.scannedDocuments.has(path));
+    assert.isFalse(cache.analyzedDocuments.has(path));
+  }
+
+  async function assertDocumentScannedButNotResolved(
+      cache: AnalysisCache, path: string) {
+    assert.equal(
+        await cache.parsedDocumentPromises.get(path), `parsed ${path} promise`);
+    assert.equal(
+        await cache.scannedDocumentPromises.get(path),
+        `scanned ${path} promise`);
+    assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
+    assert.isFalse(cache.analyzedDocuments.has(path));
+    assert.isFalse(cache.analyzedDocumentPromises.has(path));
+  }
+
+  test('it invalidates a path when asked to', async() => {
+    const cache = new AnalysisCache();
+    addFakeDocumentToCache(cache, 'index.html');
+    addFakeDocumentToCache(cache, 'unrelated.html');
+    await assertHasDocument(cache, 'index.html');
+    await assertHasDocument(cache, 'unrelated.html');
+
+    const forkedCache = cache.onPathChanged('index.html', []);
+    await assertHasDocument(cache, 'index.html');
+    await assertHasDocument(cache, 'unrelated.html');
+    assertNotHasDocument(forkedCache, 'index.html');
+    await assertHasDocument(forkedCache, 'unrelated.html');
+
+    // The promise of unrelated.html's result has been turned into
+    // a Promise.resolve() of its non-promise cache.
+    assert.equal(
+        await forkedCache.analyzedDocumentPromises.get('unrelated.html'),
+        `analyzed unrelated.html`);
+  });
+
+  test('it invalidates the dependants of a path when asked to', async() => {
+    const cache = new AnalysisCache();
+    // Picture a graph where
+    addFakeDocumentToCache(cache, 'index.html');
+    addFakeDocumentToCache(cache, 'element.html');
+    addFakeDocumentToCache(cache, 'behavior.html');
+    addFakeDocumentToCache(cache, 'unrelated.html');
+    // We added the documents.
+    await assertHasDocument(cache, 'index.html');
+    await assertHasDocument(cache, 'unrelated.html');
+    await assertHasDocument(cache, 'behavior.html');
+    await assertHasDocument(cache, 'unrelated.html');
+
+    const forkedCache =
+        cache.onPathChanged('behavior.html', ['index.html', 'element.html']);
+    // The original cache is untouched.
+    await assertHasDocument(cache, 'index.html');
+    await assertHasDocument(cache, 'unrelated.html');
+    await assertHasDocument(cache, 'behavior.html');
+    await assertHasDocument(cache, 'unrelated.html');
+
+    // The fork has no trace of behavior.html, and its dependants are scanned
+    // but not resolved. Unrelated documents are still fully cached.
+    assertNotHasDocument(forkedCache, 'behavior.html');
+    await assertDocumentScannedButNotResolved(forkedCache, 'index.html');
+    await assertDocumentScannedButNotResolved(forkedCache, 'element.html');
+    await assertHasDocument(forkedCache, 'unrelated.html');
+  });
+});
+
+suite('getImportersOf', () => {
+  let analyzer: Analyzer;
+  setup(() => {
+    analyzer = new Analyzer(
+        {urlLoader: new FSUrlLoader(path.join(__dirname, 'static'))});
+  });
+
+  test('it works with a basic document with no dependencies', async() => {
+    const document = await analyzer.analyze('dependencies/leaf.html');
+    assert.deepEqual(
+        Array.from(getImportersOf(
+            'dependencies/leaf.html', document.getByKind('document'))),
+        ['dependencies/leaf.html']);
+  });
+
+  test('it works with a simple tree of dependencies', async() => {
+    const documents = (await analyzer.analyze('dependencies/root.html'))
+                          .getByKind('document');
+    assert.deepEqual(
+        Array.from(getImportersOf('dependencies/root.html', documents)),
+        ['dependencies/root.html']);
+    assert.deepEqual(
+        Array.from(getImportersOf('dependencies/leaf.html', documents)).sort(),
+        ['dependencies/leaf.html', 'dependencies/root.html']);
+    assert.deepEqual(
+        Array
+            .from(getImportersOf(
+                'dependencies/subfolder/subfolder-sibling.html', documents))
+            .sort(),
+        [
+          'dependencies/subfolder/subfolder-sibling.html',
+          'dependencies/subfolder/in-folder.html',
+          'dependencies/inline-and-imports.html',
+          'dependencies/root.html'
+        ].sort());
+  });
+});

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -566,6 +566,7 @@ suite('Analyzer', () => {
       for (let i = 0; i < 30; i++) {
         await wait();
         for (const keyValue of contentsMap) {
+          // Randomly edit some files.
           if (Math.random() > 0.5) {
             const p = analyzer.analyze(keyValue[0], keyValue[1]);
             const cacheContext = analyzer['_cacheContext'];
@@ -578,10 +579,13 @@ suite('Analyzer', () => {
             })());
           }
         }
+        // Analyze the base file
         promises.push(analyzer.analyze('base.html'));
         await Promise.all(promises);
       }
+      // Assert that all edits went through fine.
       await Promise.all(intermediatePromises);
+      // Assert that the resulting documents after the edits were all fine
       const documents = await Promise.all(promises);
       for (const document of documents) {
         assert.deepEqual(document.url, 'base.html');
@@ -603,6 +607,6 @@ suite('Analyzer', () => {
         const refs = Array.from(document.getByKind('element-reference'));
         assert.deepEqual(refs.map(ref => ref.tagName), ['custom-el']);
       }
-    })['timeout'](10000);
+    });
   });
 });

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -373,21 +373,23 @@ suite('Analyzer', () => {
   suite('_parse()', () => {
 
     test('loads and parses an HTML document', async() => {
-      const doc = await analyzer['_parse']('static/html-parse-target.html');
+      const doc = await analyzer['_cacheContext']['_parse'](
+          'static/html-parse-target.html');
       assert.instanceOf(doc, ParsedHtmlDocument);
       assert.equal(doc.url, 'static/html-parse-target.html');
     });
 
     test('loads and parses a JavaScript document', async() => {
-      const doc = await analyzer['_parse']('static/js-elements.js');
+      const doc =
+          await analyzer['_cacheContext']['_parse']('static/js-elements.js');
       assert.instanceOf(doc, JavaScriptDocument);
       assert.equal(doc.url, 'static/js-elements.js');
     });
 
     test('returns a Promise that rejects for non-existant files', async() => {
-      await invertPromise(analyzer['_parse']('static/not-found'));
+      await invertPromise(
+          analyzer['_cacheContext']['_parse']('static/not-found'));
     });
-
   });
 
   suite('_getScannedFeatures()', () => {
@@ -398,8 +400,8 @@ suite('Analyzer', () => {
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
-      const features =
-          <ScannedImport[]>(await analyzer['_getScannedFeatures'](document));
+      const features = <ScannedImport[]>(
+          await analyzer['_cacheContext']['_getScannedFeatures'](document));
       assert.deepEqual(
           features.map(e => e.type),
           ['html-import', 'html-script', 'html-style']);
@@ -419,7 +421,8 @@ suite('Analyzer', () => {
         </body></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
       const features =
-          <ScannedImport[]>(await analyzer['_getScannedFeatures'](document))
+          <ScannedImport[]>(
+              await analyzer['_cacheContext']['_getScannedFeatures'](document))
               .filter(e => e instanceof ScannedImport);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
@@ -433,7 +436,7 @@ suite('Analyzer', () => {
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
       const features = <ScannedInlineDocument[]>(
-          await analyzer['_getScannedFeatures'](document));
+          await analyzer['_cacheContext']['_getScannedFeatures'](document));
 
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedInlineDocument);
@@ -525,7 +528,7 @@ suite('Analyzer', () => {
     });
   });
 
-  suite.skip('race conditions and caching', () => {
+  suite.only('race conditions and caching', () => {
     const wait = () =>
         new Promise((resolve) => setTimeout(resolve, Math.random() * 30));
     class RacyUrlLoader implements UrlLoader {
@@ -559,27 +562,46 @@ suite('Analyzer', () => {
       const analyzer =
           new Analyzer({urlLoader: new RacyUrlLoader(contentsMap)});
       const promises: Promise<Document>[] = [];
+      const intermediatePromises: Promise<void>[] = [];
       for (let i = 0; i < 30; i++) {
         await wait();
-        for (const key of contentsMap) {
+        for (const keyValue of contentsMap) {
           if (Math.random() > 0.5) {
-            analyzer.analyze(key[0], key[1]);
+            const p = analyzer.analyze(keyValue[0], keyValue[1]);
+            const cacheContext = analyzer['_cacheContext'];
+            intermediatePromises.push((async() => {
+              await p;
+              const docs =
+                  Array.from(cacheContext['_cache'].analyzedDocuments.values());
+              assert.isTrue(
+                  new Set(docs.map(d => d.url).sort()).has(keyValue[0]));
+            })());
           }
         }
         promises.push(analyzer.analyze('base.html'));
+        await Promise.all(promises);
       }
+      await Promise.all(intermediatePromises);
       const documents = await Promise.all(promises);
       for (const document of documents) {
-        const imports = Array.from(document.getByKind('import'));
-        assert.deepEqual(
-            imports.map(m => m.url).sort(),
-            ['a.html', 'b.html', 'common.html', 'common.html']);
-        const docs = Array.from(document.getByKind('document'));
-        assert.deepEqual(
-            docs.map(d => d.url).sort(),
-            ['a.html', 'b.html', 'base.html', 'common.html']);
-        const refs = Array.from(document.getByKind('element-reference'));
-        assert.deepEqual(refs.map(ref => ref.tagName), ['custom-el']);
+        assert.deepEqual(document.url, 'base.html');
+        const localFeatures = document.getFeatures(false);
+        const kinds = Array.from(localFeatures).map(f => Array.from(f.kinds));
+        assert.deepEqual(kinds, [
+          ['document', 'html-document'],
+          ['import', 'html-import'],
+          ['import', 'html-import']
+        ]);
+        // const imports = Array.from(document.getByKind('import'));
+        // assert.deepEqual(
+        //     imports.map(m => m.url).sort(),
+        //     ['a.html', 'b.html', 'common.html', 'common.html']);
+        // const docs = Array.from(document.getByKind('document'));
+        // assert.deepEqual(
+        //     docs.map(d => d.url).sort(),
+        //     ['a.html', 'b.html', 'base.html', 'common.html']);
+        // const refs = Array.from(document.getByKind('element-reference'));
+        // assert.deepEqual(refs.map(ref => ref.tagName), ['custom-el']);
       }
     });
   });

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -592,17 +592,17 @@ suite('Analyzer', () => {
           ['import', 'html-import'],
           ['import', 'html-import']
         ]);
-        // const imports = Array.from(document.getByKind('import'));
-        // assert.deepEqual(
-        //     imports.map(m => m.url).sort(),
-        //     ['a.html', 'b.html', 'common.html', 'common.html']);
-        // const docs = Array.from(document.getByKind('document'));
-        // assert.deepEqual(
-        //     docs.map(d => d.url).sort(),
-        //     ['a.html', 'b.html', 'base.html', 'common.html']);
-        // const refs = Array.from(document.getByKind('element-reference'));
-        // assert.deepEqual(refs.map(ref => ref.tagName), ['custom-el']);
+        const imports = Array.from(document.getByKind('import'));
+        assert.deepEqual(
+            imports.map(m => m.url).sort(),
+            ['a.html', 'b.html', 'common.html', 'common.html']);
+        const docs = Array.from(document.getByKind('document'));
+        assert.deepEqual(
+            docs.map(d => d.url).sort(),
+            ['a.html', 'b.html', 'base.html', 'common.html']);
+        const refs = Array.from(document.getByKind('element-reference'));
+        assert.deepEqual(refs.map(ref => ref.tagName), ['custom-el']);
       }
-    });
+    })['timeout'](10000);
   });
 });

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -528,7 +528,7 @@ suite('Analyzer', () => {
     });
   });
 
-  suite.only('race conditions and caching', () => {
+  suite('race conditions and caching', () => {
     const wait = () =>
         new Promise((resolve) => setTimeout(resolve, Math.random() * 30));
     class RacyUrlLoader implements UrlLoader {

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -400,8 +400,9 @@ suite('Analyzer', () => {
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
-      const features = <ScannedImport[]>(
-          await analyzer['_cacheContext']['_getScannedFeatures'](document));
+      const features =
+          (await analyzer['_cacheContext']['_getScannedFeatures'](document))
+              .features as ScannedImport[];
       assert.deepEqual(
           features.map(e => e.type),
           ['html-import', 'html-script', 'html-style']);
@@ -421,8 +422,8 @@ suite('Analyzer', () => {
         </body></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
       const features =
-          <ScannedImport[]>(
-              await analyzer['_cacheContext']['_getScannedFeatures'](document))
+          ((await analyzer['_cacheContext']['_getScannedFeatures'](document))
+               .features as ScannedImport[])
               .filter(e => e instanceof ScannedImport);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
@@ -435,8 +436,9 @@ suite('Analyzer', () => {
           <style>body { color: red; }</style>
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
-      const features = <ScannedInlineDocument[]>(
-          await analyzer['_cacheContext']['_getScannedFeatures'](document));
+      const features =
+          (await analyzer['_cacheContext']['_getScannedFeatures'](document))
+              .features as ScannedInlineDocument[];
 
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedInlineDocument);

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -18,7 +18,7 @@ import {Analyzer} from '../../analyzer';
 import {HtmlVisitor} from '../../html/html-document';
 import {HtmlCustomElementReferenceScanner, HtmlElementReferenceScanner} from '../../html/html-element-reference-scanner';
 import {HtmlParser} from '../../html/html-parser';
-import {SourceRange} from '../../model/model';
+import {ScannedElementReference, SourceRange} from '../../model/model';
 import {WarningPrinter} from '../../warning/warning-printer';
 
 suite('HtmlElementReferenceScanner', () => {
@@ -43,7 +43,8 @@ suite('HtmlElementReferenceScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features = (await scanner.scan(document, visit))
+                           .features as ScannedElementReference[];
 
       assert.deepEqual(
           features.map(f => f.tagName),
@@ -85,7 +86,8 @@ suite('HtmlCustomElementReferenceScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features = (await scanner.scan(document, visit))
+                           .features as ScannedElementReference[];
 
       assert.deepEqual(features.map(f => f.tagName), ['x-foo', 'x-bar']);
 

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -17,6 +17,7 @@ import {assert} from 'chai';
 import {HtmlVisitor} from '../../html/html-document';
 import {HtmlImportScanner} from '../../html/html-import-scanner';
 import {HtmlParser} from '../../html/html-parser';
+import {ScannedImport} from '../../model/model';
 
 suite('HtmlImportScanner', () => {
 
@@ -37,7 +38,8 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features =
+          (await scanner.scan(document, visit)).features as ScannedImport[];
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'html-import');
       assert.equal(features[0].url, 'polymer.html');
@@ -54,7 +56,8 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features =
+          (await scanner.scan(document, visit)).features as ScannedImport[];
       assert.equal(features.length, 2);
       assert.equal(features[1].type, 'lazy-html-import');
       assert.equal(features[1].url, 'lazy-polymer.html');
@@ -81,7 +84,8 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features =
+          (await scanner.scan(document, visit)).features as ScannedImport[];
       assert.deepEqual(features.map(f => f.type), [
         'html-import',
         'lazy-html-import',

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -36,7 +36,7 @@ suite('HtmlScriptScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       let visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features = (await scanner.scan(document, visit)).features;
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptImportScanner} from '../../javascript/javascript-import-scanner';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
+import {ScannedImport} from '../../model/model';
 
 suite('JavaScriptImportScanner', () => {
 
@@ -34,7 +35,8 @@ suite('JavaScriptImportScanner', () => {
     let visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    let features = await scanner.scan(document, visit);
+    let features =
+        (await scanner.scan(document, visit)).features as ScannedImport[];
     assert.equal(features.length, 1);
     assert.equal(features[0].type, 'js-import');
     assert.equal(features[0].url, '/static/javascript/submodule.js');
@@ -51,7 +53,7 @@ suite('JavaScriptImportScanner', () => {
     let visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    let features = await scanner.scan(document, visit);
+    let features = (await scanner.scan(document, visit)).features;
     assert.equal(features.length, 0);
   });
 

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -39,7 +39,7 @@ suite('BehaviorScanner', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
+    const features = (await scanner.scan(document, visit)).features;
     behaviors = new Map();
     behaviorsList =
         <ScannedBehavior[]>features.filter((e) => e instanceof ScannedBehavior);

--- a/src/test/polymer/css-import-scanner_test.ts
+++ b/src/test/polymer/css-import-scanner_test.ts
@@ -17,6 +17,7 @@ import {assert} from 'chai';
 
 import {HtmlVisitor} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
+import {ScannedImport} from '../../model/model';
 import {CssImportScanner} from '../../polymer/css-import-scanner';
 
 suite('CssImportScanner', () => {
@@ -47,7 +48,8 @@ suite('CssImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features =
+          (await scanner.scan(document, visit)).features as ScannedImport[];
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
       assert.equal(features[0].url, 'polymer.css');

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -13,8 +13,10 @@
  */
 
 import {assert} from 'chai';
+
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
+import {ScannedPolymerElement} from '../../polymer/polymer-element';
 import {PolymerElementScanner} from '../../polymer/polymer-element-scanner';
 
 suite('PolymerElementScanner', () => {
@@ -81,7 +83,8 @@ suite('PolymerElementScanner', () => {
                        }).parse(contents, 'test-document.html');
       let visit = async(visitor: Visitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const features = (await scanner.scan(document, visit))
+                           .features as ScannedPolymerElement[];
 
       assert.deepEqual(features.map(f => f.tagName), ['x-foo', 'x-bar']);
 

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -49,7 +49,8 @@ suite('Polymer2ElementScanner', () => {
     let visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features: ScannedFeature[] = await scanner.scan(document, visit);
+    const features: ScannedFeature[] =
+        (await scanner.scan(document, visit)).features;
     elements = new Map();
     elementsList =
         <ScannedElement[]>features.filter((e) => e instanceof ScannedElement);

--- a/src/test/scanning/scan_test.ts
+++ b/src/test/scanning/scan_test.ts
@@ -27,7 +27,7 @@ suite('scan()', () => {
     let scanner = new ScannerStub(<any>[feature]);
     let document = makeTestDocument({});
 
-    const features = await scan(document, [scanner]);
+    const features = (await scan(document, [scanner])).features;
     assert.deepEqual(features, [feature]);
     assert.deepEqual(scanner.calls, [{document}]);
     assert.deepEqual(features, [feature]);
@@ -51,7 +51,7 @@ suite('scan()', () => {
           }, 0);
         });
 
-        return [`a feature` as any];
+        return {features: [`a feature` as any], warnings: []};
       },
     };
     let visitedVisitors: any[] = [];
@@ -61,7 +61,7 @@ suite('scan()', () => {
       }
     });
 
-    const features = await scan(document, [scanner]);
+    const features = (await scan(document, [scanner])).features;
     assert.deepEqual([`a feature`], features);
     assert.deepEqual(visitedVisitors, [visitor1, visitor2, visitor3]);
   });
@@ -140,6 +140,6 @@ class ScannerStub implements Scanner<any, any, any> {
 
   async scan(document: ParsedDocument<any, any>, _visit: any) {
     this.calls.push({document});
-    return this.features;
+    return {features: this.features, warnings: []};
   }
 }

--- a/src/test/static/a-frame/components.js
+++ b/src/test/static/a-frame/components.js
@@ -1,0 +1,25 @@
+/**
+ * Implement AABB collision detection for entities with a mesh.
+ * (https://en.wikipedia.org/wiki/Minimum_bounding_box#Axis-aligned_minimum_bounding_box)
+ * It sets the specified state on the intersected entities.
+ *
+ * @property {string} objects - Selector of the entities to test for collision.
+ * @property {string} state - State to set on collided entities.
+ *
+ */
+AFRAME.registerComponent(
+    'aabb-collider',
+    {schema: {objects: {default: ''}, state: {default: 'collided'}}});
+
+
+/** Bad components: */
+
+
+AFRAME.registerComponent();
+AFRAME.registerComponent('no-definition');
+AFRAME.registerComponent('too-many-args', {}, {});
+
+AFRAME.registerComponent(
+    Math.random() > 0.5 ? 'not-statically-analyzable' : 'definitely-not', {});
+
+AFRAME.registerComponent(10, {});

--- a/src/test/vanilla-custom-elements/element-scanner_test.ts
+++ b/src/test/vanilla-custom-elements/element-scanner_test.ts
@@ -41,9 +41,9 @@ suite('VanillaElementScanner', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
-    elementsList =
-        <ScannedElement[]>features.filter((e) => e instanceof ScannedElement);
+    const features =
+        (await scanner.scan(document, visit)).features as ScannedElement[];
+    elementsList = features.filter((e) => e instanceof ScannedElement);
     for (const element of elementsList) {
       elements.set(element.tagName, element);
     }

--- a/src/vanilla-custom-elements/element-scanner.ts
+++ b/src/vanilla-custom-elements/element-scanner.ts
@@ -21,6 +21,7 @@ import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
 import {ScannedElement, ScannedFeature} from '../model/model';
+import {ScanResult} from '../scanning/scanner';
 
 export interface ScannedAttribute extends ScannedFeature {
   name: string;
@@ -31,10 +32,10 @@ export interface ScannedAttribute extends ScannedFeature {
 export class ElementScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedElement[]> {
+      visit: (visitor: Visitor) => Promise<void>): Promise<ScanResult> {
     let visitor = new ElementVisitor(document);
     await visit(visitor);
-    return visitor.getRegisteredElements();
+    return {features: visitor.getRegisteredElements(), warnings: []};
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

Adds first support for a non-polymer web components library: A-Frame! This patch will recognize certain kinds of invalid A-Frame component registrations. It also sets the groundwork for doing more interesting stuff later once we also recognize A-Frame entity definitions.

In order to make that work, I noticed that there was no way to return warnings from a scanner unless those warnings had a feature to attach to, so I refactored the return type of #scan().