### PR TITLE
Fix an issue with parallel analysis of mutually importing documents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+* Fix a deadlock when there are concurrent analysis runs of cyclic graphs.
+
 ## [2.0.0-alpha.20] - 2016-12-19
 
 ### Added
@@ -20,8 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [Polymer] Extract pseudo elements from HTML comments
 
 ### Fixed
-* Fixed a class of race conditions and cache invalidation errors that can occur when there are parallel analysis runs and edits to files.
-* Fixed a deadlock when there are parallel analysis runs of cyclic graphs.
+* Fix a class of race conditions and cache invalidation errors that can occur when there are concurrent analysis runs and edits to files.
+
 
 ## [2.0.0-alpha.19] - 2016-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [Polymer] Extract pseudo elements from HTML comments
 
 ### Fixed
-* Fixed a class of race conditions and cache invalidation errors that can occur when there are concurrent analysis runs and edits to files.
-
+* Fixed a class of race conditions and cache invalidation errors that can occur when there are parallel analysis runs and edits to files.
+* Fixed a deadlock when there are parallel analysis runs of cyclic graphs.
 
 ## [2.0.0-alpha.19] - 2016-12-12
 

--- a/src/core/analysis-cache.ts
+++ b/src/core/analysis-cache.ts
@@ -29,17 +29,6 @@ export class AnalysisCache {
   analyzedDocumentPromises: AsyncWorkCache<string, Document>;
 
   /**
-   * This is a map from a resolved url to a promise that will resolve when
-   * that document's dependencies have been scanned.
-   *
-   * We need to keep track of this separate from just the scanned document
-   * promise because when one of a document's transitive dependencies changes,
-   * and then analysis of the document is requested, we shouldn't need to rescan
-   * the document itself, but we do need to rescan its dependencies.
-   */
-  dependenciesScanned: AsyncWorkCache<string, void>;
-
-  /**
    * TODO(rictic): These synchronous caches need to be kept in sync with their
    *     async work cache analogues above.
    */
@@ -62,7 +51,6 @@ export class AnalysisCache {
         new AsyncWorkCache(f.scannedDocumentPromises);
     this.analyzedDocumentPromises =
         new AsyncWorkCache(f.analyzedDocumentPromises);
-    this.dependenciesScanned = new AsyncWorkCache(f.dependenciesScanned);
 
     this.scannedDocuments = new Map(f.scannedDocuments!);
     this.analyzedDocuments = new Map(f.analyzedDocuments!);
@@ -84,7 +72,6 @@ export class AnalysisCache {
       const dependants = this.dependencyGraph.getAllDependantsOf(path);
       newCache.parsedDocumentPromises.delete(path);
       newCache.scannedDocumentPromises.delete(path);
-      newCache.dependenciesScanned.delete(path);
       newCache.scannedDocuments.delete(path);
       newCache.analyzedDocuments.delete(path);
 
@@ -93,7 +80,6 @@ export class AnalysisCache {
       // which transitively import the changed document. We also need to mark
       // all of those docs as needing to rescan their dependencies.
       for (const partiallyInvalidatedPath of dependants) {
-        newCache.dependenciesScanned.delete(partiallyInvalidatedPath);
         newCache.analyzedDocuments.delete(partiallyInvalidatedPath);
       }
 

--- a/src/core/analyzer-cache-context.ts
+++ b/src/core/analyzer-cache-context.ts
@@ -114,7 +114,6 @@ export class AnalyzerCacheContext {
     return this._fork(newCache);
   }
 
-
   /**
    * Implements Analyzer#analyze, see its docs.
    */
@@ -127,34 +126,14 @@ export class AnalyzerCacheContext {
               this._telemetryTracker.start('analyze: make document', url);
           const scannedDocument = await this._scan(resolvedUrl, contents);
           if (scannedDocument === 'visited') {
-        throw new Error(
+            throw new Error(
             `This should not happen. Got a cycle of length zero(!) scanning ${url
             }`);
           }
-          const document = this._makeDocument(scannedDocument);
+          const document = this._getDocument(scannedDocument.url);
           doneTiming();
           return document;
         });
-  }
-
-  /**
-   * Constructs a new analyzed Document and adds it to the analyzed Document
-   * cache.
-   */
-  private _makeDocument(scannedDocument: ScannedDocument): Document {
-    const resolvedUrl = scannedDocument.url;
-
-    if (this._cache.analyzedDocuments.has(resolvedUrl)) {
-      throw new Error(`Internal error: document ${resolvedUrl} already exists`);
-    }
-
-    const document = new Document(scannedDocument, this);
-    this._cache.analyzedDocuments.set(resolvedUrl, document);
-    this._cache.analyzedDocumentPromises.getOrCompute(
-        resolvedUrl, async() => document);
-
-    document.resolve();
-    return document;
   }
 
   /**
@@ -167,12 +146,22 @@ export class AnalyzerCacheContext {
    */
   _getDocument(url: string): Document|undefined {
     const resolvedUrl = this._resolveUrl(url);
-    const document = this._cache.analyzedDocuments.get(resolvedUrl);
-    if (document) {
-      return document;
+    const cachedResult = this._cache.analyzedDocuments.get(resolvedUrl);
+    if (cachedResult) {
+      return cachedResult;
     }
     const scannedDocument = this._cache.scannedDocuments.get(resolvedUrl);
-    return scannedDocument && this._makeDocument(scannedDocument);
+    if (!scannedDocument) {
+      return;
+    }
+
+    const document = new Document(scannedDocument, this);
+    this._cache.analyzedDocuments.set(resolvedUrl, document);
+    this._cache.analyzedDocumentPromises.getOrCompute(
+        resolvedUrl, async() => document);
+
+    document.resolve();
+    return document;
   }
 
   /**
@@ -235,16 +224,7 @@ export class AnalyzerCacheContext {
               return this._scanDocument(parsedDoc, actualVisited);
             });
 
-    /**
-     * We cache the act of scanning dependencies separately from the act of
-     * scanning a single file because while scanning is purely local to the
-     * file, we need to rescan a file's transitive dependencies before
-     * resolving if any of them have changed.
-     */
-    await this._cache.dependenciesScanned.getOrCompute(
-        scannedDocument.url, async() => {
-          await this._scanImports(scannedDocument, actualVisited);
-        });
+    await this._scanImports(scannedDocument, actualVisited);
     return scannedDocument;
   }
 

--- a/src/core/analyzer-cache-context.ts
+++ b/src/core/analyzer-cache-context.ts
@@ -224,7 +224,10 @@ export class AnalyzerCacheContext {
               return this._scanDocument(parsedDoc, actualVisited);
             });
 
-    await this._scanImports(scannedDocument, actualVisited);
+    if (!this._cache.dependenciesScannedOf.has(scannedDocument.url)) {
+      await this._scanImports(scannedDocument, actualVisited);
+      this._cache.dependenciesScannedOf.add(scannedDocument.url);
+    }
     return scannedDocument;
   }
 

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -350,6 +350,16 @@ suite('Analyzer', () => {
           ['static/circular/mutual-b.html', 'static/circular/mutual-a.html']);
     });
 
