### PR TITLE
Extract pseudo elements from comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * [Polymer] Extract 'listeners' from 1.0-style declarations.
-* [Polymer] Extract pseudo elements declared via `@pseudoElement` tag
+* [Polymer] Extract pseudo elements from HTML comments
 
 ### Fixed
 * Fixed a class of race conditions and cache invalidation errors that can occur when there are concurrent analysis runs and edits to files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * [Polymer] Extract 'listeners' from 1.0-style declarations.
+* [Polymer] Extract pseudo elements declared via `@pseudoElement` tag
 
 ### Fixed
 * Fixed a class of race conditions and cache invalidation errors that can occur when there are concurrent analysis runs and edits to files.

--- a/src/core/analyzer-cache-context.ts
+++ b/src/core/analyzer-cache-context.ts
@@ -31,6 +31,7 @@ import {BehaviorScanner} from '../polymer/behavior-scanner';
 import {CssImportScanner} from '../polymer/css-import-scanner';
 import {DomModuleScanner} from '../polymer/dom-module-scanner';
 import {PolymerElementScanner} from '../polymer/polymer-element-scanner';
+import {PseudoElementScanner} from '../polymer/pseudo-element-scanner';
 import {scan} from '../scanning/scan';
 import {Scanner} from '../scanning/scanner';
 import {UrlLoader} from '../url-loader/url-loader';
