### PR TITLE
Format all code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 BasedOnStyle: Google
 AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None

--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,6 @@
 BasedOnStyle: Google
-AlignAfterOpenBracket: AlwaysBreak
-AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-BinPackArguments: false
-BinPackParameters: false

--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,6 @@ AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackArguments: false
+# This breaks async functions sometimes, see
+#     https://github.com/Polymer/polymer-analyzer/pull/393
+# BinPackParameters: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None

--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,4 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+BinPackArguments: false

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -96,15 +96,19 @@ export class Analyzer {
       [
         'html',
         [
-          new HtmlImportScanner(lazyEdges), new HtmlScriptScanner(),
-          new HtmlStyleScanner(), new DomModuleScanner(),
-          new CssImportScanner(), new HtmlCustomElementReferenceScanner()
+          new HtmlImportScanner(lazyEdges),
+          new HtmlScriptScanner(),
+          new HtmlStyleScanner(),
+          new DomModuleScanner(),
+          new CssImportScanner(),
+          new HtmlCustomElementReferenceScanner()
         ]
       ],
       [
         'js',
         [
-          new PolymerElementScanner(), new BehaviorScanner(),
+          new PolymerElementScanner(),
+          new BehaviorScanner(),
           new VanillaElementScanner()
         ]
       ],
@@ -317,8 +321,11 @@ export class Analyzer {
     const inlineInfo = {locationOffset, astNode: inlineDoc.astNode};
     try {
       const scannedDocument = await this._scanSource(
-          inlineDoc.type, inlineDoc.contents, containingDocument.url,
-          inlineInfo, inlineDoc.attachedComment);
+          inlineDoc.type,
+          inlineDoc.contents,
+          containingDocument.url,
+          inlineInfo,
+          inlineDoc.attachedComment);
       inlineDoc.scannedDocument = scannedDocument;
       inlineDoc.scannedDocument.isInline = true;
       return scannedDocument;

--- a/src/editor-service/ast-from-source-position.ts
+++ b/src/editor-service/ast-from-source-position.ts
@@ -93,7 +93,8 @@ export function getLocationInfoForPosition(
 }
 
 function _getLocationInfoForPosition(
-    node: parse5.ASTNode, position: SourcePosition,
+    node: parse5.ASTNode,
+    position: SourcePosition,
     document: ParsedHtmlDocument): undefined|LocationResult {
   const sourceRange = document.sourceRangeForNode(node);
   const location = node.__location;
@@ -249,7 +250,8 @@ function comparePositionAndRange(
 }
 
 function _findLocationInChildren(
-    node: parse5.ASTNode, position: SourcePosition,
+    node: parse5.ASTNode,
+    position: SourcePosition,
     document: ParsedHtmlDocument) {
   for (const child of node.childNodes || []) {
     const result = _getLocationInfoForPosition(child, position, document);
@@ -267,7 +269,8 @@ function _findLocationInChildren(
 }
 
 function isPositionInsideRange(
-    position: SourcePosition, range: SourceRange|undefined,
+    position: SourcePosition,
+    range: SourceRange|undefined,
     includeEdges?: boolean) {
   if (!range) {
     return false;
@@ -288,9 +291,10 @@ type Parse5Location = parse5.LocationInfo|parse5.ElementLocationInfo;
  * correct LocationResult.
  */
 function getAttributeLocation(
-    node: parse5.ASTNode, position: SourcePosition,
-    document: ParsedHtmlDocument, location: Parse5Location): AttributesSection|
-    AttributeValue|undefined {
+    node: parse5.ASTNode,
+    position: SourcePosition,
+    document: ParsedHtmlDocument,
+    location: Parse5Location): AttributesSection|AttributeValue|undefined {
   /**
    * TODO(rictic): upstream to @types the fact that regular locations (not just
    * element locations) can have attrs sometimes.

--- a/src/generate-elements.ts
+++ b/src/generate-elements.ts
@@ -111,7 +111,8 @@ function serializeElement(
 }
 
 function serializeProperty(
-    resolvedElement: ResolvedElement, elementPath: string,
+    resolvedElement: ResolvedElement,
+    elementPath: string,
     resolvedProperty: ResolvedProperty): Property {
   const property: Property = {
     name: resolvedProperty.name,
@@ -128,7 +129,8 @@ function serializeProperty(
 }
 
 function serializeAttribute(
-    resolvedElement: ResolvedElement, elementPath: string,
+    resolvedElement: ResolvedElement,
+    elementPath: string,
     resolvedAttribute: ResolvedAttribute): Attribute {
   const attribute: Attribute = {
     name: resolvedAttribute.name,

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -276,9 +276,9 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
       // TODO(rictic): infer this from doc.astNode's indentation.
       const expectedIndentation = 2;
 
-      dom5.setTextContent(
-          doc.astNode, '\n' + doc.stringify({indent: expectedIndentation}) +
-              '  '.repeat(expectedIndentation - 1));
+      dom5.setTextContent(doc.astNode, '\n' + doc.stringify({
+        indent: expectedIndentation
+      }) + '  '.repeat(expectedIndentation - 1));
     }
 
     removeFakeNodes(selfClone.ast);
@@ -354,6 +354,19 @@ function getAttributeLocation(
  * Source: https://www.w3.org/TR/html5/syntax.html#void-elements
  */
 const voidTagNames = new Set([
-  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen', 'link',
-  'meta', 'param', 'source', 'track', 'wbr'
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr'
 ]);

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -26,13 +26,18 @@ const linkTag = p.hasTagName('link');
 const notCssLink = p.NOT(p.hasAttrValue('type', 'css'));
 
 const isHtmlImportNode = p.AND(
-    linkTag, p.hasAttr('href'), p.hasSpaceSeparatedAttrValue('rel', 'import'),
-    p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'lazy-import')), notCssLink,
+    linkTag,
+    p.hasAttr('href'),
+    p.hasSpaceSeparatedAttrValue('rel', 'import'),
+    p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'lazy-import')),
+    notCssLink,
     p.NOT(p.parentMatches(p.hasTagName('template'))));
 
 const isLazyImportNode = p.AND(
-    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'lazy-import'),
-    p.hasAttr('href'), p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'import')),
+    p.hasTagName('link'),
+    p.hasSpaceSeparatedAttrValue('rel', 'lazy-import'),
+    p.hasAttr('href'),
+    p.NOT(p.hasSpaceSeparatedAttrValue('rel', 'import')),
     notCssLink,
     p.parentMatches(
         p.AND(p.hasTagName('dom-module'), p.NOT(p.hasTagName('template')))));
@@ -62,8 +67,11 @@ export class HtmlImportScanner implements HtmlScanner {
       const href = dom5.getAttribute(node, 'href')!;
       const importUrl = resolveUrl(document.url, href);
       imports.push(new ScannedImport(
-          type, importUrl, document.sourceRangeForNode(node)!,
-          document.sourceRangeForAttributeValue(node, 'href')!, node));
+          type,
+          importUrl,
+          document.sourceRangeForNode(node)!,
+          document.sourceRangeForAttributeValue(node, 'href')!,
+          node));
     });
     if (this._lazyEdges) {
       const edges = this._lazyEdges.get(document.url);

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -26,7 +26,8 @@ const p = dom5.predicates;
 const isJsScriptNode = p.AND(
     p.hasTagName('script'),
     p.OR(
-        p.NOT(p.hasAttr('type')), p.hasAttrValue('type', 'text/javascript'),
+        p.NOT(p.hasAttr('type')),
+        p.hasAttrValue('type', 'text/javascript'),
         p.hasAttrValue('type', 'application/javascript'),
         p.hasAttrValue('type', 'module')));
 
@@ -43,16 +44,23 @@ export class HtmlScriptScanner implements HtmlScanner {
         if (src) {
           const importUrl = resolveUrl(document.url, src);
           features.push(new ScannedScriptTagImport(
-              'html-script', importUrl, document.sourceRangeForNode(node)!,
-              document.sourceRangeForAttributeValue(node, 'src')!, node));
+              'html-script',
+              importUrl,
+              document.sourceRangeForNode(node)!,
+              document.sourceRangeForAttributeValue(node, 'src')!,
+              node));
         } else {
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const attachedCommentText = getAttachedCommentText(node) || '';
           const contents = dom5.getTextContent(node);
 
           features.push(new ScannedInlineDocument(
-              'js', contents, locationOffset, attachedCommentText,
-              document.sourceRangeForNode(node)!, node));
+              'js',
+              contents,
+              locationOffset,
+              attachedCommentText,
+              document.sourceRangeForNode(node)!,
+              node));
         }
       }
     };

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -40,8 +40,13 @@ export class ScannedScriptTagImport extends ScannedImport {
       importedDocument._addFeature(document);
       importedDocument.resolve();
       return new ScriptTagImport(
-          this.url, this.type, importedDocument, this.sourceRange,
-          this.urlSourceRange, this.astNode, this.warnings);
+          this.url,
+          this.type,
+          importedDocument,
+          this.sourceRange,
+          this.urlSourceRange,
+          this.astNode,
+          this.warnings);
     } else {
       // not found or syntax error
       return undefined;

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -27,7 +27,8 @@ const isStyleElement = p.AND(
     p.OR(p.NOT(p.hasAttr('type')), p.hasAttrValue('type', 'text/css')));
 
 const isStyleLink = p.AND(
-    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'stylesheet'),
+    p.hasTagName('link'),
+    p.hasSpaceSeparatedAttrValue('rel', 'stylesheet'),
     p.hasAttr('href'));
 
 const isStyleNode = p.OR(isStyleElement, isStyleLink);
