### PR TITLE
ReferenceScanner should descend into <template>s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Properly cache warning for incorrect imports or when failing parsing an import.
+* Notice references to elements within `<template>` tags.
 
 ## [2.0.0-alpha.22] - 2017-01-13
 

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -80,6 +80,9 @@ suite('HtmlCustomElementReferenceScanner', () => {
             <x-bar></x-bar>
           </div>
           <h1>Bar</h1>
+          <template>
+            <x-baz></x-baz>
+          </template>
         </body></html>`;
 
       const document = new HtmlParser().parse(contents, 'test-document.html');
@@ -87,7 +90,8 @@ suite('HtmlCustomElementReferenceScanner', () => {
 
       const features = await scanner.scan(document, visit);
 
-      assert.deepEqual(features.map(f => f.tagName), ['x-foo', 'x-bar']);
+      assert.deepEqual(
+          features.map(f => f.tagName), ['x-foo', 'x-bar', 'x-baz']);
 
       assert.deepEqual(
           features[0].attributes.map(a => [a.name, a.value]),
@@ -102,6 +106,9 @@ suite('HtmlCustomElementReferenceScanner', () => {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
         `
             <x-bar></x-bar>
+            ~~~~~~~~~~~~~~~`,
+        `
+            <x-baz></x-baz>
             ~~~~~~~~~~~~~~~`
       ]);
 
@@ -121,6 +128,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
           <x-foo a=5 b="test" c></x-foo>
                               ~`
         ],
+        [],
         []
       ]);
 
@@ -140,6 +148,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
           <x-foo a=5 b="test" c></x-foo>
                               ~`
         ],
+        [],
         []
       ]);
 
@@ -157,6 +166,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
                        ~~~~~~`,
           `No source range produced`
         ],
+        [],
         []
       ]);
     });


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

Fixes #419
