### PR TITLE
Fix the build, option #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/escodegen": "^0.0.2",
     "@types/estraverse": "^0.0.2",
     "@types/estree": "^0.0.34",
-    "@types/node": "^4.0.30",
+    "@types/node": "^6.0.0",
     "@types/parse5": "^2.2.34",
     "chalk": "^1.1.3",
     "clone": "^2.0.0",

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -21,19 +21,19 @@ suite('FSUrlLoader', function() {
   suite('canLoad', () => {
 
     test('canLoad is true an in-package URL', () => {
-      assert.isTrue(new FSUrlLoader().canLoad('foo.html'));
+      assert.isTrue(new FSUrlLoader('').canLoad('foo.html'));
     });
 
     test('canLoad is false for a sibling URL', () => {
-      assert.isFalse(new FSUrlLoader().canLoad('../foo/foo.html'));
+      assert.isFalse(new FSUrlLoader('').canLoad('../foo/foo.html'));
     });
 
     test('canLoad is false for a cousin URL', () => {
-      assert.isFalse(new FSUrlLoader().canLoad('../../foo/foo.html'));
+      assert.isFalse(new FSUrlLoader('').canLoad('../../foo/foo.html'));
     });
 
     test('canLoad is false for URL with a hostname', () => {
-      assert.isFalse(new FSUrlLoader().canLoad('http://abc.xyz/foo.html'));
+      assert.isFalse(new FSUrlLoader('').canLoad('http://abc.xyz/foo.html'));
     });
 
   });
@@ -41,7 +41,7 @@ suite('FSUrlLoader', function() {
   suite('getFilePath', () => {
 
     test('resolves an in-package URL', () => {
-      assert.equal(new FSUrlLoader().getFilePath('foo.html'), 'foo.html');
+      assert.equal(new FSUrlLoader('').getFilePath('foo.html'), 'foo.html');
     });
 
     test('resolves an in-package URL', () => {
@@ -50,16 +50,17 @@ suite('FSUrlLoader', function() {
     });
 
     test('throws for a sibling URL', () => {
-      assert.throws(() => new FSUrlLoader().getFilePath('../foo/foo.html'));
+      assert.throws(() => new FSUrlLoader('').getFilePath('../foo/foo.html'));
     });
 
     test('throws for a cousin URL', () => {
-      assert.throws(() => new FSUrlLoader().getFilePath('../../foo/foo.html'));
+      assert.throws(
+          () => new FSUrlLoader('').getFilePath('../../foo/foo.html'));
     });
 
     test('throws for a URL with a hostname', () => {
       assert.throws(
-          () => new FSUrlLoader().getFilePath('http://abc.xyz/foo.html'));
+          () => new FSUrlLoader('').getFilePath('http://abc.xyz/foo.html'));
     });
 
   });

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -27,7 +27,7 @@ export class FSUrlLoader implements UrlLoader {
   root: string;
 
   constructor(root?: string) {
-    this.root = root || process.cwd();
+    this.root = root || '';
   }
 
   canLoad(url: string): boolean {

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -24,10 +24,10 @@ import {UrlLoader} from './url-loader';
  * Resolves requests via the file system.
  */
 export class FSUrlLoader implements UrlLoader {
-  root: string|undefined;
+  root: string;
 
   constructor(root?: string) {
-    this.root = root;
+    this.root = root || process.cwd();
   }
 
   canLoad(url: string): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
         "removeComments": false,
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true,
-        "lib": ["es2017"],
+        "lib": [
+            "es2017"
+        ],
         "outDir": "./lib",
         "declaration": true,
         "sourceMap": true,
@@ -22,6 +24,6 @@
         "src/**/*.ts"
     ],
     "exclude": [
-      "node_modules"
+        "node_modules"
     ]
 }


### PR DESCRIPTION
It looks like the node v4 typings don't include definitions for `console` anymore? Seems like a bug, but moving to node v6 typings fixes.

 - [x] CHANGELOG.md not updated, internal change.
