### PR TITLE
Properly handle 'listeners' property when scanning polymer element...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+### Added
+* [Polymer] Extract 'listeners' from 1.0-style declarations.
+
 ## [2.0.0-alpha.19] - 2016-12-12
 
 ### Added

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -74,10 +74,11 @@ export function declarationPropertyHandlers(
         return;
       }
       for (let prop of node.properties) {
-        if (prop.key.type !== 'Literal' || prop.value.type !== 'Literal') {
-            continue;
+        if (prop.key.type !== 'Literal' || typeof prop.key.value !== 'string' ||
+            prop.value.type !== 'Literal' || typeof prop.value.value !== 'string') {
+          continue;
         }
-        declaration.listeners.push({event: <string>prop.key.value, handler: <string>prop.value.value});
+        declaration.listeners.push({event: prop.key.value, handler: prop.value.value});
       }
     }
   };

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -68,6 +68,17 @@ export function declarationPropertyHandlers(
         }
         declaration.observers.push({javascriptNode: element, expression: v});
       }
+    },
+    listeners(node: estree.Node) {
+      if (node.type !== 'ObjectExpression') {
+        return;
+      }
+      for (let prop of node.properties) {
+        if (prop.key.type !== 'Literal' || prop.value.type !== 'Literal') {
+            continue;
+        }
+        declaration.listeners.push({event: <string>prop.key.value, handler: <string>prop.value.value});
+      }
     }
   };
 }

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -19,6 +19,7 @@ import {JavaScriptDocument} from '../javascript/javascript-document';
 
 import {analyzeProperties} from './analyze-properties';
 import {ScannedPolymerElement} from './polymer-element';
+import {Severity} from '../warning/warning';
 
 export type PropertyHandlers = {
   [key: string]: (node: estree.Node) => void
@@ -71,11 +72,23 @@ export function declarationPropertyHandlers(
     },
     listeners(node: estree.Node) {
       if (node.type !== 'ObjectExpression') {
+        declaration.warnings.push({
+          code: 'invalid-listeners-declaration',
+          message: '`listeners` property should be an object expression',
+          severity: Severity.ERROR,
+          sourceRange: document.sourceRangeForNode(node)!
+        });
         return;
       }
       for (let prop of node.properties) {
         if (prop.key.type !== 'Literal' || typeof prop.key.value !== 'string' ||
             prop.value.type !== 'Literal' || typeof prop.value.value !== 'string') {
+          declaration.warnings.push({
+            code: 'invalid-listeners-declaration',
+            message: 'handler value should be a string',
+            severity: Severity.ERROR,
+            sourceRange: document.sourceRangeForNode(prop.value)!
+          });
           continue;
         }
         declaration.listeners.push({event: prop.key.value, handler: prop.value.value});

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -147,6 +147,10 @@ export class PolymerElement extends Element {
     javascriptNode: estree.Expression | estree.SpreadElement,
     expression: LiteralValue
   }[];
+  listeners: {
+    event: string,
+    handler: string
+  }[];
   behaviorAssignments: ScannedBehaviorAssignment[];
   domModule?: dom5.Node;
   scriptElement?: dom5.Node;

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -60,6 +60,10 @@ export interface Options {
     javascriptNode: estree.Expression | estree.SpreadElement,
     expression: LiteralValue
   }[];
+  listeners?: {
+    event: string,
+    handler: string
+  }[];
   behaviors?: ScannedBehaviorAssignment[];
 
   demos?: {desc: string; path: string}[];
@@ -78,6 +82,10 @@ export class ScannedPolymerElement extends ScannedElement {
     javascriptNode: estree.Expression | estree.SpreadElement,
     expression: LiteralValue
   }[] = [];
+  listeners: {
+    event: string,
+    handler: string
+  }[];
   behaviorAssignments: ScannedBehaviorAssignment[] = [];
   // FIXME(rictic): domModule and scriptElement aren't known at a file local
   //     level. Remove them here, they should only exist on PolymerElement.
@@ -96,6 +104,7 @@ export class ScannedPolymerElement extends ScannedElement {
     if (options.properties) {
       options.properties.forEach((p) => this.addProperty(p));
     }
+    this.listeners = this.listeners || [];
   }
 
   addProperty(prop: ScannedPolymerProperty) {

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -85,7 +85,7 @@ export class ScannedPolymerElement extends ScannedElement {
   listeners: {
     event: string,
     handler: string
-  }[];
+  }[] = [];
   behaviorAssignments: ScannedBehaviorAssignment[] = [];
   // FIXME(rictic): domModule and scriptElement aren't known at a file local
   //     level. Remove them here, they should only exist on PolymerElement.
@@ -104,7 +104,6 @@ export class ScannedPolymerElement extends ScannedElement {
     if (options.properties) {
       options.properties.forEach((p) => this.addProperty(p));
     }
-    this.listeners = this.listeners || [];
   }
 
   addProperty(prop: ScannedPolymerProperty) {

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+
 import {assert} from 'chai';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
@@ -73,7 +75,10 @@ suite('PolymerElementScanner', () => {
         observers: [
           '_anObserver()',
           '_anotherObserver()'
-        ]
+        ],
+        listeners: {
+          'event-a': '_handleA'
+        }
       });
       Polymer({ is: 'x-bar' });`;
 
@@ -143,6 +148,10 @@ suite('PolymerElementScanner', () => {
       assert.deepEqual(
           features[0].properties.filter(p => p.notify).map(p => p.name),
           ['e', 'all']);
+
+      assert.deepEqual(features[0].listeners, [
+        {event: 'event-a', handler: '_handleA'}
+      ]);
     });
   });
 

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -77,7 +77,8 @@ suite('PolymerElementScanner', () => {
           '_anotherObserver()'
         ],
         listeners: {
-          'event-a': '_handleA'
+          'event-a': '_handleA',
+          'event-b': '_handleB'
         }
       });
       Polymer({ is: 'x-bar' });`;
@@ -150,7 +151,8 @@ suite('PolymerElementScanner', () => {
           ['e', 'all']);
 
       assert.deepEqual(features[0].listeners, [
-        {event: 'event-a', handler: '_handleA'}
+        {event: 'event-a', handler: '_handleA'},
+        {event: 'event-b', handler: '_handleB'}
       ]);
     });
   });

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -78,10 +78,14 @@ suite('PolymerElementScanner', () => {
         ],
         listeners: {
           'event-a': '_handleA',
-          'event-b': '_handleB'
+          'event-b': '_handleB',
+          'event-c': _handleC
         }
       });
