### PR TITLE
Fix several compilation errors with Typescript 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "shady-css-parser": "0.0.8",
     "split": "^1.0.0",
     "strip-indent": "^2.0.0",
-    "typescript": "^2.1.4"
+    "typescript": "2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "shady-css-parser": "0.0.8",
     "split": "^1.0.0",
     "strip-indent": "^2.0.0",
-    "typescript": "2.1.4"
+    "typescript": "^2.1.4"
   }
 }

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -28,6 +28,9 @@ function literalToValue(literal: estree.Literal): LiteralValue {
  */
 function unaryToValue(unary: estree.UnaryExpression): LiteralValue {
   const operand = expressionToValue(unary.argument);
+  if (operand === null || operand === undefined) {
+    return operand;
+  }
   switch (unary.operator) {
     case '!':
       return !operand;

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -28,18 +28,15 @@ function literalToValue(literal: estree.Literal): LiteralValue {
  */
 function unaryToValue(unary: estree.UnaryExpression): LiteralValue {
   const operand = expressionToValue(unary.argument);
-  if (operand === null || operand === undefined) {
-    return operand;
-  }
   switch (unary.operator) {
     case '!':
-      return !operand;
+      return !(operand as any);
     case '-':
-      return -operand;
+      return -(operand as any);
     case '+':
-      return +operand;
+      return +(operand as any);
     case '~':
-      return ~operand;
+      return ~(operand as any);
     case 'typeof':
       return typeof operand;
     case 'void':

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -176,7 +176,7 @@ class Averager<K> {
 
   entries(): Iterable<[K, number]> {
     const entries = this.count.keys().map(
-        (k) => <[K, number]>[k, this.elapsed.get(k) / this.count.get(k)]);
+        (k) => <[K, number]>[k, this.elapsed.get(k)! / this.count.get(k)!]);
     return entries.sort((a, b) => a[1] - b[1]);
   }
 }

--- a/src/typescript/typescript-analyzer.ts
+++ b/src/typescript/typescript-analyzer.ts
@@ -49,7 +49,7 @@ function isLibraryPath(filename: string) {
   return filename.startsWith('/$lib/');
 }
 
-const libraryCache = new Map<string, string>();
+const libraryCache = new Map<string, string|undefined>();
 function getLibrarySource(filePath: string) {
   if (libraryCache.has(filePath)) {
     return libraryCache.get(filePath);


### PR DESCRIPTION
Installing the analyzer with `yarn` pulls in Typescript 2.2. This resulted in some compiler errors which I fixed all but one.

In TS 2.2 operators are more thoroughly checked, most notably arithmetic expressions do not allow undefined or null. I fixed these errors.

The last compiler error is because `lib.es2017.d.ts` in `typescript-analyzer.ts` pulls in `lib.es2016.d.ts` which pulls in `lib.es2015.d.ts` which pulls in `lib.es2015.collection.d.ts` and that file has a definition of `Map<K,V>`. This definition forces the second argument `value` of to be non-null per [this commit](https://github.com/Microsoft/TypeScript/commit/adedc1953b9a1136b5067f5224a3b4e7cd5b8956#diff-f7219547c512c7ed79bb415579ceb5afR27). I am not sure why the Typescript maintainers introduced this change, since on master `value` is allowed to be `undefined`. Therefore I pinned the version of Typescript to 2.1.4 for now.

 - [x] CHANGELOG.md has not been updated, internal change
