### PR TITLE
Handle mutually recursive import graphs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   * Warn, don't throw when a behavior is declared twice.
   * Warn when there's a problem mixing behaviors into other behaviors, the same way that we warn when mixing behaviors into elements.
 
+* Fix some bugs with recursive and mutually recursive imports.
+
 ## [2.0.0-alpha.17] - 2016-10-28 - [minor]
 
 ### Added

--- a/src/css/css-parser.ts
+++ b/src/css/css-parser.ts
@@ -29,13 +29,14 @@ export class CssParser implements Parser<ParsedCssDocument> {
   parse(contents: string, url: string, inlineInfo?: InlineDocInfo<any>):
       ParsedCssDocument {
     let ast = this._parser.parse(contents);
+    const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
     return new ParsedCssDocument({
       url,
       contents,
       ast,
       locationOffset: inlineInfo.astNode,
-      astNode: inlineInfo.astNode
+      astNode: inlineInfo.astNode, isInline,
     });
   }
 }

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -29,13 +29,14 @@ export class HtmlParser implements Parser<ParsedHtmlDocument> {
   parse(contents: string, url: string, inlineInfo?: InlineDocInfo<any>):
       ParsedHtmlDocument {
     let ast = parseHtml(contents, {locationInfo: true});
+    const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
     return new ParsedHtmlDocument({
       url,
       contents,
       ast,
       locationOffset: inlineInfo.locationOffset,
-      astNode: inlineInfo.astNode
+      astNode: inlineInfo.astNode, isInline,
     });
   }
 }

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -38,6 +38,7 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
 
   parse(contents: string, url: string, inlineInfo?: InlineDocInfo<any>):
       JavaScriptDocument {
+    const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
     let ast: Program;
     try {
@@ -71,7 +72,7 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
       contents,
       ast,
       locationOffset: inlineInfo.locationOffset,
-      astNode: inlineInfo.astNode
+      astNode: inlineInfo.astNode, isInline,
     });
   }
 }

--- a/src/json/json-parser.ts
+++ b/src/json/json-parser.ts
@@ -20,13 +20,14 @@ import {ParsedJsonDocument} from './json-document';
 export class JsonParser implements Parser<ParsedJsonDocument> {
   parse(contents: string, url: string, inlineDocInfo: InlineDocInfo<any>):
       ParsedJsonDocument {
+    const isInline = !!inlineDocInfo;
     inlineDocInfo = inlineDocInfo || {};
     return new ParsedJsonDocument({
       url,
       contents,
       ast: JSON.parse(contents),
       locationOffset: inlineDocInfo.locationOffset,
-      astNode: inlineDocInfo.astNode
+      astNode: inlineDocInfo.astNode, isInline
     });
   }
 }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -31,19 +31,18 @@ import {SourceRange} from './source-range';
  */
 export class ScannedDocument {
   document: ParsedDocument<any, any>;
-  dependencies: ScannedDocument[];
   features: ScannedFeature[];
   isInline = false;
   sourceRange: SourceRange|undefined = undefined;  // TODO(rictic): track this
   warnings: Warning[];
 
   constructor(
-      document: ParsedDocument<any, any>, dependencies: ScannedDocument[],
-      features: ScannedFeature[], warnings?: Warning[]) {
+      document: ParsedDocument<any, any>, features: ScannedFeature[],
+      isInline: boolean, warnings?: Warning[]) {
     this.document = document;
-    this.dependencies = dependencies;
     this.features = features;
     this.warnings = warnings || [];
+    this.isInline = isInline;
   }
 
   get url() {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -38,11 +38,11 @@ export class ScannedDocument {
 
   constructor(
       document: ParsedDocument<any, any>, features: ScannedFeature[],
-      isInline: boolean, warnings?: Warning[]) {
+      warnings?: Warning[]) {
     this.document = document;
     this.features = features;
     this.warnings = warnings || [];
-    this.isInline = isInline;
+    this.isInline = document.isInline;
   }
 
   get url() {

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -25,6 +25,7 @@ export abstract class ParsedDocument<A, V> {
   url: string;
   contents: string;
   ast: A;
+  isInline: boolean;
 
   /**
    * If not null, this is an inline document, and astNode is the AST Node of
@@ -40,6 +41,7 @@ export abstract class ParsedDocument<A, V> {
     this.ast = from.ast;
     this._locationOffset = from.locationOffset;
     this.astNode = from.astNode;
+    this.isInline = from.isInline;
   }
 
   /**
@@ -74,6 +76,7 @@ export interface Options<A> {
   ast: A;
   locationOffset: LocationOffset|undefined;
   astNode: any|null;
+  isInline: boolean;
 }
 
 export interface StringifyOptions {

--- a/src/test/static/circular/mutual-a.html
+++ b/src/test/static/circular/mutual-a.html
@@ -1,0 +1,1 @@
+<link rel="import" href="./mutual-b.html">

--- a/src/test/static/circular/mutual-b.html
+++ b/src/test/static/circular/mutual-b.html
@@ -1,0 +1,1 @@
+<link rel="import" href="./mutual-a.html">

--- a/src/test/static/circular/self-import.html
+++ b/src/test/static/circular/self-import.html
@@ -1,0 +1,2 @@
+<link rel="import" href="">
+<link rel="import" href="./self-import.html">


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

This required two changes:
  * break up scanning a document and its dependencies. cache the scanned document once it has been scanned but before its dependencies are.
  * track a scanned document's inline status a bit better, and don't cache inline scanned documents. This was always a hidden error that was masked by the earlier order of operations.

Fixes #388

 - [x] CHANGELOG.md has been updated