@@ -80,7 +81,8 @@ export class AnalyzerCacheContext {
           new HtmlStyleScanner(),
           new DomModuleScanner(),
           new CssImportScanner(),
-          new HtmlCustomElementReferenceScanner()
+          new HtmlCustomElementReferenceScanner(),
+          new PseudoElementScanner()
         ]
       ],
       [

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -285,27 +285,3 @@ export function cleanElement(element: ScannedPolymerElement) {
 function cleanProperty(property: ScannedProperty) {
   clean(property);
 }
-
-/**
- * Parse elements defined only in comments.
- */
-export function parsePseudoElements(comments: string[]):
-    ScannedPolymerElement[] {
-  const elements: ScannedPolymerElement[] = [];
-  comments.forEach(function(comment) {
-    const parsedJsdoc = jsdoc.parseJsdoc(comment);
-    const pseudoTag = jsdoc.getTag(parsedJsdoc, 'pseudoElement', 'name');
-    if (pseudoTag) {
-      let element = new ScannedPolymerElement({
-        tagName: pseudoTag,
-        jsdoc: {description: parsedJsdoc.description, tags: parsedJsdoc.tags},
-        properties: [],
-        description: parsedJsdoc.description,
-        sourceRange: undefined
-      });
-      annotateElementHeader(element);
-      elements.push(element);
-    }
-  });
-  return elements;
-}

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -91,6 +91,8 @@ export class ScannedPolymerElement extends ScannedElement {
   //     level. Remove them here, they should only exist on PolymerElement.
   domModule?: dom5.Node;
   scriptElement?: dom5.Node;
+  // Indicates if an element is a pseudo element
+  pseudo: boolean = false;
 
   abstract?: boolean;
 
@@ -221,6 +223,10 @@ function resolveElement(
     clone.description = scannedElement.description || domModule.comment || '';
     clone.domModule = domModule.node;
     clone.slots = domModule.slots.slice();
+  }
+
+  if (scannedElement.pseudo) {
+    clone.kinds.add('pseudo-element');
   }
 
   return clone;

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as dom5 from 'dom5';
+import {ASTNode} from 'parse5';
+
+import * as jsdoc from '../javascript/jsdoc';
+import {annotateElementHeader} from './docs';
+
+import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
+import {HtmlScanner} from '../html/html-scanner';
+import {ScannedPolymerElement} from './polymer-element';
+
+export class PseudoElementScanner implements HtmlScanner {
+  async scan(
+      document: ParsedHtmlDocument,
+      visit: (visitor: HtmlVisitor) => Promise<void>):
+      Promise<ScannedPolymerElement[]> {
+    let elements: ScannedPolymerElement[] = [];
+
+    await visit((node: ASTNode) => {
+      if (dom5.isCommentNode(node) && node.data && node.data.includes('@pseudoElement')) {
+        const parsedJsdoc = jsdoc.parseJsdoc(node.data);
+        const pseudoTag = jsdoc.getTag(parsedJsdoc, 'pseudoElement', 'name');
+        if (pseudoTag) {
+          let element = new ScannedPolymerElement({
+            tagName: pseudoTag,
+            jsdoc: {description: parsedJsdoc.description, tags: parsedJsdoc.tags},
+            properties: [],
+            description: parsedJsdoc.description,
+            sourceRange: document.sourceRangeForNode(node)
+          });
+          annotateElementHeader(element);
+          elements.push(element);
+        }
+      }
+    });
+    return elements;
+  }
+}

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -46,6 +46,7 @@ export class PseudoElementScanner implements HtmlScanner {
             description: parsedJsdoc.description,
             sourceRange: document.sourceRangeForNode(node)
           });
+          element.pseudo = true;
           annotateElementHeader(element);
           elements.push(element);
         }

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -22,6 +22,11 @@ import {HtmlVisitor, ParsedHtmlDocument} from '../html/html-document';
 import {HtmlScanner} from '../html/html-scanner';
 import {ScannedPolymerElement} from './polymer-element';
 
+/**
+ * A Polymer pseudo-element is an element that is declared in an unusual way, such
+ * that the analyzer couldn't normally analyze it, so instead it is declared in
+ * comments.
+ */
 export class PseudoElementScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,

--- a/src/test/polymer/pseudo-element-scanner_test.ts
+++ b/src/test/polymer/pseudo-element-scanner_test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+
+import {HtmlVisitor} from '../../html/html-document';
+import {HtmlParser} from '../../html/html-parser';
+import {PseudoElementScanner} from '../../polymer/pseudo-element-scanner';
+
+suite('PseudoElementScanner', () => {
+
+  suite('scan()', () => {
+    let scanner: PseudoElementScanner;
+
+    setup(() => {
+      scanner = new PseudoElementScanner();
+    });
+
+    test('finds pseudo elements in html comments ', async() => {
+      const desc = `This is a pseudo element`;
+      const contents = `<html><head></head><body>
+          <!--
+          ${desc}
+          @pseudoElement x-foo
+          @demo demo/index.html
+          -->
+        </body>
+        </html>`;
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const features = await scanner.scan(document, visit);
+      assert.equal(features.length, 1);
+      assert.equal(features[0].tagName, 'x-foo');
+      assert.equal(features[0].description.trim(), desc);
+      assert.deepEqual(features[0].demos, [{desc: 'demo', path: 'demo/index.html'}]);
+    });
+
+  });
+
+});

--- a/src/test/polymer/pseudo-element-scanner_test.ts
+++ b/src/test/polymer/pseudo-element-scanner_test.ts
@@ -43,6 +43,7 @@ suite('PseudoElementScanner', () => {
       const features = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.equal(features[0].tagName, 'x-foo');
+      assert(features[0].pseudo);
       assert.equal(features[0].description.trim(), desc);
       assert.deepEqual(features[0].demos, [{desc: 'demo', path: 'demo/index.html'}]);
     });


### PR DESCRIPTION
Adds support for extracting pseudo elements declared in comments via the `@pseudoElement` tag. (partially) fixes https://github.com/Polymer/polymer-analyzer/issues/187

Some notes:

* Only works for HTML comments for now. If you guys are happy with this, I'll add support for javascript comments as well.
* Right now the scanner extracts `ScannedPolymerElement`. We'll probably want to at least add a `pseudo` flag to mark elements as pseudo elements but a separate feature would probably be better. Maybe extend PolymerElement and add something like `pseudo-element` to the `kinds` set?
* I saw that there is already a [parsePseudoElements](https://github.com/Polymer/polymer-analyzer/blob/master/src/polymer/docs.ts#L292) function but it doesn't seem to be used anywhere yet. I copy/pasted some of the code instead of using it directly since it didn't support extracting the source range. Not sure what's the deal with that function though.