-      Polymer({ is: 'x-bar' });`;
+      Polymer({
+        is: 'x-bar',
+        listeners: []
+      });`;
 
       const document = new JavaScriptParser({
                          sourceType: 'script'
@@ -154,6 +158,11 @@ suite('PolymerElementScanner', () => {
         {event: 'event-a', handler: '_handleA'},
         {event: 'event-b', handler: '_handleB'}
       ]);
+
+      // Non-string handler value on `listeners`
+      assert.equal(features[0].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 1);
+      // Non-object literal for `listeners`
+      assert.equal(features[1].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 1);
     });
   });
 

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -78,8 +78,9 @@ suite('PolymerElementScanner', () => {
         ],
         listeners: {
           'event-a': '_handleA',
-          'event-b': '_handleB',
-          'event-c': _handleC
+          eventb: '_handleB',
+          'event-c': _handleC,
+          [['event', 'd'].join('-')]: '_handleD'
         }
       });
       Polymer({
@@ -156,12 +157,12 @@ suite('PolymerElementScanner', () => {
 
       assert.deepEqual(features[0].listeners, [
         {event: 'event-a', handler: '_handleA'},
-        {event: 'event-b', handler: '_handleB'}
+        {event: 'eventb', handler: '_handleB'}
       ]);
 
-      // Non-string handler value on `listeners`
-      assert.equal(features[0].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 1);
-      // Non-object literal for `listeners`
+      // Skip not statically analizable entries without emitting a warning
+      assert.equal(features[0].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 0);
+      // Emit warning for non-object `listeners` literal
       assert.equal(features[1].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 1);
     });
   });


### PR DESCRIPTION
... as described [here](https://www.polymer-project.org/1.0/docs/devguide/events#event-listeners). Before, it was treated like any other property. Fixes https://github.com/Polymer/polymer-analyzer/issues/285