+    test(
+        'handles parallel analyses of mutually recursive documents',
+        async() => {
+          // At one point this deadlocked, or threw a _makeDocument error.
+          await Promise.all([
+            analyzer.analyze('static/circular/mutual-a.html'),
+            analyzer.analyze('static/circular/mutual-b.html')
+          ]);
+        });
+
     test('handles a document importing itself', async() => {
       const document =
           await analyzer.analyze('static/circular/self-import.html');

--- a/src/test/core/analysis-cache_test.ts
+++ b/src/test/core/analysis-cache_test.ts
@@ -26,6 +26,7 @@ suite('AnalysisCache', () => {
     cache.parsedDocumentPromises.set(path, `parsed ${path} promise` as any);
     cache.scannedDocumentPromises.set(path, `scanned ${path} promise` as any);
     cache.analyzedDocumentPromises.set(path, `analyzed ${path} promise` as any);
+    cache.dependenciesScannedOf.add(path);
     cache.scannedDocuments.set(path, `scanned ${path}` as any);
     cache.analyzedDocuments.set(path, `analyzed ${path}` as any);
     cache.dependencyGraph.addDependenciesOf(path, dependencies);
@@ -38,6 +39,7 @@ suite('AnalysisCache', () => {
     assert.equal(
         await cache.scannedDocumentPromises.getOrCompute(path, null as any),
         `scanned ${path} promise`);
+    assert.isTrue(cache.dependenciesScannedOf.has(path));
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.equal(cache.analyzedDocuments.get(path), `analyzed ${path}`);
@@ -46,6 +48,7 @@ suite('AnalysisCache', () => {
   function assertNotHasDocument(cache: AnalysisCache, path: string) {
     assert.isFalse(cache.parsedDocumentPromises.has(path));
     assert.isFalse(cache.scannedDocumentPromises.has(path));
+    assert.isFalse(cache.dependenciesScannedOf.has(path));
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.isFalse(cache.scannedDocuments.has(path));
     assert.isFalse(cache.analyzedDocuments.has(path));

--- a/src/test/core/analysis-cache_test.ts
+++ b/src/test/core/analysis-cache_test.ts
@@ -26,7 +26,6 @@ suite('AnalysisCache', () => {
     cache.parsedDocumentPromises.set(path, `parsed ${path} promise` as any);
     cache.scannedDocumentPromises.set(path, `scanned ${path} promise` as any);
     cache.analyzedDocumentPromises.set(path, `analyzed ${path} promise` as any);
-    cache.dependenciesScanned.set(path, undefined);
     cache.scannedDocuments.set(path, `scanned ${path}` as any);
     cache.analyzedDocuments.set(path, `analyzed ${path}` as any);
     cache.dependencyGraph.addDependenciesOf(path, dependencies);
@@ -39,9 +38,6 @@ suite('AnalysisCache', () => {
     assert.equal(
         await cache.scannedDocumentPromises.getOrCompute(path, null as any),
         `scanned ${path} promise`);
-    assert.equal(
-        await cache.dependenciesScanned.getOrCompute(path, null as any),
-        undefined);
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.equal(cache.analyzedDocuments.get(path), `analyzed ${path}`);
@@ -50,7 +46,6 @@ suite('AnalysisCache', () => {
   function assertNotHasDocument(cache: AnalysisCache, path: string) {
     assert.isFalse(cache.parsedDocumentPromises.has(path));
     assert.isFalse(cache.scannedDocumentPromises.has(path));
-    assert.isFalse(cache.dependenciesScanned.has(path));
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.isFalse(cache.scannedDocuments.has(path));
     assert.isFalse(cache.analyzedDocuments.has(path));
@@ -67,7 +62,6 @@ suite('AnalysisCache', () => {
     assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
     assert.isFalse(cache.analyzedDocuments.has(path));
     assert.isFalse(cache.analyzedDocumentPromises.has(path));
-    assert.isFalse(cache.dependenciesScanned.has(path));
   }
 
   test('it invalidates a path when asked to', async() => {


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

We do take a ~100% hit to the benchmark, but that is a worst case scenario for this change (modifying the root of a very large import graph), and analysis is still only taking ~40ms.

It would still be nice if we could figure out a way to add something like this cache. There's no correctness issue with scanning dependencies multiple times, just a performance one, so we don't need the full power of getOrCompute. Hm. I think I have an idea for a followup PR that restores this performance win.