@@ -46,15 +47,22 @@ export class HtmlStyleScanner implements HtmlScanner {
           const href = dom5.getAttribute(node, 'href')!;
           const importUrl = resolveUrl(document.url, href);
           features.push(new ScannedImport(
-              'html-style', importUrl, document.sourceRangeForNode(node)!,
-              document.sourceRangeForAttributeValue(node, 'href')!, node));
+              'html-style',
+              importUrl,
+              document.sourceRangeForNode(node)!,
+              document.sourceRangeForAttributeValue(node, 'href')!,
+              node));
         } else {
           const contents = dom5.getTextContent(node);
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const commentText = getAttachedCommentText(node) || '';
           features.push(new ScannedInlineDocument(
-              'css', contents, locationOffset, commentText,
-              document.sourceRangeForNode(node)!, node));
+              'css',
+              contents,
+              locationOffset,
+              commentText,
+              document.sourceRangeForNode(node)!,
+              node));
         }
       }
     });

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -66,7 +66,8 @@ export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
     // a visitor to break early, or to skip a subtree of the AST. We need to
     // track this ourselves because we're running all the visitors at once.
     const _shouldSkip =
-        (visitor: Visitor, callbackName: string,
+        (visitor: Visitor,
+         callbackName: string,
          nodeType: typeof __exampleNode.type) => {
           const skipRecord = this.visitorSkips.get(visitor);
           if (!skipRecord) {
@@ -91,7 +92,9 @@ export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
         };
 
     const handleVisitorResult =
-        (visitorOption: VisitorOption, callbackName: string, visitor: Visitor,
+        (visitorOption: VisitorOption,
+         callbackName: string,
+         visitor: Visitor,
          nodeType: typeof __exampleNode.type) => {
           switch (visitorOption) {
             case VisitorOption.Remove:

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -35,8 +35,11 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
         }
         const importUrl = resolveUrl(document.url, source);
         imports.push(new ScannedImport(
-            'js-import', importUrl, document.sourceRangeForNode(node)!,
-            document.sourceRangeForNode(node.source)!, node));
+            'js-import',
+            importUrl,
+            document.sourceRangeForNode(node)!,
+            document.sourceRangeForNode(node.source)!,
+            node));
       }
     });
     return imports;

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -161,8 +161,8 @@ export function hasTag(
 export function getTag(
     jsdoc: Annotation|null|undefined, tagName: string): (Tag|null);
 export function getTag(
-    jsdoc: Annotation|null|undefined, tagName: string,
-    key: string): (string|null);
+    jsdoc: Annotation|null|undefined, tagName: string, key: string): (string|
+                                                                      null);
 export function getTag(
     jsdoc: Annotation|null|undefined, tagName: string, key?: string): any {
   if (!jsdoc || !jsdoc.tags)

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -60,10 +60,14 @@ export class ScannedImport implements Resolvable {
 
   resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
-    return importedDocument &&
-        new Import(
-               this.url, this.type, importedDocument, this.sourceRange,
-               this.urlSourceRange, this.astNode, this.warnings);
+    return importedDocument && new Import(
+                                   this.url,
+                                   this.type,
+                                   importedDocument,
+                                   this.sourceRange,
+                                   this.urlSourceRange,
+                                   this.astNode,
+                                   this.warnings);
   }
 }
 

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -22,8 +22,10 @@ import {ScannedImport} from '../model/model';
 const p = dom5.predicates;
 
 const isCssImportNode = p.AND(
-    p.hasTagName('link'), p.hasSpaceSeparatedAttrValue('rel', 'import'),
-    p.hasAttr('href'), p.hasAttrValue('type', 'css'),
+    p.hasTagName('link'),
+    p.hasSpaceSeparatedAttrValue('rel', 'import'),
+    p.hasAttr('href'),
+    p.hasAttrValue('type', 'css'),
     p.parentMatches(p.hasTagName('dom-module')));
 
 export class CssImportScanner implements HtmlScanner {
@@ -38,8 +40,11 @@ export class CssImportScanner implements HtmlScanner {
         const href = dom5.getAttribute(node, 'href')!;
         const importUrl = resolveUrl(document.url, href);
         imports.push(new ScannedImport(
-            'css-import', importUrl, document.sourceRangeForNode(node)!,
-            document.sourceRangeForAttributeValue(node, 'href')!, node));
+            'css-import',
+            importUrl,
+            document.sourceRangeForNode(node)!,
+            document.sourceRangeForAttributeValue(node, 'href')!,
+            node));
       }
     });
     return imports;

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -34,9 +34,21 @@ if (Math.random() > 1000) {
 
 /** Properties on element prototypes that are purely configuration. */
 const ELEMENT_CONFIGURATION = [
-  'attached', 'attributeChanged', 'beforeRegister', 'configure', 'constructor',
-  'created', 'detached', 'enableCustomStyleProperties', 'extends',
-  'hostAttributes', 'is', 'listeners', 'mixins', 'properties', 'ready',
+  'attached',
+  'attributeChanged',
+  'beforeRegister',
+  'configure',
+  'constructor',
+  'created',
+  'detached',
+  'enableCustomStyleProperties',
+  'extends',
+  'hostAttributes',
+  'is',
+  'listeners',
+  'mixins',
+  'properties',
+  'ready',
   'registered'
 ];
 

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -44,7 +44,11 @@ export class ScannedDomModule implements Resolvable {
 
   resolve() {
     return new DomModule(
-        this.node, this.id, this.comment, this.sourceRange, this.astNode,
+        this.node,
+        this.id,
+        this.comment,
+        this.sourceRange,
+        this.astNode,
         this.warnings);
   }
 }
@@ -84,8 +88,10 @@ export class DomModuleScanner implements HtmlScanner {
     await visit((node) => {
       if (isDomModule(node)) {
         domModules.push(new ScannedDomModule(
-            dom5.getAttribute(node, 'id'), node,
-            document.sourceRangeForNode(node)!, node));
+            dom5.getAttribute(node, 'id'),
+            node,
+            document.sourceRangeForNode(node)!,
+            node));
       }
     });
     return domModules;

