### PR TITLE
Manage async work caching in a class.

### DIFF
--- a/src/core/analysis-cache.ts
+++ b/src/core/analysis-cache.ts
@@ -39,6 +39,10 @@ export class AnalysisCache {
    */
   dependenciesScanned: AsyncWorkCache<string, void>;
 
+  /**
+   * TODO(rictic): These synchronous caches need to be kept in sync with their
+   *     async work cache analogues above.
+   */
   scannedDocuments: Map<string, ScannedDocument>;
   analyzedDocuments: Map<string, Document>;
 
@@ -100,8 +104,7 @@ export class AnalysisCache {
       // definite, and not invalidated.
       newCache.analyzedDocumentPromises.clear();
       for (const keyValue of newCache.analyzedDocuments) {
-        newCache.analyzedDocumentPromises.set(
-            keyValue[0], Promise.resolve(keyValue[1]));
+        newCache.analyzedDocumentPromises.set(keyValue[0], keyValue[1]);
       }
     }
 

--- a/src/core/analysis-cache.ts
+++ b/src/core/analysis-cache.ts
@@ -57,16 +57,15 @@ export class AnalysisCache {
    */
   constructor(from?: AnalysisCache, newDependencyGraph?: DependencyGraph) {
     const f: Partial<AnalysisCache> = from || {};
-    this.parsedDocumentPromises =
-        shallowCopyAsyncWorkCache(f.parsedDocumentPromises);
+    this.parsedDocumentPromises = new AsyncWorkCache(f.parsedDocumentPromises);
     this.scannedDocumentPromises =
-        shallowCopyAsyncWorkCache(f.scannedDocumentPromises);
+        new AsyncWorkCache(f.scannedDocumentPromises);
     this.analyzedDocumentPromises =
-        shallowCopyAsyncWorkCache(f.analyzedDocumentPromises);
-    this.dependenciesScanned = shallowCopyAsyncWorkCache(f.dependenciesScanned);
+        new AsyncWorkCache(f.analyzedDocumentPromises);
+    this.dependenciesScanned = new AsyncWorkCache(f.dependenciesScanned);
 
-    this.scannedDocuments = shallowCopyMap(f.scannedDocuments);
-    this.analyzedDocuments = shallowCopyMap(f.analyzedDocuments);
+    this.scannedDocuments = new Map(f.scannedDocuments!);
+    this.analyzedDocuments = new Map(f.analyzedDocuments!);
     this.dependencyGraph = newDependencyGraph || new DependencyGraph();
   }
 
@@ -110,18 +109,4 @@ export class AnalysisCache {
 
     return newCache;
   }
-}
-
-function shallowCopyMap<K, V>(from?: Map<K, V>) {
-  if (from) {
-    return new Map(from);
-  }
-  return new Map();
-}
-
-function shallowCopyAsyncWorkCache<K, V>(from?: AsyncWorkCache<K, V>) {
-  if (from) {
-    return new AsyncWorkCache<K, V>(from);
-  }
-  return new AsyncWorkCache<K, V>();
 }

--- a/src/core/async-work-cache.ts
+++ b/src/core/async-work-cache.ts
@@ -15,7 +15,16 @@
 /**
  * A map from keys to promises of values. Used for caching asynchronous work.
  */
-export class AsyncWorkCache<K, V> extends Map<K, Promise<V>> {
+export class AsyncWorkCache<K, V> {
+  private _keyToResultMap: Map<K, Promise<V>>;
+  constructor(from?: AsyncWorkCache<K, V>) {
+    if (from) {
+      this._keyToResultMap = new Map(from._keyToResultMap);
+    } else {
+      this._keyToResultMap = new Map();
+    }
+  }
+
   /**
    * If work has already begun to compute the given key, return a promise for
    * the result of that work.
@@ -27,7 +36,7 @@ export class AsyncWorkCache<K, V> extends Map<K, Promise<V>> {
    * recursively.
    */
   async getOrCompute(key: K, compute: () => Promise<V>) {
-    const cachedResult = this.get(key);
+    const cachedResult = this._keyToResultMap.get(key);
     if (cachedResult) {
       return cachedResult;
     }
@@ -37,7 +46,23 @@ export class AsyncWorkCache<K, V> extends Map<K, Promise<V>> {
       await Promise.resolve();
       return compute();
     })();
-    this.set(key, promise);
+    this._keyToResultMap.set(key, promise);
     return promise;
+  }
+
+  delete (key: K) {
+    this._keyToResultMap.delete(key);
+  }
+
+  clear() {
+    this._keyToResultMap.clear();
+  }
+
+  set(key: K, value: V) {
+    this._keyToResultMap.set(key, Promise.resolve(value));
+  }
+
+  has(key: K) {
+    return this._keyToResultMap.has(key);
   }
 }

--- a/src/core/async-work-cache.ts
+++ b/src/core/async-work-cache.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * A map from keys to promises of values. Used for caching asynchronous work.
+ */
+export class AsyncWorkCache<K, V> extends Map<K, Promise<V>> {
+  /**
+   * If work has already begun to compute the given key, return a promise for
+   * the result of that work.
+   *
+   * If not, compute it with the given function.
+   *
+   * This method ensures that we will only try to compute the value for `key`
+   * once, no matter how often or with what timing getOrCompute is called, even
+   * recursively.
+   */
+  async getOrCompute(key: K, compute: () => Promise<V>) {
+    const cachedResult = this.get(key);
+    if (cachedResult) {
+      return cachedResult;
+    }
+    const promise = (async() => {
+      // Make sure we wait and return a Promise before doing any work, so that
+      // the Promise is cached before control flow enters compute().
+      await Promise.resolve();
+      return compute();
+    })();
+    this.set(key, promise);
+    return promise;
+  }
+}

--- a/src/test/core/analysis-cache_test.ts
+++ b/src/test/core/analysis-cache_test.ts
@@ -23,13 +23,10 @@ suite('AnalysisCache', () => {
 
   function addFakeDocumentToCache(
       cache: AnalysisCache, path: string, dependencies: string[]) {
-    cache.parsedDocumentPromises.set(
-        path, Promise.resolve(`parsed ${path} promise` as any));
-    cache.scannedDocumentPromises.set(
-        path, Promise.resolve(`scanned ${path} promise` as any));
-    cache.analyzedDocumentPromises.set(
-        path, Promise.resolve(`analyzed ${path} promise` as any));
-    cache.dependenciesScanned.set(path, Promise.resolve());
+    cache.parsedDocumentPromises.set(path, `parsed ${path} promise` as any);
+    cache.scannedDocumentPromises.set(path, `scanned ${path} promise` as any);
+    cache.analyzedDocumentPromises.set(path, `analyzed ${path} promise` as any);
+    cache.dependenciesScanned.set(path, undefined);
     cache.scannedDocuments.set(path, `scanned ${path}` as any);
     cache.analyzedDocuments.set(path, `analyzed ${path}` as any);
     cache.dependencyGraph.addDependenciesOf(path, dependencies);
@@ -37,11 +34,14 @@ suite('AnalysisCache', () => {
 
   async function assertHasDocument(cache: AnalysisCache, path: string) {
     assert.equal(
-        await cache.parsedDocumentPromises.get(path), `parsed ${path} promise`);
+        await cache.parsedDocumentPromises.getOrCompute(path, null as any),
+        `parsed ${path} promise`);
     assert.equal(
-        await cache.scannedDocumentPromises.get(path),
+        await cache.scannedDocumentPromises.getOrCompute(path, null as any),
         `scanned ${path} promise`);
-    assert.equal(await cache.dependenciesScanned.get(path), undefined);
+    assert.equal(
+        await cache.dependenciesScanned.getOrCompute(path, null as any),
+        undefined);
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.equal(cache.analyzedDocuments.get(path), `analyzed ${path}`);
@@ -59,9 +59,10 @@ suite('AnalysisCache', () => {
   async function assertDocumentScannedButNotResolved(
       cache: AnalysisCache, path: string) {
     assert.equal(
-        await cache.parsedDocumentPromises.get(path), `parsed ${path} promise`);
+        await cache.parsedDocumentPromises.getOrCompute(path, null as any),
+        `parsed ${path} promise`);
     assert.equal(
-        await cache.scannedDocumentPromises.get(path),
+        await cache.scannedDocumentPromises.getOrCompute(path, null as any),
         `scanned ${path} promise`);
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.isFalse(cache.analyzedDocuments.has(path));
@@ -85,7 +86,8 @@ suite('AnalysisCache', () => {
     // The promise of unrelated.html's result has been turned into
     // a Promise.resolve() of its non-promise cache.
     assert.equal(
-        await forkedCache.analyzedDocumentPromises.get('unrelated.html'),
+        await forkedCache.analyzedDocumentPromises.getOrCompute(
+            'unrelated.html', null as any),
         `analyzed unrelated.html`);
   });
 


### PR DESCRIPTION
This lets us remove the difficult-to-reason-about code (including the IIAFE with the immediate `await Promise.resolve()`) into one place where it can declare its invariants and be better maintained.

 - [x] CHANGELOG.md has been not been updated, this is an internal noop refactoring.