### PR TITLE
Add test that demonstrates issues with caching.

### DIFF
--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -141,6 +141,30 @@ suite('Analyzer', () => {
               chainedDocument.getWarnings(true), [expectedWarning]);
         });
 
+    // currently passing
+    test('analyzes multiple imports of the same behavior', async() => {
+      const documentA = await analyzer.analyze(
+          'static/multiple-behavior-imports/element-a.html');
+      const documentB = await analyzer.analyze(
+          'static/multiple-behavior-imports/element-b.html');
+      assert.deepEqual(documentA.getWarnings(true), []);
+      assert.deepEqual(documentB.getWarnings(true), []);
+    });
+
+    // currently failing
+    test(
+        'analyzes multiple imports of the same behavior simultaneously',
+        async() => {
+          const result = await Promise.all([
+            analyzer.analyze('static/multiple-behavior-imports/element-a.html'),
+            analyzer.analyze('static/multiple-behavior-imports/element-b.html')
+          ]);
+          const documentA = result[0];
+          const documentB = result[1];
+          assert.deepEqual(documentA.getWarnings(true), []);
+          assert.deepEqual(documentB.getWarnings(true), []);
+        });
+
     test(
         'an inline document can find features from its container document',
         async() => {

--- a/src/test/static/multiple-behavior-imports/behavior.html
+++ b/src/test/static/multiple-behavior-imports/behavior.html
@@ -1,0 +1,14 @@
+<script>
+  /**
+   * @polymerBehavior
+   */
+  Polymer.TestBehavior = {
+    properties: {
+      isHighlighted: {
+        type: Boolean,
+        value: false,
+        notify: true,
+      }
+    }
+  };
+</script>

--- a/src/test/static/multiple-behavior-imports/element-a.html
+++ b/src/test/static/multiple-behavior-imports/element-a.html
@@ -1,0 +1,7 @@
+<link rel="import" href="behavior.html">
+<script>
+  Polymer({
+    is: 'element-a',
+    behaviors: [Polymer.TestBehavior]
+  });
+</script>

--- a/src/test/static/multiple-behavior-imports/element-b.html
+++ b/src/test/static/multiple-behavior-imports/element-b.html
@@ -1,0 +1,7 @@
+<link rel="import" href="behavior.html">
+<script>
+  Polymer({
+    is: 'element-b',
+    behaviors: [Polymer.TestBehavior]
+  });
+</script>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,25 @@ export function trimLeft(str: string, char: string): string {
   }
   return str.substring(leftEdge);
 }
+
+export class Deferred<T> {
+  promise: Promise<T>;
+  resolve: (result: T) => void;
+  reject: (error: Error) => void;
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  toNodeCallback() {
+    return (error: any, value: T) => {
+      if (error) {
+        this.reject(error);
+      } else {
+        this.resolve(value);
+      }
+    };
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

The test is skipped for now, but it demonstrates that our caching strategy doesn't work properly with modifications of files coming in while other analyses are happening.

I believe this demonstrates the bug that's happening in https://github.com/Polymer/polymer-editor-service/issues/28

 - [x] CHANGELOG.md not updated, entirely internal change.