--- a/src/polymer/feature-scanner.ts
+++ b/src/polymer/feature-scanner.ts
@@ -26,19 +26,23 @@ export function featureScanner(document: JavaScriptDocument) {
   const features: ScannedPolymerCoreFeature[] = [];
 
   function _extractDesc(
-      feature: ScannedPolymerCoreFeature, _node: estree.CallExpression,
+      feature: ScannedPolymerCoreFeature,
+      _node: estree.CallExpression,
       parent: estree.Node) {
     feature.description = esutil.getAttachedComment(parent) || '';
   }
 
   function _extractProperties(
-      feature: ScannedPolymerCoreFeature, node: estree.CallExpression,
+      feature: ScannedPolymerCoreFeature,
+      node: estree.CallExpression,
       _parent: estree.Node) {
     const featureNode = node.arguments[0];
     if (featureNode.type !== 'ObjectExpression') {
       console.warn(
           'Expected first argument to Polymer.Base._addFeature to be an object.',
-          'Got', featureNode.type, 'instead.');
+          'Got',
+          featureNode.type,
+          'instead.');
       return;
     }
     if (!featureNode.properties) {

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -221,7 +221,8 @@ export function getFlattenedAndResolvedBehaviors(
 }
 
 function _getFlattenedAndResolvedBehaviors(
-    behaviorAssignments: ScannedBehaviorAssignment[], document: Document,
+    behaviorAssignments: ScannedBehaviorAssignment[],
+    document: Document,
     resolvedBehaviors: Set<Behavior>) {
   const warnings: Warning[] = [];
   for (const behavior of behaviorAssignments) {

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -264,7 +264,8 @@ suite('Analyzer', () => {
             ['static/dependencies/inline-and-imports.html', 'js', true],
             ['static/dependencies/subfolder/in-folder.html', 'html', false],
             [
-              'static/dependencies/subfolder/subfolder-sibling.html', 'html',
+              'static/dependencies/subfolder/subfolder-sibling.html',
+              'html',
               false
             ],
             ['static/dependencies/inline-and-imports.html', 'css', true],

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -264,8 +264,7 @@ suite('Analyzer', () => {
             ['static/dependencies/inline-and-imports.html', 'js', true],
             ['static/dependencies/subfolder/in-folder.html', 'html', false],
             [
-              'static/dependencies/subfolder/subfolder-sibling.html',
-              'html',
+              'static/dependencies/subfolder/subfolder-sibling.html', 'html',
               false
             ],
             ['static/dependencies/inline-and-imports.html', 'css', true],

--- a/src/test/editor-service/ast-from-source-position_test.ts
+++ b/src/test/editor-service/ast-from-source-position_test.ts
@@ -59,7 +59,8 @@ suite('getLocationInfoForPosition', () => {
   test('works for a closed tag with a boolean attribute', () => {
     const allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a></t>');
     assert.equal(
-        allKindsSpaceSeparated, 'text tagName tagName attribute attribute ' +
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute ' +
             'text endTag endTag endTag text');
   });
 
@@ -79,13 +80,15 @@ suite('getLocationInfoForPosition', () => {
 
     allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=""></t>');
     assert.equal(
-        allKindsSpaceSeparated, 'text tagName tagName attribute attribute ' +
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute ' +
             'attributeValue attributeValue attributeValue text ' +
             'endTag endTag endTag text');
 
     allKindsSpaceSeparated = getAllKindsSpaceSeparated('<t a=\'\'></t>');
     assert.equal(
-        allKindsSpaceSeparated, 'text tagName tagName attribute attribute ' +
+        allKindsSpaceSeparated,
+        'text tagName tagName attribute attribute ' +
             'attributeValue attributeValue attributeValue text ' +
             'endTag endTag endTag text');
   });

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -291,7 +291,8 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
     test('Get attribute completions when adding a new attribute', async() => {
       await editorService.fileChanged(indexFile, indexContents);
       const partialContents = [
-        `<behavior-test-elem >`, `<behavior-test-elem existing-attr>`,
+        `<behavior-test-elem >`,
+        `<behavior-test-elem existing-attr>`,
         `<behavior-test-elem existing-attr></behavior-test-elem>`,
         `<behavior-test-elem existing-attr></wrong-closing-tag>`
       ];

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -83,7 +83,9 @@ suite('HtmlImportScanner', () => {
 
       const features = await scanner.scan(document, visit);
       assert.deepEqual(features.map(f => f.type), [
-        'html-import', 'lazy-html-import', 'lazy-html-import',
+        'html-import',
+        'lazy-html-import',
+        'lazy-html-import',
         'lazy-html-import'
       ]);
       assert.deepEqual(

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -50,7 +50,9 @@ suite('BehaviorScanner', () => {
 
   test('Finds behavior object assignments', () => {
     assert.deepEqual(behaviorsList.map(b => b.className).sort(), [
-      'SimpleBehavior', 'AwesomeBehavior', 'Really.Really.Deep.Behavior',
+      'SimpleBehavior',
+      'AwesomeBehavior',
+      'Really.Really.Deep.Behavior',
       'CustomBehaviorList'
     ].sort());
   });
@@ -91,7 +93,9 @@ suite('BehaviorScanner', () => {
         behaviors.get('Really.Really.Deep.Behavior')!.behaviorAssignments;
     assert.deepEqual(
         childBehaviors.map((b: ScannedBehaviorAssignment) => b.name), [
-          'SimpleBehavior', 'CustomNamedBehavior', 'Really.Really.Deep.Behavior'
+          'SimpleBehavior',
+          'CustomNamedBehavior',
+          'Really.Really.Deep.Behavior'
         ]);
     assert.deepEqual(
         deepChainedBehaviors.map((b: ScannedBehaviorAssignment) => b.name),

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -106,8 +106,14 @@ suite('PolymerElementScanner', () => {
           ]]);
 
       assert.deepEqual(features[0].properties.map(p => [p.name, p.type]), [
-        ['a', 'boolean'], ['b', 'string'], ['c', 'number'], ['d', 'number'],
-        ['e', 'string'], ['f', 'Object'], ['g', undefined], ['all', 'Object']
+        ['a', 'boolean'],
+        ['b', 'string'],
+        ['c', 'number'],
+        ['d', 'number'],
+        ['e', 'string'],
+        ['f', 'Object'],
+        ['g', undefined],
+        ['all', 'Object']
       ]);
 
       assert.deepEqual(

--- a/src/test/vanilla-custom-elements/element-scanner_test.ts
+++ b/src/test/vanilla-custom-elements/element-scanner_test.ts
@@ -51,13 +51,19 @@ suite('VanillaElementScanner', () => {
 
   test('Finds elements', () => {
     assert.deepEqual(elementsList.map(e => e.tagName).sort(), [
-      'anonymous-class', 'class-declaration', 'class-expression',
-      'vanilla-with-observed-attributes', 'register-before-declaration',
+      'anonymous-class',
+      'class-declaration',
+      'class-expression',
+      'vanilla-with-observed-attributes',
+      'register-before-declaration',
       'register-before-expression'
     ].sort());
     assert.deepEqual(elementsList.map(e => e.className).sort(), [
-      undefined, 'ClassDeclaration', 'ClassExpression',
-      'WithObservedAttributes', 'RegisterBeforeDeclaration',
+      undefined,
+      'ClassDeclaration',
+      'ClassExpression',
+      'WithObservedAttributes',
+      'RegisterBeforeDeclaration',
       'RegisterBeforeExpression'
     ].sort());
     assert.deepEqual(elementsList.map(e => e.superClass).sort(), [


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has not been updated, internal change

The formatting options introduced with #384 cause clang-format to produce invalid code with async methods whose signatures are a certain length. Specifically `BinPackParameters: false` will turn

```typescript
class C {
  async method(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, b, c) {
  }
}
```

into

```typescript
class C {
  async
  method(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, b, c) {
  }
}
```

which is semantically different code. I would report a bug upstream but account creation in their bug tracker is disabled: https://llvm.org/bugs/enter_bug.cgi

Given this, I'm leaning towards the idea that future changes that affect formatting should also include the results of `npm run format`. There will be merge conflicts, but resolving them with the `ours` strategy and then following with `npm run format` should make them trivial.