### PR TITLE
Fix caching of warnings for failed scanning of imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+### Fixed
+
+* Properly cache warning for incorrect imports or when failing parsing an import.
+
 ## [2.0.0-alpha.22] - 2017-01-13
 
 ### Fixed

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -334,20 +334,7 @@ export class AnalysisContext {
             // DependencyGraph
             // to wait for all transitive dependencies to load.
             this.scan(importUrl).catch((error) => {
-              if (error instanceof NoKnownParserError) {
-                // We probably don't want to fail when importing something
-                // that we don't know about here.
-              }
-              error = error || '';
-              // TODO(rictic): move this to the resolve phase, it will be
-              // improperly cached as it is.
-              scannedDocument.warnings.push({
-                code: 'could-not-load',
-                message: `Unable to load import: ${error.message || error}`,
-                sourceRange: (
-                    scannedImport.urlSourceRange || scannedImport.sourceRange)!,
-                severity: Severity.ERROR
-              });
+              scannedImport.error = error || '';
             });
           }
           await this._cache.dependencyGraph.whenReady(resolvedUrl);

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -13,6 +13,7 @@
  */
 
 import {Document, Import, ScannedImport} from '../model/model';
+import {Severity} from '../warning/warning';
 
 /**
  * <script> tags are represented in two different ways: as inline documents,
@@ -49,6 +50,12 @@ export class ScannedScriptTagImport extends ScannedImport {
           this.warnings);
     } else {
       // not found or syntax error
+      document.warnings.push({
+        code: 'could-not-load',
+        message: `Unable to load import: ${this.error!.message || this.error}`,
+        sourceRange: (this.urlSourceRange || this.sourceRange)!,
+        severity: Severity.ERROR
+      });
       return undefined;
     }
   }

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -52,7 +52,7 @@ export class ScannedScriptTagImport extends ScannedImport {
       // not found or syntax error
       document.warnings.push({
         code: 'could-not-load',
-        message: `Unable to load import: ${this.error!.message || this.error}`,
+        message: `Unable to load import: ${this.error ? (this.error.message || this.error) : ''}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
       });

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Warning} from '../warning/warning';
+import {Severity, Warning} from '../warning/warning';
 
 import {Document} from './document';
 import {Feature} from './feature';
@@ -36,6 +36,8 @@ export class ScannedImport implements Resolvable {
 
   sourceRange: SourceRange|undefined;
 
+  error: {message?: string}|undefined;
+
   /**
    * The source range specifically for the URL or reference to the imported
    * resource.
@@ -58,14 +60,23 @@ export class ScannedImport implements Resolvable {
 
   resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
-    return importedDocument && new Import(
-                                   this.url,
-                                   this.type,
-                                   importedDocument,
-                                   this.sourceRange,
-                                   this.urlSourceRange,
-                                   this.astNode,
-                                   this.warnings);
+    if (!importedDocument) {
+      document.warnings.push({
+        code: 'could-not-load',
+        message: `Unable to load import: ${this.error!.message || this.error}`,
+        sourceRange: (this.urlSourceRange || this.sourceRange)!,
+        severity: Severity.ERROR
+      });
+      return undefined;
+    }
+    return new Import(
+        this.url,
+        this.type,
+        importedDocument,
+        this.sourceRange,
+        this.urlSourceRange,
+        this.astNode,
+        this.warnings);
   }
 }
 

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -63,7 +63,7 @@ export class ScannedImport implements Resolvable {
     if (!importedDocument) {
       document.warnings.push({
         code: 'could-not-load',
-        message: `Unable to load import: ${this.error!.message || this.error}`,
+        message: `Unable to load import: ${this.error ? (this.error.message || this.error) : ''}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
       });


### PR DESCRIPTION
This fixes a TODO in the code. I am not 100% this is the correct fix, but given the comment regarding `resolve` I think this code should live in the `resolve` of `Import`. Note that since `html-script-tag` contains duplicate code, the same code is added twice. This can be fixed later I suppose.

 - [x] CHANGELOG.md has been updated
