### PR TITLE
Improve ES6 module support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+### Fixed
+
+* Do not complain about ES6 module syntax, but store enough information that we can warn about referencing modules as scripts.
+
+
 ## [2.0.0-alpha.21] - 2016-12-22
 
 ### Added

--- a/src/core/analyzer-cache-context.ts
+++ b/src/core/analyzer-cache-context.ts
@@ -53,7 +53,7 @@ import {AnalysisCache} from './analysis-cache';
 export class AnalyzerCacheContext {
   private _parsers = new Map<string, Parser<ParsedDocument<any, any>>>([
     ['html', new HtmlParser()],
-    ['js', new JavaScriptParser({sourceType: 'script'})],
+    ['js', new JavaScriptParser()],
     ['css', new CssParser()],
     ['json', new JsonParser()],
   ]);

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -17,7 +17,7 @@ import {traverse, VisitorOption} from 'estraverse';
 import {Node, Program} from 'estree';
 
 import {SourceRange} from '../model/model';
-import {Options, ParsedDocument, StringifyOptions} from '../parser/document';
+import {Options as ParsedDocumentOptions, ParsedDocument, StringifyOptions} from '../parser/document';
 
 import {Visitor, VisitResult} from './estree-visitor';
 
@@ -36,13 +36,26 @@ interface SkipRecord {
   depth: number;
 }
 
+export interface Options extends ParsedDocumentOptions<Program> {
+  parsedAsSourceType: 'script'|'module';
+}
+
 export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
   type = 'js';
   private visitorSkips = new Map<Visitor, SkipRecord>();
   ast: Program;
 
-  constructor(from: Options<Program>) {
+  /**
+   * How the js document was parsed. If 'module' then the source code is
+   * definitely an ES6 module, as it has imports or exports. If 'script' then
+   * it may be an ES6 module with no imports or exports, or it may be a
+   * script.
+   */
+  parsedAsSourceType: 'script'|'module';
+
+  constructor(from: Options) {
     super(from);
+    this.parsedAsSourceType = from.parsedAsSourceType;
   }
 
   visit(visitors: Visitor[]) {

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -23,7 +23,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 
 suite('JavaScriptImportScanner', () => {
 
-  const parser = new JavaScriptParser({sourceType: 'module'});
+  const parser = new JavaScriptParser();
   const scanner = new JavaScriptImportScanner();
 
   test('finds imports', async() => {

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -25,7 +25,7 @@ suite('JavaScriptParser', () => {
   let parser: JavaScriptParser;
 
   setup(() => {
-    parser = new JavaScriptParser({sourceType: 'script'});
+    parser = new JavaScriptParser();
   });
 
 
@@ -45,6 +45,7 @@ suite('JavaScriptParser', () => {
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
+      assert.equal(document.parsedAsSourceType, 'script');
       // First statement is a class declaration
       assert.equal(document.ast.body[0].type, 'ClassDeclaration');
     });
@@ -59,6 +60,7 @@ suite('JavaScriptParser', () => {
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
+      assert.equal(document.parsedAsSourceType, 'script');
       // First statement is an async function declaration
       const functionDecl = document.ast.body[0];
       if (functionDecl.type !== 'FunctionDeclaration') {
@@ -83,6 +85,16 @@ suite('JavaScriptParser', () => {
       assert.isTrue(comment.indexOf('test-element') !== -1);
     });
 
+    test('parses an ES module', () => {
+      const contents = `
+        import foo from 'foo';
+      `;
+      const document = parser.parse(contents, '/static/es6-support.js');
+      assert.instanceOf(document, JavaScriptDocument);
+      assert.equal(document.url, '/static/es6-support.js');
+      assert.equal(document.ast.type, 'Program');
+      assert.equal(document.parsedAsSourceType, 'module');
+    });
   });
 
   suite(`stringify()`, () => {

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -31,7 +31,7 @@ suite('BehaviorScanner', () => {
   let behaviorsList: ScannedBehavior[];
 
   suiteSetup(async() => {
-    const parser = new JavaScriptParser({sourceType: 'script'});
+    const parser = new JavaScriptParser();
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/js-behaviors.js'), 'utf8');
     document = parser.parse(file, '/static/js-behaviors.js');

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -88,9 +88,8 @@ suite('PolymerElementScanner', () => {
         listeners: []
       });`;
 
-      const document = new JavaScriptParser({
-                         sourceType: 'script'
-                       }).parse(contents, 'test-document.html');
+      const document =
+          new JavaScriptParser().parse(contents, 'test-document.html');
       const visit = async(visitor: Visitor) => document.visit([visitor]);
 
       const features = await scanner.scan(document, visit);
@@ -129,17 +128,18 @@ suite('PolymerElementScanner', () => {
         ['all', 'Object']
       ]);
 
-      assert.deepEqual(features[0].attributes.map(p => [p.name, p.changeEvent]), [
-        ['a', undefined],
-        ['b', undefined],
-        ['c', undefined],
-        ['d', undefined],
-        ['e', 'e-changed'],
-        ['f', undefined],
-        ['g', undefined],
-        ['h', undefined],
-        ['all', 'all-changed']
-      ]);
+      assert.deepEqual(
+          features[0].attributes.map(p => [p.name, p.changeEvent]), [
+            ['a', undefined],
+            ['b', undefined],
+            ['c', undefined],
+            ['d', undefined],
+            ['e', 'e-changed'],
+            ['f', undefined],
+            ['g', undefined],
+            ['h', undefined],
+            ['all', 'all-changed']
+          ]);
 
       assert.deepEqual(
           features[0].properties.filter(p => p.readOnly).map(p => p.name),
@@ -161,9 +161,17 @@ suite('PolymerElementScanner', () => {
       ]);
 
       // Skip not statically analizable entries without emitting a warning
-      assert.equal(features[0].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 0);
+      assert.equal(
+          features[0]
+              .warnings.filter(w => w.code === 'invalid-listeners-declaration')
+              .length,
+          0);
       // Emit warning for non-object `listeners` literal
-      assert.equal(features[1].warnings.filter(w => w.code === 'invalid-listeners-declaration').length, 1);
+      assert.equal(
+          features[1]
+              .warnings.filter(w => w.code === 'invalid-listeners-declaration')
+              .length,
+          1);
     });
   });
 

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -41,7 +41,7 @@ suite('Polymer2ElementScanner', () => {
   let elementsList: ScannedElement[];
 
   suiteSetup(async() => {
-    const parser = new JavaScriptParser({sourceType: 'script'});
+    const parser = new JavaScriptParser();
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/polymer2/test-element.js'), 'utf8');
     document = parser.parse(file, '/static/polymer2/test-element.js');

--- a/src/test/vanilla-custom-elements/element-scanner_test.ts
+++ b/src/test/vanilla-custom-elements/element-scanner_test.ts
@@ -33,7 +33,7 @@ suite('VanillaElementScanner', () => {
   let elementsList: ScannedElement[];
 
   suiteSetup(async() => {
-    const parser = new JavaScriptParser({sourceType: 'script'});
+    const parser = new JavaScriptParser();
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/vanilla-elements.js'), 'utf8');
     document = parser.parse(file, '/static/vanilla-elements.js');


### PR DESCRIPTION
This ensures that we don't throw parse errors for ES6 modules. We can't, in general, know at parse time whether a given bit of JS should be parsed as a module or a script.

I think, given that, it is better to parse robustly and just note whether a file must be a module, or that it is legal syntax as either a module or a script.

 - [x] CHANGELOG.md has been updated

Fixes https://github.com/Polymer/polymer-editor-service/issues/12 and https://github.com/Polymer/vscode-plugin/issues/44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-analyzer/428)
<!-- Reviewable:end -->
