### PR TITLE
Add a query options object for all Queryable methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+### Added
+
+* [BREAKING] All methods on Document no longer return results from dependencies, but do return results from inline documents. Added a queryOptions param to all query methods to specify getting results from dependencies.
+
 ### Fixed
 
 * Properly cache warning for incorrect imports or when failing parsing an import.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ task('build', ['compile', 'json-schema']);
 
 task('compile', function() {
   const srcs = gulp.src('src/**/*.ts').pipe(newer({dest: 'lib', ext: '.js'}));
-  const tsResult = srcs.pipe(sourcemaps.init()).pipe(typescript(tsProject));
+  const tsResult = srcs.pipe(sourcemaps.init()).pipe(typescript(tsProject, [], typescript.reporter.nullReporter()));
 
   // Use this once typescript-gulp supports `include` in tsconfig:
   // const srcs = tsProject.src();

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "shady-css-parser": "0.0.8",
     "split": "^1.0.0",
     "strip-indent": "^2.0.0",
-    "typescript": "^2.1.4"
+    "typescript": "^2.2.0"
   }
 }

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -120,7 +120,7 @@ export class AnalysisContext {
    */
   filesChanged(urls: string[]) {
     const newCache =
-        this._cache.invalidate(urls.map(url => this.resolveUrl(url)));
+        this._cache.invalidate(urls.map((url) => this.resolveUrl(url)));
     return this._fork(newCache);
   }
 
@@ -167,16 +167,17 @@ export class AnalysisContext {
     // TODO(rictic): parameterize this, perhaps with polymer.json.
     const dependencyDirPrefixes: string[] =
         ['bower_components', 'node_modules'];
-    const filesInPackage = allFiles.filter(file => {
+    const filesInPackage = allFiles.filter((file) => {
       const dirname = path.dirname(file);
-      return !dependencyDirPrefixes.some(prefix => dirname.startsWith(prefix));
+      return !dependencyDirPrefixes.some(
+          (prefix) => dirname.startsWith(prefix));
     });
 
     const extensions = new Set(this._parsers.keys());
     const filesWithParsers = filesInPackage.filter(
-        fn => extensions.has(path.extname(fn).substring(1)));
-    const documentsOrWarnings =
-        await Promise.all(filesWithParsers.map(f => this._analyzeOrWarning(f)));
+        (fn) => extensions.has(path.extname(fn).substring(1)));
+    const documentsOrWarnings = await Promise.all(
+        filesWithParsers.map((f) => this._analyzeOrWarning(f)));
     const documents = [];
     const warnings = [];
     for (const docOrWarning of documentsOrWarnings) {

--- a/src/core/dependency-graph.ts
+++ b/src/core/dependency-graph.ts
@@ -122,7 +122,7 @@ export class DependencyGraph {
     }
     visited.add(key);
     const dependenciesKnown = this._getRecordFor(key).dependenciesKnown;
-    const forgivingDependenciesKnown = dependenciesKnown.catch(_ => []);
+    const forgivingDependenciesKnown = dependenciesKnown.catch((_) => []);
     const deps = await forgivingDependenciesKnown;
     for (const dep of deps) {
       await this._whenReady(dep, visited);

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -98,7 +98,7 @@ export class ParsedCssDocument extends ParsedDocument<shady.Node, Visitor> {
     const indent = '  '.repeat(options.indent || 0);
 
     return beautifulResults.split('\n')
-               .map(line => line === '' ? '' : indent + line)
+               .map((line) => line === '' ? '' : indent + line)
                .join('\n') +
         '\n';
   }

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -40,7 +40,7 @@ async function getWarnings(analyzer: Analyzer, localPath: string):
     Promise<Warning[]> {
       try {
         const document = await analyzer.analyze(localPath);
-        return document.getWarnings({lookInDependencies: false});
+        return document.getWarnings({imported: false});
       } catch (e) {
         if (e instanceof WarningCarryingException) {
           return [e.warning];

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -40,7 +40,7 @@ async function getWarnings(analyzer: Analyzer, localPath: string):
     Promise<Warning[]> {
       try {
         const document = await analyzer.analyze(localPath);
-        return document.getWarnings();
+        return document.getWarnings({lookInDependencies: false});
       } catch (e) {
         if (e instanceof WarningCarryingException) {
           return [e.warning];

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -50,7 +50,7 @@ async function getWarnings(analyzer: Analyzer, localPath: string):
     }
 
 main()
-    .catch(err => {
+    .catch((err) => {
       console.error(err.stack || err.message || err);
       process.exit(1);
     });

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -66,10 +66,10 @@ export class LocalEditorService extends EditorService {
     if (location.kind === 'tagName' || location.kind === 'text') {
       const elements =
           Array.from(document.getByKind('element', {lookInDependencies: true}))
-              .filter(e => e.tagName);
+              .filter((e) => e.tagName);
       return {
         kind: 'element-tags',
-        elements: elements.map(e => {
+        elements: elements.map((e) => {
           const attributesSpace = e.attributes.length > 0 ? ' ' : '';
           return {
             tagname: e.tagName!,
@@ -97,7 +97,7 @@ export class LocalEditorService extends EditorService {
           sortPrefixes.set(element.extends, 'ccc-');
         }
         const elementAttributes: AttributeCompletion[] =
-            element.attributes.map(p => {
+            element.attributes.map((p) => {
               const sortKey =
                   (sortPrefixes.get(p.inheritedFrom) || `ddd-`) + p.name;
               return {
@@ -164,7 +164,7 @@ export class LocalEditorService extends EditorService {
       }
 
       return concatMap(elements, (el) => el.attributes)
-          .find(at => at.name === location.attribute);
+          .find((at) => at.name === location.attribute);
     }
   }
 

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -65,7 +65,7 @@ export class LocalEditorService extends EditorService {
     }
     if (location.kind === 'tagName' || location.kind === 'text') {
       const elements =
-          Array.from(document.getByKind('element', {lookInDependencies: true}))
+          Array.from(document.getByKind('element', {imported: true}))
               .filter((e) => e.tagName);
       return {
         kind: 'element-tags',
@@ -82,7 +82,7 @@ export class LocalEditorService extends EditorService {
       };
     } else if (location.kind === 'attribute') {
       const elements = document.getById(
-          'element', location.element.nodeName, {lookInDependencies: true});
+          'element', location.element.nodeName, {imported: true});
       let attributes: AttributeCompletion[] = [];
       for (const element of elements) {
         // A map from the inheritedFrom to a sort prefix. Note that
@@ -129,7 +129,7 @@ export class LocalEditorService extends EditorService {
   async getWarningsForFile(localPath: string): Promise<Warning[]> {
     try {
       const doc = await this._analyzer.analyze(localPath);
-      return doc.getWarnings({lookInDependencies: false});
+      return doc.getWarnings({imported: false});
     } catch (e) {
       // This might happen if, e.g. `localPath` has a parse error. In that case
       // we can't construct a valid Document, but we might still be able to give
@@ -155,10 +155,10 @@ export class LocalEditorService extends EditorService {
     }
     if (location.kind === 'tagName') {
       return document.getOnlyAtId(
-          'element', location.element.nodeName, {lookInDependencies: true});
+          'element', location.element.nodeName, {imported: true});
     } else if (location.kind === 'attribute') {
       const elements = document.getById(
-          'element', location.element.nodeName, {lookInDependencies: true});
+          'element', location.element.nodeName, {imported: true});
       if (elements.size === 0) {
         return;
       }

--- a/src/editor-service/local-editor-service.ts
+++ b/src/editor-service/local-editor-service.ts
@@ -65,7 +65,8 @@ export class LocalEditorService extends EditorService {
     }
     if (location.kind === 'tagName' || location.kind === 'text') {
       const elements =
-          Array.from(document.getByKind('element')).filter(e => e.tagName);
+          Array.from(document.getByKind('element', {lookInDependencies: true}))
+              .filter(e => e.tagName);
       return {
         kind: 'element-tags',
         elements: elements.map(e => {
@@ -80,7 +81,8 @@ export class LocalEditorService extends EditorService {
         })
       };
     } else if (location.kind === 'attribute') {
-      const elements = document.getById('element', location.element.nodeName);
+      const elements = document.getById(
+          'element', location.element.nodeName, {lookInDependencies: true});
       let attributes: AttributeCompletion[] = [];
       for (const element of elements) {
         // A map from the inheritedFrom to a sort prefix. Note that
@@ -127,7 +129,7 @@ export class LocalEditorService extends EditorService {
   async getWarningsForFile(localPath: string): Promise<Warning[]> {
     try {
       const doc = await this._analyzer.analyze(localPath);
-      return doc.getWarnings();
+      return doc.getWarnings({lookInDependencies: false});
     } catch (e) {
       // This might happen if, e.g. `localPath` has a parse error. In that case
       // we can't construct a valid Document, but we might still be able to give
@@ -152,9 +154,11 @@ export class LocalEditorService extends EditorService {
       return;
     }
     if (location.kind === 'tagName') {
-      return document.getOnlyAtId('element', location.element.nodeName);
+      return document.getOnlyAtId(
+          'element', location.element.nodeName, {lookInDependencies: true});
     } else if (location.kind === 'attribute') {
-      const elements = document.getById('element', location.element.nodeName);
+      const elements = document.getById(
+          'element', location.element.nodeName, {lookInDependencies: true});
       if (elements.size === 0) {
         return;
       }

--- a/src/generate-elements.ts
+++ b/src/generate-elements.ts
@@ -24,8 +24,8 @@ export function generateElementMetadata(
     elements: ResolvedElement[], packagePath: string): Elements|undefined {
   return {
     schema_version: '1.0.0',
-    elements: elements.map(e => serializeElement(e, packagePath))
-                  .filter(e => !!e) as Element[]
+    elements: elements.map((e) => serializeElement(e, packagePath))
+                  .filter((e) => !!e) as Element[]
   };
 }
 
@@ -38,7 +38,8 @@ export class ValidationError extends Error {
   constructor(result: jsonschema.ValidatorResult) {
     const message = `Unable to validate serialized Polymer analysis. ` +
         `Got ${result.errors.length} errors: ` +
-        `${result.errors.map(err => '    ' + (err.message || err)).join('\n')}`;
+        `${result.errors.map((err) => '    ' + (err.message || err))
+            .join('\n')}`;
     super(message);
     this.errors = result.errors;
   }
@@ -75,16 +76,16 @@ function serializeElement(
       pathLib.relative(packagePath, resolvedElement.sourceRange.file);
 
   const attributes = resolvedElement.attributes.map(
-      a => serializeAttribute(resolvedElement, path, a));
+      (a) => serializeAttribute(resolvedElement, path, a));
   const properties =
       resolvedElement.properties
           .filter(
-              p => !p.private &&
+              (p) => !p.private &&
                   // Blacklist functions until we figure out what to do.
                   p.type !== 'Function')
-          .map(p => serializeProperty(resolvedElement, path, p));
+          .map((p) => serializeProperty(resolvedElement, path, p));
   const events = resolvedElement.events.map(
-      e => ({
+      (e) => ({
         name: e.name,
         description: e.description || '',
         type: 'CustomEvent',
@@ -102,8 +103,8 @@ function serializeElement(
       cssVariables: [],
       selectors: [],
     },
-    demos: (resolvedElement.demos || []).map(d => d.path),
-    slots: resolvedElement.slots.map(s => {
+    demos: (resolvedElement.demos || []).map((d) => d.path),
+    slots: resolvedElement.slots.map((s) => {
       return {description: '', name: s.name, range: s.range};
     }),
     events: events,

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -50,12 +50,10 @@ export class ScannedScriptTagImport extends ScannedImport {
           this.warnings);
     } else {
       // not found or syntax error
+      const error = this.error ? (this.error.message || this.error) : '';
       document.warnings.push({
         code: 'could-not-load',
-        message: `Unable to load import: ${this.error ?
-            (this.error.message || this.error) :
-            ''
-            }`,
+        message: `Unable to load import: ${error}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
       });

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -52,7 +52,10 @@ export class ScannedScriptTagImport extends ScannedImport {
       // not found or syntax error
       document.warnings.push({
         code: 'could-not-load',
-        message: `Unable to load import: ${this.error ? (this.error.message || this.error) : ''}`,
+        message: `Unable to load import: ${this.error ?
+            (this.error.message || this.error) :
+            ''
+            }`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
       });

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -115,7 +115,7 @@ export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
                   `estraverse.VisitorOption.Remove not ` +
                   `supported by JavascriptDocument`);
             case VisitorOption.Break:
-              visitors = visitors.filter(v => v !== visitor);
+              visitors = visitors.filter((v) => v !== visitor);
               break;
             case VisitorOption.Skip:
               if (callbackName.startsWith('leave')) {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -358,7 +358,7 @@ export class Document implements Feature, Queryable {
     for (const localFeature of this._localFeatures) {
       if (localFeature instanceof Document) {
         result = result.concat(
-            localFeature._toString(documentsWalked).map(line => `  ${line}`));
+            localFeature._toString(documentsWalked).map((line) => `  ${line}`));
       } else {
         let subResult = localFeature.toString();
         if (subResult === '[object Object]') {
@@ -378,8 +378,8 @@ export class Document implements Feature, Queryable {
   stringify(): string {
     const inlineDocuments =
         (Array.from(this._localFeatures)
-             .filter(f => f instanceof Document && f.isInline) as Document[])
-            .map(d => d.parsedDocument);
+             .filter((f) => f instanceof Document && f.isInline) as Document[])
+            .map((d) => d.parsedDocument);
     return this.parsedDocument.stringify({inlineDocuments: inlineDocuments});
   }
 

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -99,10 +99,10 @@ export interface FeatureKinds {
 
 export type QueryOptions = object & {
   /**
-   * If given and true, the query will return results from the document and its
+   * If true, the query will return results from the document and its
    * dependencies. Otherwise it will only include results from the document.
    */
-  lookInDependencies?: boolean;
+  imported?: boolean;
 };
 
 export class Document implements Feature, Queryable {
@@ -217,10 +217,10 @@ export class Document implements Feature, Queryable {
   getByKind(kind: string, options?: QueryOptions): Set<Feature>;
   getByKind(kind: string, options?: QueryOptions): Set<Feature> {
     options = options || {};
-    if (this._featuresByKind && options.lookInDependencies) {
+    if (this._featuresByKind && options.imported) {
       // We have a fast index! Use that.
       return this._featuresByKind.get(kind) || new Set();
-    } else if (this._doneResolving && options.lookInDependencies) {
+    } else if (this._doneResolving && options.imported) {
       // We're done discovering features in this document and its children so
       // we can safely build up the indexes.
       this._buildIndexes();
@@ -237,11 +237,11 @@ export class Document implements Feature, Queryable {
   getById(kind: string, identifier: string, options?: QueryOptions):
       Set<Feature> {
     options = options || {};
-    if (this._featuresByKindAndId && options.lookInDependencies) {
+    if (this._featuresByKindAndId && options.imported) {
       // We have a fast index! Use that.
       const idMap = this._featuresByKindAndId.get(kind);
       return (idMap && idMap.get(identifier)) || new Set();
-    } else if (this._doneResolving && options.lookInDependencies) {
+    } else if (this._doneResolving && options.imported) {
       // We're done discovering features in this document and its children so
       // we can safely build up the indexes.
       this._buildIndexes();
@@ -282,7 +282,7 @@ export class Document implements Feature, Queryable {
       if (feature.kinds.has(kind)) {
         result.add(feature);
       }
-      if (options.lookInDependencies && feature.kinds.has('import')) {
+      if (options.imported && feature.kinds.has('import')) {
         const document = (feature as Import).document;
         if (!documentsWalked.has(document)) {
           for (const subFeature of document._getByKind(
@@ -323,7 +323,7 @@ export class Document implements Feature, Queryable {
       if (feature.kinds.has('document')) {
         (feature as Document)._getFeatures(result, visited, options);
       }
-      if (feature.kinds.has('import') && options.lookInDependencies) {
+      if (feature.kinds.has('import') && options.imported) {
         (feature as Import).document._getFeatures(result, visited, options);
       }
     }
@@ -421,7 +421,7 @@ export class Document implements Feature, Queryable {
           `Need to wait until afterwards or the indexes would be incomplete.`);
     }
     this._initIndexes();
-    for (const feature of this.getFeatures({lookInDependencies: true})) {
+    for (const feature of this.getFeatures({imported: true})) {
       this._indexFeature(feature);
     }
   }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -61,12 +61,10 @@ export class ScannedImport implements Resolvable {
   resolve(document: Document): Import|undefined {
     const importedDocument = document.analyzer._getDocument(this.url);
     if (!importedDocument) {
+      const error = this.error ? (this.error.message || this.error) : '';
       document.warnings.push({
         code: 'could-not-load',
-        message: `Unable to load import: ${this.error ?
-            (this.error.message || this.error) :
-            ''
-            }`,
+        message: `Unable to load import: ${error}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
       });

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -63,7 +63,10 @@ export class ScannedImport implements Resolvable {
     if (!importedDocument) {
       document.warnings.push({
         code: 'could-not-load',
-        message: `Unable to load import: ${this.error ? (this.error.message || this.error) : ''}`,
+        message: `Unable to load import: ${this.error ?
+            (this.error.message || this.error) :
+            ''
+            }`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
       });

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -104,7 +104,7 @@ function isLocationInfo(loc: (parse5.LocationInfo|parse5.ElementLocationInfo)):
 export function getLocationOffsetOfStartOfTextContent(node: ASTNode):
     LocationOffset {
   const childNodes = node.childNodes || [];
-  const firstChildNodeWithLocation = childNodes.find(n => !!n.__location);
+  const firstChildNodeWithLocation = childNodes.find((n) => !!n.__location);
   const bestLocation = firstChildNodeWithLocation ?
       firstChildNodeWithLocation.__location :
       node.__location;

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -32,7 +32,7 @@
  * Earlier stages have the longer names, like ParsedDocument and ScannedElement.
  */
 
-export * from './document';
+export {Document, FeatureKinds, QueryOptions as DocumentQueryOptions, ScannedDocument} from './document';
 export * from './element';
 export {ElementReference, ScannedElementReference} from './element-reference';
 export * from './event';

--- a/src/model/package.ts
+++ b/src/model/package.ts
@@ -37,7 +37,7 @@ export class Package implements Queryable {
     // can be reached from them. That way we'll do less duplicate work when we
     // query over all documents.
     for (const doc of potentialRoots) {
-      for (const imprt of doc.getByKind('import', {lookInDependencies: true})) {
+      for (const imprt of doc.getByKind('import', {imported: true})) {
         // When there's cycles we can keep any element of the cycle, so why not
         // this one.
         if (imprt.document !== doc) {
@@ -52,7 +52,7 @@ export class Package implements Queryable {
   getByKind(kind: string): Set<Feature>;
   getByKind(kind: string): Set<Feature> {
     const result = new Set();
-    const docQueryOptions = {lookInDependencies: true};
+    const docQueryOptions = {imported: true};
     for (const doc of this._documents) {
       addAll(result, doc.getByKind(kind, docQueryOptions));
     }
@@ -64,7 +64,7 @@ export class Package implements Queryable {
   getById(kind: string, identifier: string): Set<Feature>;
   getById(kind: string, identifier: string): Set<Feature> {
     const result = new Set();
-    const docQueryOptions = {lookInDependencies: true};
+    const docQueryOptions = {imported: true};
     for (const doc of this._documents) {
       addAll(result, doc.getById(kind, identifier, docQueryOptions));
     }
@@ -89,7 +89,7 @@ export class Package implements Queryable {
    */
   getFeatures(): Set<Feature> {
     const result = new Set();
-    const docQueryOptions = {lookInDependencies: true};
+    const docQueryOptions = {imported: true};
     for (const doc of this._documents) {
       addAll(result, doc.getFeatures(docQueryOptions));
     }
@@ -101,7 +101,7 @@ export class Package implements Queryable {
    */
   getWarnings(): Warning[] {
     const result = new Set(this._toplevelWarnings);
-    const docQueryOptions = {lookInDependencies: true};
+    const docQueryOptions = {imported: true};
     for (const doc of this._documents) {
       addAll(result, new Set(doc.getWarnings(docQueryOptions)));
     }

--- a/src/model/package.ts
+++ b/src/model/package.ts
@@ -37,7 +37,7 @@ export class Package implements Queryable {
     // can be reached from them. That way we'll do less duplicate work when we
     // query over all documents.
     for (const doc of potentialRoots) {
-      for (const imprt of doc.getByKind('import')) {
+      for (const imprt of doc.getByKind('import', {lookInDependencies: true})) {
         // When there's cycles we can keep any element of the cycle, so why not
         // this one.
         if (imprt.document !== doc) {
@@ -52,8 +52,9 @@ export class Package implements Queryable {
   getByKind(kind: string): Set<Feature>;
   getByKind(kind: string): Set<Feature> {
     const result = new Set();
+    const docQueryOptions = {lookInDependencies: true};
     for (const doc of this._documents) {
-      addAll(result, doc.getByKind(kind));
+      addAll(result, doc.getByKind(kind, docQueryOptions));
     }
     return result;
   }
@@ -63,8 +64,9 @@ export class Package implements Queryable {
   getById(kind: string, identifier: string): Set<Feature>;
   getById(kind: string, identifier: string): Set<Feature> {
     const result = new Set();
+    const docQueryOptions = {lookInDependencies: true};
     for (const doc of this._documents) {
-      addAll(result, doc.getById(kind, identifier));
+      addAll(result, doc.getById(kind, identifier, docQueryOptions));
     }
     return result;
   }
@@ -87,8 +89,9 @@ export class Package implements Queryable {
    */
   getFeatures(): Set<Feature> {
     const result = new Set();
+    const docQueryOptions = {lookInDependencies: true};
     for (const doc of this._documents) {
-      addAll(result, doc.getFeatures(true));
+      addAll(result, doc.getFeatures(docQueryOptions));
     }
     return result;
   }
@@ -98,8 +101,9 @@ export class Package implements Queryable {
    */
   getWarnings(): Warning[] {
     const result = new Set(this._toplevelWarnings);
+    const docQueryOptions = {lookInDependencies: true};
     for (const doc of this._documents) {
-      addAll(result, new Set(doc.getWarnings(true)));
+      addAll(result, new Set(doc.getWarnings(docQueryOptions)));
     }
     return Array.from(result);
   }

--- a/src/model/queryable.ts
+++ b/src/model/queryable.ts
@@ -16,29 +16,30 @@ import {Warning} from '../warning/warning';
 import {FeatureKinds} from './document';
 import {Feature} from './feature';
 
+export type QueryOptions = {} & object;
+
 /**
  * Represents something like a Document or a Package. A container of features
  * and warnings that's queryable in a few different ways.
  */
 export interface Queryable {
-  getByKind<K extends keyof FeatureKinds>(kind: K): Set<FeatureKinds[K]>;
-  getByKind(kind: string): Set<Feature>;
-
-  getById<K extends keyof FeatureKinds>(kind: K, identifier: string):
+  getByKind<K extends keyof FeatureKinds>(kind: K, options?: QueryOptions):
       Set<FeatureKinds[K]>;
-  getById(kind: string, identifier: string): Set<Feature>;
+  getByKind(kind: string, options?: QueryOptions): Set<Feature>;
 
-  getOnlyAtId<K extends keyof FeatureKinds>(kind: K, identifier: string):
-      FeatureKinds[K]|undefined;
-  getOnlyAtId(kind: string, identifier: string): Feature|undefined;
+  getById<K extends keyof FeatureKinds>(
+      kind: K, identifier: string,
+      options?: QueryOptions): Set<FeatureKinds[K]>;
+  getById(kind: string, identifier: string, options?: QueryOptions):
+      Set<Feature>;
 
-  /**
-   * Get all transatively reachable features.
-   */
-  getFeatures(): Set<Feature>;
+  getOnlyAtId<K extends keyof FeatureKinds>(
+      kind: K, identifier: string,
+      options?: QueryOptions): FeatureKinds[K]|undefined;
+  getOnlyAtId(kind: string, identifier: string, options?: QueryOptions): Feature
+      |undefined;
 
-  /**
-   * Get all transatively reachable warnings.
-   */
-  getWarnings(): Warning[];
+  getFeatures(options?: QueryOptions): Set<Feature>;
+
+  getWarnings(options?: QueryOptions): Warning[];
 }

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -103,7 +103,7 @@ export class DomModuleScanner implements HtmlScanner {
                           treeAdapters.default.getTemplateContent(template),
                           dom5.predicates.hasTagName('slot'))
                       .map(
-                          s => new Slot(
+                          (s) => new Slot(
                               dom5.getAttribute(s, 'name') || '',
                               document.sourceRangeForNode(s)!));
         }

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -200,13 +200,13 @@ function resolveElement(
   const behaviors = Array.from(flatteningResult.resolvedBehaviors);
   clone.properties = mergeByName(
       scannedElement.properties,
-      behaviors.map(b => ({name: b.className, vals: b.properties})));
+      behaviors.map((b) => ({name: b.className, vals: b.properties})));
   clone.attributes = mergeByName(
       scannedElement.attributes,
-      behaviors.map(b => ({name: b.className, vals: b.attributes})));
+      behaviors.map((b) => ({name: b.className, vals: b.attributes})));
   clone.events = mergeByName(
       scannedElement.events,
-      behaviors.map(b => ({name: b.className, vals: b.events})));
+      behaviors.map((b) => ({name: b.className, vals: b.events})));
 
   const domModule = document.getOnlyAtId(
       'dom-module', scannedElement.tagName || '', {lookInDependencies: true});

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -208,8 +208,8 @@ function resolveElement(
       scannedElement.events,
       behaviors.map(b => ({name: b.className, vals: b.events})));
 
-  const domModule =
-      document.getOnlyAtId('dom-module', scannedElement.tagName || '');
+  const domModule = document.getOnlyAtId(
+      'dom-module', scannedElement.tagName || '', {lookInDependencies: true});
   if (domModule) {
     clone.description = scannedElement.description || domModule.comment || '';
     clone.domModule = domModule.node;
@@ -237,7 +237,8 @@ function _getFlattenedAndResolvedBehaviors(
     resolvedBehaviors: Set<Behavior>) {
   const warnings: Warning[] = [];
   for (const behavior of behaviorAssignments) {
-    const foundBehaviors = document.getById('behavior', behavior.name);
+    const foundBehaviors =
+        document.getById('behavior', behavior.name, {lookInDependencies: true});
     if (foundBehaviors.size === 0) {
       warnings.push({
         message: `Unable to resolve behavior ` +

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -209,7 +209,7 @@ function resolveElement(
       behaviors.map((b) => ({name: b.className, vals: b.events})));
 
   const domModule = document.getOnlyAtId(
-      'dom-module', scannedElement.tagName || '', {lookInDependencies: true});
+      'dom-module', scannedElement.tagName || '', {imported: true});
   if (domModule) {
     clone.description = scannedElement.description || domModule.comment || '';
     clone.domModule = domModule.node;
@@ -238,7 +238,7 @@ function _getFlattenedAndResolvedBehaviors(
   const warnings: Warning[] = [];
   for (const behavior of behaviorAssignments) {
     const foundBehaviors =
-        document.getById('behavior', behavior.name, {lookInDependencies: true});
+        document.getById('behavior', behavior.name, {imported: true});
     if (foundBehaviors.size === 0) {
       warnings.push({
         message: `Unable to resolve behavior ` +

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -67,7 +67,7 @@ suite('Analyzer', () => {
               'static/analysis/simple/simple-element.html');
           const elements = Array.from(
               document.getByKind('element', {lookInDependencies: false}));
-          assert.deepEqual(elements.map(e => e.tagName), ['simple-element']);
+          assert.deepEqual(elements.map((e) => e.tagName), ['simple-element']);
         });
 
     test(
@@ -77,7 +77,7 @@ suite('Analyzer', () => {
               'static/analysis/separate-js/element.html');
           const elements = Array.from(
               document.getByKind('element', {lookInDependencies: true}));
-          assert.deepEqual(elements.map(e => e.tagName), ['my-element']);
+          assert.deepEqual(elements.map((e) => e.tagName), ['my-element']);
         });
 
     test('analyzes a document with an import', async() => {
@@ -87,7 +87,7 @@ suite('Analyzer', () => {
       const behaviors = Array.from(
           document.getByKind('behavior', {lookInDependencies: true}));
       assert.deepEqual(
-          behaviors.map(b => b.className),
+          behaviors.map((b) => b.className),
           ['MyNamespace.SubBehavior', 'MyNamespace.SimpleBehavior']);
     });
 
@@ -188,7 +188,7 @@ suite('Analyzer', () => {
               Array
                   .from(document.getByKind(
                       'document', {lookInDependencies: false}))
-                  .filter(d => d.isInline);
+                  .filter((d) => d.isInline);
           assert.equal(inlineDocuments.length, 1);
           const inlineJsDocument = inlineDocuments[0];
 
@@ -326,7 +326,7 @@ suite('Analyzer', () => {
           {lookInDependencies: true})!;
       assert.deepEqual(
           Array.from(inFolder.getByKind('document', {lookInDependencies: true}))
-              .map(d => d.url),
+              .map((d) => d.url),
           [
             'static/dependencies/subfolder/in-folder.html',
             'static/dependencies/subfolder/subfolder-sibling.html'
@@ -355,25 +355,25 @@ suite('Analyzer', () => {
       const shallowFeatures = document.getFeatures({lookInDependencies: false});
       assert.deepEqual(
           Array.from(shallowFeatures)
-              .filter(f => f.kinds.has('document'))
-              .map(f => (f as Document).url),
+              .filter((f) => f.kinds.has('document'))
+              .map((f) => (f as Document).url),
           ['static/circular/mutual-a.html']);
       assert.deepEqual(
           Array.from(shallowFeatures)
-              .filter(f => f.kinds.has('import'))
-              .map(f => (f as Import).url),
+              .filter((f) => f.kinds.has('import'))
+              .map((f) => (f as Import).url),
           ['static/circular/mutual-b.html']);
 
       const deepFeatures = document.getFeatures({lookInDependencies: true});
       assert.deepEqual(
           Array.from(deepFeatures)
-              .filter(f => f.kinds.has('document'))
-              .map(f => (f as Document).url),
+              .filter((f) => f.kinds.has('document'))
+              .map((f) => (f as Document).url),
           ['static/circular/mutual-a.html', 'static/circular/mutual-b.html']);
       assert.deepEqual(
           Array.from(deepFeatures)
-              .filter(f => f.kinds.has('import'))
-              .map(f => (f as Import).url),
+              .filter((f) => f.kinds.has('import'))
+              .map((f) => (f as Import).url),
           ['static/circular/mutual-b.html', 'static/circular/mutual-a.html']);
     });
 
@@ -393,13 +393,13 @@ suite('Analyzer', () => {
       const features = document.getFeatures({lookInDependencies: true});
       assert.deepEqual(
           Array.from(features)
-              .filter(f => f.kinds.has('document'))
-              .map(f => (f as Document).url),
+              .filter((f) => f.kinds.has('document'))
+              .map((f) => (f as Document).url),
           ['static/circular/self-import.html']);
       assert.deepEqual(
           Array.from(features)
-              .filter(f => f.kinds.has('import'))
-              .map(f => (f as Import).url),
+              .filter((f) => f.kinds.has('import'))
+              .map((f) => (f as Import).url),
           [
             'static/circular/self-import.html',
             'static/circular/self-import.html'
@@ -441,10 +441,10 @@ suite('Analyzer', () => {
       const features = <ScannedImport[]>(
           await analyzer['_context']['_getScannedFeatures'](document));
       assert.deepEqual(
-          features.map(e => e.type),
+          features.map((e) => e.type),
           ['html-import', 'html-script', 'html-style']);
       assert.deepEqual(
-          features.map(e => e.url),  //
+          features.map((e) => e.url),  //
           ['polymer.html', 'foo.js', 'foo.css']);
     });
 
@@ -461,7 +461,7 @@ suite('Analyzer', () => {
       const features =
           <ScannedImport[]>(
               await analyzer['_context']['_getScannedFeatures'](document))
-              .filter(e => e instanceof ScannedImport);
+              .filter((e) => e instanceof ScannedImport);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
       assert.equal(features[0].url, 'bar.css');
@@ -554,7 +554,7 @@ suite('Analyzer', () => {
       const elements = Array.from(
           document.getByKind('polymer-element', {lookInDependencies: false}));
       assert.deepEqual(
-          elements.map(e => e.tagName), ['test-seed', 'test-element']);
+          elements.map((e) => e.tagName), ['test-seed', 'test-element']);
       const testSeed = elements[0];
 
       assert.deepEqual(
@@ -565,7 +565,7 @@ suite('Analyzer', () => {
       assert.equal(testSeed.properties.length, 4);
 
       assert.deepEqual(
-          testSeed.events.map(e => e.name), ['fired-event', 'data-changed']);
+          testSeed.events.map((e) => e.name), ['fired-event', 'data-changed']);
     });
   });
 
@@ -579,7 +579,7 @@ suite('Analyzer', () => {
       // The root documents of the project are a minimal set of documents whose
       // imports touch every document in the project.
       assert.deepEqual(
-          Array.from(project['_documents']).map(d => d.url).sort(),
+          Array.from(project['_documents']).map((d) => d.url).sort(),
           ['cyclic-a.html', 'root.html', 'subdir/root-in-subdir.html']
               .sort(), );
 
@@ -587,7 +587,8 @@ suite('Analyzer', () => {
       // bower_components directory that are reachable from imports in the
       // project.
       assert.deepEqual(
-          Array.from(project.getByKind('element')).map(e => e.tagName).sort(), [
+          Array.from(project.getByKind('element')).map((e) => e.tagName).sort(),
+          [
             'root-root',
             'leaf-leaf',
             'cyclic-a',
@@ -652,7 +653,7 @@ suite('Analyzer', () => {
                 await p;
                 const docs = Array.from(
                     cacheContext['_cache'].analyzedDocuments.values());
-                assert.isTrue(new Set(docs.map(d => d.url).sort()).has(path));
+                assert.isTrue(new Set(docs.map((d) => d.url).sort()).has(path));
               })());
             }
           }
@@ -671,7 +672,7 @@ suite('Analyzer', () => {
       for (const document of documents) {
         assert.deepEqual(document.url, 'base.html');
         const localFeatures = document.getFeatures({lookInDependencies: false});
-        const kinds = Array.from(localFeatures).map(f => Array.from(f.kinds));
+        const kinds = Array.from(localFeatures).map((f) => Array.from(f.kinds));
         const message = `localFeatures: ${JSON.stringify(
             Array.from(localFeatures).map((f) => ({
                                             kinds: Array.from(f.kinds),
@@ -688,16 +689,16 @@ suite('Analyzer', () => {
         const imports = Array.from(
             document.getByKind('import', {lookInDependencies: true}));
         assert.sameMembers(
-            imports.map(m => m.url),
+            imports.map((m) => m.url),
             ['a.html', 'b.html', 'common.html', 'common.html']);
         const docs = Array.from(
             document.getByKind('document', {lookInDependencies: true}));
         assert.sameMembers(
-            docs.map(d => d.url),
+            docs.map((d) => d.url),
             ['a.html', 'b.html', 'base.html', 'common.html']);
         const refs = Array.from(document.getByKind(
             'element-reference', {lookInDependencies: true}));
-        assert.sameMembers(refs.map(ref => ref.tagName), ['custom-el']);
+        assert.sameMembers(refs.map((ref) => ref.tagName), ['custom-el']);
       }
     };
 
@@ -853,7 +854,7 @@ suite('Analyzer', () => {
         const root = documents[1];
 
         const localFeatures = root.getFeatures({lookInDependencies: false});
-        const kinds = Array.from(localFeatures).map(f => Array.from(f.kinds));
+        const kinds = Array.from(localFeatures).map((f) => Array.from(f.kinds));
         assert.deepEqual(kinds, [
           ['document', 'html-document'],
           ['import', 'html-import'],

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -65,7 +65,8 @@ suite('Analyzer', () => {
         async() => {
           const document = await analyzer.analyze(
               'static/analysis/simple/simple-element.html');
-          const elements = Array.from(document.getByKind('element'));
+          const elements = Array.from(
+              document.getByKind('element', {lookInDependencies: false}));
           assert.deepEqual(elements.map(e => e.tagName), ['simple-element']);
         });
 
@@ -74,7 +75,8 @@ suite('Analyzer', () => {
         async() => {
           const document = await analyzer.analyze(
               'static/analysis/separate-js/element.html');
-          const elements = Array.from(document.getByKind('element'));
+          const elements = Array.from(
+              document.getByKind('element', {lookInDependencies: true}));
           assert.deepEqual(elements.map(e => e.tagName), ['my-element']);
         });
 
@@ -82,7 +84,8 @@ suite('Analyzer', () => {
       const document =
           await analyzer.analyze('static/analysis/behaviors/behavior.html');
 
-      const behaviors = Array.from(document.getByKind('behavior'));
+      const behaviors = Array.from(
+          document.getByKind('behavior', {lookInDependencies: true}));
       assert.deepEqual(
           behaviors.map(b => b.className),
           ['MyNamespace.SubBehavior', 'MyNamespace.SimpleBehavior']);
@@ -93,9 +96,7 @@ suite('Analyzer', () => {
         async() => {
           const document =
               await analyzer.analyze('static/html-missing-behaviors.html');
-          // TODO(#372): this should be false, we should treat inline documents
-          //     as not requiring `deep` to be true.
-          const warnings = document.getWarnings(true);
+          const warnings = document.getWarnings({lookInDependencies: false});
           assert.deepEqual(warnings, [
             {
               message:
@@ -124,7 +125,9 @@ suite('Analyzer', () => {
           const document = await analyzer.analyze(
               'static/chained-missing-behavior/index.html');
           const chainedDocument = document.getOnlyAtId(
-              'document', 'static/chained-missing-behavior/chained.html')!;
+              'document',
+              'static/chained-missing-behavior/chained.html',
+              {lookInDependencies: true})!;
           const expectedWarning = {
             code: 'unknown-polymer-behavior',
             message:
@@ -136,12 +139,14 @@ suite('Analyzer', () => {
               file: 'static/chained-missing-behavior/chained.html'
             },
           };
-          assert.deepEqual(document.getWarnings(false), []);
-          assert.deepEqual(document.getWarnings(true), [expectedWarning]);
-          // TODO(#372): this should be false, we should treat inline documents
-          //     as not requiring `deep` to be true.
           assert.deepEqual(
-              chainedDocument.getWarnings(true), [expectedWarning]);
+              document.getWarnings({lookInDependencies: false}), []);
+          assert.deepEqual(
+              document.getWarnings({lookInDependencies: true}),
+              [expectedWarning]);
+          assert.deepEqual(
+              chainedDocument.getWarnings({lookInDependencies: false}),
+              [expectedWarning]);
         });
 
     test(
@@ -149,15 +154,17 @@ suite('Analyzer', () => {
         async() => {
           const document =
               await analyzer.analyze('static/analysis/behaviors/behavior.html');
-          // TODO(justinfagnani): make a shallow option and check that this only
-          // has itself and an inline document, but not the sub-document. For
-          // now check that this fixture has 4 documents: behavior.html,
-          // subbehavior.html, and their inline js documents
-          const documents = document.getByKind('document');
-          assert.equal(documents.size, 4);
+
+          const localDocuments =
+              document.getByKind('document', {lookInDependencies: false});
+          assert.equal(localDocuments.size, 2);  // behavior.html and its inline
+
+          const allDocuments =
+              document.getByKind('document', {lookInDependencies: true});
+          assert.equal(allDocuments.size, 4);
 
           const inlineDocuments =
-              Array.from(document.getFeatures(false))
+              Array.from(document.getFeatures({lookInDependencies: false}))
                   .filter(
                       (d) => d instanceof Document && d.isInline) as Document[];
           assert.equal(inlineDocuments.length, 1);
@@ -166,7 +173,9 @@ suite('Analyzer', () => {
           // document that's imported by the container document
           const behaviorJsDocument = inlineDocuments[0];
           const subBehavior = behaviorJsDocument.getOnlyAtId(
-              'behavior', 'MyNamespace.SubBehavior');
+              'behavior',
+              'MyNamespace.SubBehavior',
+              {lookInDependencies: true});
           assert.equal(subBehavior!.className, 'MyNamespace.SubBehavior');
         });
 
@@ -175,18 +184,17 @@ suite('Analyzer', () => {
         async() => {
           const document = await analyzer.analyze(
               'static/script-tags/inline/test-element.html');
-          // TODO(justinfagnani): this could be better with a shallow
-          // Document.getByKind()
           const inlineDocuments =
-              Array.from(document.getFeatures(false))
-                  .filter(
-                      (d) => d instanceof Document && d.isInline) as Document[];
+              Array
+                  .from(document.getByKind(
+                      'document', {lookInDependencies: false}))
+                  .filter(d => d.isInline);
           assert.equal(inlineDocuments.length, 1);
           const inlineJsDocument = inlineDocuments[0];
 
           // The inline document can find the container's imported features
-          const subBehavior =
-              inlineJsDocument.getOnlyAtId('behavior', 'TestBehavior');
+          const subBehavior = inlineJsDocument.getOnlyAtId(
+              'behavior', 'TestBehavior', {lookInDependencies: true});
           assert.equal(subBehavior!.className, 'TestBehavior');
         });
 
@@ -196,16 +204,17 @@ suite('Analyzer', () => {
           const document = await analyzer.analyze(
               'static/script-tags/external/test-element.html');
 
-          const htmlScriptTags = Array.from(document.getByKind('html-script'));
+          const htmlScriptTags = Array.from(
+              document.getByKind('html-script', {lookInDependencies: false}));
           assert.equal(htmlScriptTags.length, 1);
 
           const htmlScriptTag = htmlScriptTags[0] as ScriptTagImport;
           const scriptDocument = htmlScriptTag.document;
 
           // The inline document can find the container's imported features
-          const subBehavior =
-              scriptDocument.getOnlyAtId('behavior', 'TestBehavior');
-          assert.equal(subBehavior!.className, 'TestBehavior');
+          const subBehavior = scriptDocument.getOnlyAtId(
+              'behavior', 'TestBehavior', {lookInDependencies: true})!;
+          assert.equal(subBehavior.className, 'TestBehavior');
         });
 
 
@@ -220,32 +229,27 @@ suite('Analyzer', () => {
           const document = await analyzer.analyze(
               'static/analysis/behaviors/elementdir/element.html');
 
-          // TODO(justinfagnani): make a shallow option and check that this only
-          // has
-          // itself and an inline document, but not the sub-document. For now
-          // check
-          // that this fixture has 6 documents: element.html, behavior.html,
-          // subbehavior.html, and their inline js documents
-          const documents = document.getByKind('document');
-          assert.equal(documents.size, 6);
+          const documents =
+              document.getByKind('document', {lookInDependencies: false});
+          assert.equal(documents.size, 2);
 
-          const inlineDocuments =
-              Array.from(document.getFeatures(false))
-                  .filter(
-                      (d) => d instanceof Document && d.isInline) as Document[];
+          const inlineDocuments = Array.from(documents).filter(
+              (d) => d instanceof Document && d.isInline) as Document[];
           assert.equal(inlineDocuments.length, 1);
 
           // This is the main purpose of the test: get a feature from the inline
           // document that's imported by the container document
           const behaviorJsDocument = inlineDocuments[0];
           const subBehavior = behaviorJsDocument.getOnlyAtId(
-              'behavior', 'MyNamespace.SubBehavior');
-          assert.equal(subBehavior!.className, 'MyNamespace.SubBehavior');
+              'behavior',
+              'MyNamespace.SubBehavior',
+              {lookInDependencies: true})!;
+          assert.equal(subBehavior.className, 'MyNamespace.SubBehavior');
         });
 
     test('returns a Document with warnings for malformed files', async() => {
       const document = await analyzer.analyze('static/malformed.html');
-      assert(document.getWarnings().length >= 1);
+      assert(document.getWarnings({lookInDependencies: false}).length >= 1);
     });
 
     test('analyzes transitive dependencies', async() => {
@@ -253,7 +257,7 @@ suite('Analyzer', () => {
 
       // If we ask for documents we get every document in evaluation order.
       assert.deepEqual(
-          Array.from(root.getByKind('document'))
+          Array.from(root.getByKind('document', {lookInDependencies: true}))
               .map((d) => [d.url, d.parsedDocument.type, d.isInline]),
           [
             ['static/dependencies/root.html', 'html', false],
@@ -275,36 +279,55 @@ suite('Analyzer', () => {
       // If we ask for imports we get the import statements in evaluation order.
       // Unlike documents, we can have duplicates here because imports exist
       // in distinct places in their containing docs.
-      assert.deepEqual(Array.from(root.getByKind('import')).map((d) => d.url), [
-        'static/dependencies/inline-only.html',
-        'static/dependencies/leaf.html',
-        'static/dependencies/inline-and-imports.html',
-        'static/dependencies/subfolder/in-folder.html',
-        'static/dependencies/subfolder/subfolder-sibling.html',
-        'static/dependencies/subfolder/in-folder.html',
-      ]);
-
-      const inlineOnly =
-          root.getOnlyAtId('document', 'static/dependencies/inline-only.html');
       assert.deepEqual(
-          Array.from(inlineOnly!.getByKind('document'))
+          Array.from(root.getByKind('import', {lookInDependencies: true}))
+              .map((d) => d.url),
+          [
+            'static/dependencies/inline-only.html',
+            'static/dependencies/leaf.html',
+            'static/dependencies/inline-and-imports.html',
+            'static/dependencies/subfolder/in-folder.html',
+            'static/dependencies/subfolder/subfolder-sibling.html',
+            'static/dependencies/subfolder/in-folder.html',
+          ]);
+
+      const inlineOnly = root.getOnlyAtId(
+          'document',
+          'static/dependencies/inline-only.html',
+          {lookInDependencies: true});
+      assert.deepEqual(
+          Array
+              .from(
+                  inlineOnly!.getByKind('document', {lookInDependencies: true}))
               .map((d) => d.parsedDocument.type),
           ['html', 'js', 'css']);
 
-      const leaf =
-          root.getOnlyAtId('document', 'static/dependencies/leaf.html');
-      assert.deepEqual(Array.from(leaf!.getByKind('document')), [leaf]);
+      const leaf = root.getOnlyAtId(
+          'document',
+          'static/dependencies/leaf.html',
+          {lookInDependencies: true})!;
+      assert.deepEqual(
+          Array.from(leaf.getByKind('document', {lookInDependencies: true})),
+          [leaf]);
 
       const inlineAndImports = root.getOnlyAtId(
-          'document', 'static/dependencies/inline-and-imports.html');
+          'document',
+          'static/dependencies/inline-and-imports.html',
+          {lookInDependencies: true})!;
       assert.deepEqual(
-          Array.from(inlineAndImports!.getByKind('document'))
+          Array
+              .from(inlineAndImports.getByKind(
+                  'document', {lookInDependencies: true}))
               .map((d) => d.parsedDocument.type),
           ['html', 'js', 'html', 'html', 'css']);
       const inFolder = root.getOnlyAtId(
-          'document', 'static/dependencies/subfolder/in-folder.html');
+          'document',
+          'static/dependencies/subfolder/in-folder.html',
+          {lookInDependencies: true})!;
       assert.deepEqual(
-          Array.from(inFolder!.getByKind('document')).map(d => d.url), [
+          Array.from(inFolder.getByKind('document', {lookInDependencies: true}))
+              .map(d => d.url),
+          [
             'static/dependencies/subfolder/in-folder.html',
             'static/dependencies/subfolder/subfolder-sibling.html'
           ]);
@@ -312,7 +335,9 @@ suite('Analyzer', () => {
       // check de-duplication
       assert.equal(
           inlineAndImports!.getOnlyAtId(
-              'document', 'static/dependencies/subfolder/in-folder.html'),
+              'document',
+              'static/dependencies/subfolder/in-folder.html',
+              {lookInDependencies: true}),
           inFolder);
     });
 
@@ -327,7 +352,7 @@ suite('Analyzer', () => {
 
     test('handles mutually recursive documents', async() => {
       const document = await analyzer.analyze('static/circular/mutual-a.html');
-      const shallowFeatures = document.getFeatures(false);
+      const shallowFeatures = document.getFeatures({lookInDependencies: false});
       assert.deepEqual(
           Array.from(shallowFeatures)
               .filter(f => f.kinds.has('document'))
@@ -339,7 +364,7 @@ suite('Analyzer', () => {
               .map(f => (f as Import).url),
           ['static/circular/mutual-b.html']);
 
-      const deepFeatures = document.getFeatures(true);
+      const deepFeatures = document.getFeatures({lookInDependencies: true});
       assert.deepEqual(
           Array.from(deepFeatures)
               .filter(f => f.kinds.has('document'))
@@ -365,7 +390,7 @@ suite('Analyzer', () => {
     test('handles a document importing itself', async() => {
       const document =
           await analyzer.analyze('static/circular/self-import.html');
-      const features = document.getFeatures(true);
+      const features = document.getFeatures({lookInDependencies: true});
       assert.deepEqual(
           Array.from(features)
               .filter(f => f.kinds.has('document'))
@@ -488,7 +513,8 @@ suite('Analyzer', () => {
 
       // In document, we'll change `foo` to `bar` in the js and `blue` to
       // `red` in the css.
-      const jsDocs = document.getByKind('js-document') as Set<Document>;
+      const jsDocs =
+          document.getByKind('js-document', {lookInDependencies: true});
       assert.equal(1, jsDocs.size);
       const jsDoc = jsDocs.values().next().value;
       (jsDoc.parsedDocument as JavaScriptDocument).visit([{
@@ -498,7 +524,8 @@ suite('Analyzer', () => {
         }
       }]);
 
-      const cssDocs = document.getByKind('css-document') as Set<Document>;
+      const cssDocs =
+          document.getByKind('css-document', {lookInDependencies: true});
       assert.equal(1, cssDocs.size);
       const cssDoc = cssDocs.values().next().value;
       (cssDoc.parsedDocument as ParsedCssDocument).visit([{
@@ -524,7 +551,8 @@ suite('Analyzer', () => {
     test.skip('parses classes', async() => {
       const document = await analyzer.analyze('static/es6-support.js');
 
-      const elements = Array.from(document.getByKind('polymer-element'));
+      const elements = Array.from(
+          document.getByKind('polymer-element', {lookInDependencies: false}));
       assert.deepEqual(
           elements.map(e => e.tagName), ['test-seed', 'test-element']);
       const testSeed = elements[0];
@@ -642,7 +670,7 @@ suite('Analyzer', () => {
       const documents = await Promise.all(promises);
       for (const document of documents) {
         assert.deepEqual(document.url, 'base.html');
-        const localFeatures = document.getFeatures(false);
+        const localFeatures = document.getFeatures({lookInDependencies: false});
         const kinds = Array.from(localFeatures).map(f => Array.from(f.kinds));
         const message = `localFeatures: ${JSON.stringify(
             Array.from(localFeatures).map((f) => ({
@@ -657,15 +685,18 @@ suite('Analyzer', () => {
               ['import', 'html-import']
             ],
             message);
-        const imports = Array.from(document.getByKind('import'));
+        const imports = Array.from(
+            document.getByKind('import', {lookInDependencies: true}));
         assert.sameMembers(
             imports.map(m => m.url),
             ['a.html', 'b.html', 'common.html', 'common.html']);
-        const docs = Array.from(document.getByKind('document'));
+        const docs = Array.from(
+            document.getByKind('document', {lookInDependencies: true}));
         assert.sameMembers(
             docs.map(d => d.url),
             ['a.html', 'b.html', 'base.html', 'common.html']);
-        const refs = Array.from(document.getByKind('element-reference'));
+        const refs = Array.from(document.getByKind(
+            'element-reference', {lookInDependencies: true}));
         assert.sameMembers(refs.map(ref => ref.tagName), ['custom-el']);
       }
     };
@@ -821,7 +852,7 @@ suite('Analyzer', () => {
 
         const root = documents[1];
 
-        const localFeatures = root.getFeatures(false);
+        const localFeatures = root.getFeatures({lookInDependencies: false});
         const kinds = Array.from(localFeatures).map(f => Array.from(f.kinds));
         assert.deepEqual(kinds, [
           ['document', 'html-document'],
@@ -881,8 +912,8 @@ suite('Analyzer', () => {
             'static/multiple-behavior-imports/element-a.html');
         const documentB = await analyzer.analyze(
             'static/multiple-behavior-imports/element-b.html');
-        assert.deepEqual(documentA.getWarnings(true), []);
-        assert.deepEqual(documentB.getWarnings(true), []);
+        assert.deepEqual(documentA.getWarnings({lookInDependencies: true}), []);
+        assert.deepEqual(documentB.getWarnings({lookInDependencies: true}), []);
       });
 
       test(
@@ -896,8 +927,10 @@ suite('Analyzer', () => {
             ]);
             const documentA = result[0];
             const documentB = result[1];
-            assert.deepEqual(documentA.getWarnings(true), []);
-            assert.deepEqual(documentB.getWarnings(true), []);
+            assert.deepEqual(
+                documentA.getWarnings({lookInDependencies: true}), []);
+            assert.deepEqual(
+                documentB.getWarnings({lookInDependencies: true}), []);
           });
     });
   });

--- a/src/test/editor-service/ast-from-source-position_test.ts
+++ b/src/test/editor-service/ast-from-source-position_test.ts
@@ -170,7 +170,7 @@ suite('getLocationInfoForPosition', () => {
   function getAllKindsSpaceSeparated(text: string) {
     const doc = parser.parse(text, 'uninteresting file name.html');
     return getEveryPosition(text)
-        .map(pos => getLocationInfoForPosition(doc, pos).kind)
+        .map((pos) => getLocationInfoForPosition(doc, pos).kind)
         .join(' ');
   }
 });

--- a/src/test/editor-service/editor-server-test.ts
+++ b/src/test/editor-service/editor-server-test.ts
@@ -145,7 +145,7 @@ suite('RemoteEditorService', () => {
 
     async function getNextResponse(expectedId: number) {
       const line =
-          await new Promise<string>(resolve => lines.once('data', resolve));
+          await new Promise<string>((resolve) => lines.once('data', resolve));
       const message = JSON.parse(line);
       assert.equal(message.id, expectedId);
       if (message.value.kind === 'resolution') {

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -65,7 +65,7 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
   // in a context where we don't have one.
   const emptyStartElementTypeahead = Object.assign({}, elementTypeahead);
   emptyStartElementTypeahead.elements =
-      emptyStartElementTypeahead.elements.map(e => {
+      emptyStartElementTypeahead.elements.map((e) => {
         const copy = Object.assign({}, e);
         let space = '';
         const elementsWithAttributes =

--- a/src/test/generate_elements_test.ts
+++ b/src/test/generate_elements_test.ts
@@ -157,5 +157,5 @@ async function analyzeDir(baseDir: string) {
               fn => `<link rel="import" href="${path.relative(baseDir, fn)}">`);
   const document = await analyzer.analyze(
       path.join('ephemeral.html'), importStatements.join('\n'));
-  return Array.from(document.getByKind('element'));
+  return Array.from(document.getByKind('element', {lookInDependencies: true}));
 }

--- a/src/test/generate_elements_test.ts
+++ b/src/test/generate_elements_test.ts
@@ -31,8 +31,8 @@ const skipTests = new Set<string>(['bower_packages', 'nested-packages']);
 suite('elements.json generation', function() {
   const basedir = path.join(__dirname, 'static', 'analysis');
   const analysisFixtureDirs = fs.readdirSync(basedir)
-                                  .map(p => path.join(basedir, p))
-                                  .filter(p => fs.statSync(p).isDirectory());
+                                  .map((p) => path.join(basedir, p))
+                                  .filter((p) => fs.statSync(p).isDirectory());
 
   for (const analysisFixtureDir of analysisFixtureDirs) {
     // Generate a test from the goldens found in every dir in
@@ -154,7 +154,8 @@ async function analyzeDir(baseDir: string) {
   const importStatements =
       Array.from(filterI(walkRecursively(baseDir), (f) => f.endsWith('.html')))
           .map(
-              fn => `<link rel="import" href="${path.relative(baseDir, fn)}">`);
+              (fn) =>
+                  `<link rel="import" href="${path.relative(baseDir, fn)}">`);
   const document = await analyzer.analyze(
       path.join('ephemeral.html'), importStatements.join('\n'));
   return Array.from(document.getByKind('element', {lookInDependencies: true}));

--- a/src/test/generate_elements_test.ts
+++ b/src/test/generate_elements_test.ts
@@ -158,5 +158,5 @@ async function analyzeDir(baseDir: string) {
                   `<link rel="import" href="${path.relative(baseDir, fn)}">`);
   const document = await analyzer.analyze(
       path.join('ephemeral.html'), importStatements.join('\n'));
-  return Array.from(document.getByKind('element', {lookInDependencies: true}));
+  return Array.from(document.getByKind('element', {imported: true}));
 }

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -44,7 +44,7 @@ suite('HtmlElementReferenceScanner', () => {
       const features = await scanner.scan(document, visit);
 
       assert.deepEqual(
-          features.map(f => f.tagName),
+          features.map((f) => f.tagName),
           ['html', 'head', 'body', 'div', 'x-foo', 'div', 'x-bar']);
     });
   });
@@ -81,14 +81,14 @@ suite('HtmlCustomElementReferenceScanner', () => {
       const features = await scanner.scan(document, visit);
 
       assert.deepEqual(
-          features.map(f => f.tagName), ['x-foo', 'x-bar', 'x-baz']);
+          features.map((f) => f.tagName), ['x-foo', 'x-bar', 'x-baz']);
 
       assert.deepEqual(
-          features[0].attributes.map(a => [a.name, a.value]),
+          features[0].attributes.map((a) => [a.name, a.value]),
           [['a', '5'], ['b', 'test'], ['c', '']]);
 
       const sourceRanges = await Promise.all(
-          features.map(async f => await underliner.underline(f.sourceRange)));
+          features.map(async(f) => await underliner.underline(f.sourceRange)));
 
       assert.deepEqual(sourceRanges, [
         `
@@ -103,8 +103,8 @@ suite('HtmlCustomElementReferenceScanner', () => {
       ]);
 
       const attrRanges = await Promise.all(features.map(
-          async f => await Promise.all(f.attributes.map(
-              async a => await underliner.underline(a.sourceRange)))));
+          async(f) => await Promise.all(f.attributes.map(
+              async(a) => await underliner.underline(a.sourceRange)))));
 
       assert.deepEqual(attrRanges, [
         [
@@ -123,8 +123,8 @@ suite('HtmlCustomElementReferenceScanner', () => {
       ]);
 
       const attrNameRanges = await Promise.all(features.map(
-          async f => await underliner.underline(
-              f.attributes.map(a => a.nameSourceRange))));
+          async(f) => await underliner.underline(
+              f.attributes.map((a) => a.nameSourceRange))));
 
       assert.deepEqual(attrNameRanges, [
         [
@@ -143,8 +143,8 @@ suite('HtmlCustomElementReferenceScanner', () => {
       ]);
 
       const attrValueRanges = await Promise.all(features.map(
-          async f => await Promise.all(f.attributes.map(
-              async a => await underliner.underline(a.valueSourceRange)))));
+          async(f) => await Promise.all(f.attributes.map(
+              async(a) => await underliner.underline(a.valueSourceRange)))));
 
       assert.deepEqual(attrValueRanges, [
         [

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -82,14 +82,14 @@ suite('HtmlImportScanner', () => {
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
       const features = await scanner.scan(document, visit);
-      assert.deepEqual(features.map(f => f.type), [
+      assert.deepEqual(features.map((f) => f.type), [
         'html-import',
         'lazy-html-import',
         'lazy-html-import',
         'lazy-html-import'
       ]);
       assert.deepEqual(
-          features.map(f => f.url),
+          features.map((f) => f.url),
           ['polymer.html', 'lazy1.html', 'lazy2.html', 'lazy3.html']);
     });
 

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -49,7 +49,7 @@ suite('BehaviorScanner', () => {
   });
 
   test('Finds behavior object assignments', () => {
-    assert.deepEqual(behaviorsList.map(b => b.className).sort(), [
+    assert.deepEqual(behaviorsList.map((b) => b.className).sort(), [
       'SimpleBehavior',
       'AwesomeBehavior',
       'Really.Really.Deep.Behavior',

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -94,20 +94,20 @@ suite('PolymerElementScanner', () => {
 
       const features = await scanner.scan(document, visit);
 
-      assert.deepEqual(features.map(f => f.tagName), ['x-foo', 'x-bar']);
+      assert.deepEqual(features.map((f) => f.tagName), ['x-foo', 'x-bar']);
 
       assert.deepEqual(
-          features[0].observers.map(o => o.expression),
+          features[0].observers.map((o) => o.expression),
           ['_anObserver()', '_anotherObserver()']);
       assert.deepEqual(
-          features[0].events.map(e => e.name), ['e-changed', 'all-changed']);
+          features[0].events.map((e) => e.name), ['e-changed', 'all-changed']);
 
       assert.equal(features[0].properties.length, 9);
 
       assert.deepEqual(
           features[0]
-              .properties.filter(p => p.warnings.length > 0)
-              .map(p => [p.name, p.warnings.map(w => w.message)]),
+              .properties.filter((p) => p.warnings.length > 0)
+              .map((p) => [p.name, p.warnings.map((w) => w.message)]),
           [[
             'g',
             [
@@ -116,7 +116,7 @@ suite('PolymerElementScanner', () => {
             ]
           ]]);
 
-      assert.deepEqual(features[0].properties.map(p => [p.name, p.type]), [
+      assert.deepEqual(features[0].properties.map((p) => [p.name, p.type]), [
         ['a', 'boolean'],
         ['b', 'string'],
         ['c', 'number'],
@@ -129,7 +129,7 @@ suite('PolymerElementScanner', () => {
       ]);
 
       assert.deepEqual(
-          features[0].attributes.map(p => [p.name, p.changeEvent]), [
+          features[0].attributes.map((p) => [p.name, p.changeEvent]), [
             ['a', undefined],
             ['b', undefined],
             ['c', undefined],
@@ -142,17 +142,17 @@ suite('PolymerElementScanner', () => {
           ]);
 
       assert.deepEqual(
-          features[0].properties.filter(p => p.readOnly).map(p => p.name),
+          features[0].properties.filter((p) => p.readOnly).map((p) => p.name),
           ['c', 'd', 'g']);
 
       assert.deepEqual(
           features[0]
-              .properties.filter(p => p.default)
-              .map(p => [p.name, p.default]),
+              .properties.filter((p) => p.default)
+              .map((p) => [p.name, p.default]),
           [['a', '5'], ['b', '"test"']]);
 
       assert.deepEqual(
-          features[0].properties.filter(p => p.notify).map(p => p.name),
+          features[0].properties.filter((p) => p.notify).map((p) => p.name),
           ['e', 'all']);
 
       assert.deepEqual(features[0].listeners, [
@@ -163,13 +163,15 @@ suite('PolymerElementScanner', () => {
       // Skip not statically analizable entries without emitting a warning
       assert.equal(
           features[0]
-              .warnings.filter(w => w.code === 'invalid-listeners-declaration')
+              .warnings
+              .filter((w) => w.code === 'invalid-listeners-declaration')
               .length,
           0);
       // Emit warning for non-object `listeners` literal
       assert.equal(
           features[1]
-              .warnings.filter(w => w.code === 'invalid-listeners-declaration')
+              .warnings
+              .filter((w) => w.code === 'invalid-listeners-declaration')
               .length,
           1);
     });

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -92,7 +92,7 @@ export class CodeUnderliner {
           isWarning(references) ? references.sourceRange : references;
       return '\n' + await this.warningPrinter.getUnderlinedText(sourceRange);
     }
-    return Promise.all(references.map(ref => this.underline(ref)));
+    return Promise.all(references.map((ref) => this.underline(ref)));
   }
 }
 

--- a/src/test/vanilla-custom-elements/element-scanner_test.ts
+++ b/src/test/vanilla-custom-elements/element-scanner_test.ts
@@ -50,7 +50,7 @@ suite('VanillaElementScanner', () => {
   });
 
   test('Finds elements', () => {
-    assert.deepEqual(elementsList.map(e => e.tagName).sort(), [
+    assert.deepEqual(elementsList.map((e) => e.tagName).sort(), [
       'anonymous-class',
       'class-declaration',
       'class-expression',
@@ -58,7 +58,7 @@ suite('VanillaElementScanner', () => {
       'register-before-declaration',
       'register-before-expression'
     ].sort());
-    assert.deepEqual(elementsList.map(e => e.className).sort(), [
+    assert.deepEqual(elementsList.map((e) => e.className).sort(), [
       undefined,
       'ClassDeclaration',
       'ClassExpression',
@@ -66,7 +66,7 @@ suite('VanillaElementScanner', () => {
       'RegisterBeforeDeclaration',
       'RegisterBeforeExpression'
     ].sort());
-    assert.deepEqual(elementsList.map(e => e.superClass).sort(), [
+    assert.deepEqual(elementsList.map((e) => e.superClass).sort(), [
       'HTMLElement',
       'HTMLElement',
       'HTMLElement',

--- a/src/typescript/typescript-analyzer.ts
+++ b/src/typescript/typescript-analyzer.ts
@@ -161,7 +161,7 @@ class AnalyzerCompilerHost implements ts.CompilerHost {
 
   resolveModuleNames(moduleNames: string[], containingFile: string):
       ts.ResolvedModule[] {
-    return moduleNames.map(moduleName => {
+    return moduleNames.map((moduleName) => {
       // We only support path resolution, not node resolution
       if (!(moduleName.startsWith('./') || moduleName.startsWith('../') ||
             moduleName.startsWith('/'))) {

--- a/src/typescript/typescript-preparser.ts
+++ b/src/typescript/typescript-preparser.ts
@@ -43,7 +43,7 @@ export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
     const diagnostics =
         (sourceFile['parseDiagnostics'] || []) as ts.Diagnostic[];
     const parseError =
-        diagnostics.find(d => d.category === ts.DiagnosticCategory.Error);
+        diagnostics.find((d) => d.category === ts.DiagnosticCategory.Error);
     if (parseError) {
       const start = sourceFile.getLineAndCharacterOfPosition(parseError.start);
       const end = sourceFile.getLineAndCharacterOfPosition(

--- a/src/vanilla-custom-elements/element-scanner.ts
+++ b/src/vanilla-custom-elements/element-scanner.ts
@@ -85,7 +85,7 @@ class ElementVisitor implements Visitor {
       element.superClass = node.superClass.name;
     }
     const observedAttributesDefn: estree.MethodDefinition|undefined =
-        node.body.body.find(m => {
+        node.body.body.find((m) => {
           if (m.type !== 'MethodDefinition' || !m.static) {
             return false;
           }

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "arrow-parens": true,
         "class-name": true,
         "indent": [
             true,


### PR DESCRIPTION
By default we do not look in dependencies, and we do look in inline documents.

Ironically, it is currently much faster to look in dependencies than not to.

Lays the foundation for more query options, on documents and on packages.

Fixes #372

 - [x] CHANGELOG.md has been updated
