### PR TITLE
Fix scanning of function calls to previously defined behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+### Fixed
+
+* Fixed basic scanning of behaviors as direct function calls
+
 ## [2.0.0-alpha.23] - 2017-02-10
 
 ### Added

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -53,7 +53,9 @@ suite('BehaviorScanner', () => {
       'SimpleBehavior',
       'AwesomeBehavior',
       'Really.Really.Deep.Behavior',
-      'CustomBehaviorList'
+      'CustomBehaviorList',
+      'UnhoistedGeneratedBehaviorBefore',
+      'UnhoistedGeneratedBehaviorAfter'
     ].sort());
   });
 
@@ -100,6 +102,17 @@ suite('BehaviorScanner', () => {
     assert.deepEqual(
         deepChainedBehaviors.map((b: ScannedBehaviorAssignment) => b.name),
         ['Do.Re.Mi.Fa']);
+  });
+
+  test('Supports function calls', function() {
+    assert(behaviors.has('UnhoistedGeneratedBehaviorBefore'));
+    assert(behaviors.has('UnhoistedGeneratedBehaviorAfter'));
+    ['Before', 'After'].forEach((name) => {
+      const behavior = behaviors.get(`UnhoistedGeneratedBehavior${name}`)!;
+      assert.equal(behavior.properties.length, 1);
+      assert.equal(behavior.properties[0].name, 'generatedBy');
+      assert.equal(behavior.properties[0].default, '"unhoistedGenerateBehavior"');
+    });
   });
 
 });

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -22,3 +22,35 @@ Really.Really.Deep.Behavior = [
 */
 CustomBehaviorList =
     [SimpleBehavior, CustomNamedBehavior, Really.Really.Deep.Behavior];
+
+function unhoistedGenerateBehaviorBefore() {
+  return {
+    properties: {
+      generatedBy: {
+        value: 'unhoistedGenerateBehavior'
+      }
+    }
+  };
+}
+
+/**
+ * Call to a function declared before
+ * @polymerBehavior
+*/
+var UnhoistedGeneratedBehaviorBefore = unhoistedGenerateBehaviorBefore();
+
+/**
+* Call to a function declared after
+* @polymerBehavior
+*/
+var UnhoistedGeneratedBehaviorAfter = unhoistedGenerateBehaviorAfter();
+
+function unhoistedGenerateBehaviorAfter() {
+  return {
+    properties: {
+      generatedBy: {
+        value: 'unhoistedGenerateBehavior'
+      }
+    }
+  };
+}


### PR DESCRIPTION
This should at least support the base case of defining behaviors with function calls. There are some edge cases:

- The function call must be the first polymer behavior declaration after the function is defined. Else it will not be able to find the function
- The function must live in the same document (this is a bummer, but the fix uses AST traversal and memoizes function declarations)
- The function must have the return statement as last statement and it must return an object.

Therefore this should fix the issue described in https://github.com/Polymer/polymer-analyzer/issues/432#issuecomment-276699368 but not the issue of the OP, since this uses a function which is globally defined.

 - [x] CHANGELOG.md has been updated
