### PR TITLE
Honor thy <base> tag and resolve thy urls according to its href attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    this comment.
 -->
 
+* Document now includes a `baseUrl` property which is properly resolved
+  from an HTML document's `<base href="...">` tag, when present.
+
 ## [2.0.0-alpha.23] - 2017-02-10
 
 ### Added

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -65,7 +65,7 @@ export class HtmlImportScanner implements HtmlScanner {
         return;
       }
       const href = dom5.getAttribute(node, 'href')!;
-      const importUrl = resolveUrl(document.url, href);
+      const importUrl = resolveUrl(document.baseUrl, href);
       imports.push(new ScannedImport(
           type,
           importUrl,

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -42,7 +42,7 @@ export class HtmlScriptScanner implements HtmlScanner {
       if (isJsScriptNode(node)) {
         const src = dom5.getAttribute(node, 'src');
         if (src) {
-          const importUrl = resolveUrl(document.url, src);
+          const importUrl = resolveUrl(document.baseUrl, src);
           features.push(new ScannedScriptTagImport(
               'html-script',
               importUrl,

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -45,7 +45,7 @@ export class HtmlStyleScanner implements HtmlScanner {
         const tagName = node.nodeName;
         if (tagName === 'link') {
           const href = dom5.getAttribute(node, 'href')!;
-          const importUrl = resolveUrl(document.url, href);
+          const importUrl = resolveUrl(document.baseUrl, href);
           features.push(new ScannedImport(
               'html-style',
               importUrl,

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -23,6 +23,7 @@ import {correctSourceRange, LocationOffset, SourceRange} from '../model/source-r
 export abstract class ParsedDocument<AstNode, Visitor> {
   abstract type: string;
   url: string;
+  baseUrl: string;
   contents: string;
   ast: AstNode;
   isInline: boolean;
@@ -37,6 +38,7 @@ export abstract class ParsedDocument<AstNode, Visitor> {
 
   constructor(from: Options<AstNode>) {
     this.url = from.url;
+    this.baseUrl = from.baseUrl || this.url;
     this.contents = from.contents;
     this.ast = from.ast;
     this._locationOffset = from.locationOffset;
@@ -72,6 +74,7 @@ export abstract class ParsedDocument<AstNode, Visitor> {
 
 export interface Options<A> {
   url: string;
+  baseUrl?: string;
   contents: string;
   ast: A;
   locationOffset: LocationOffset|undefined;

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -38,7 +38,7 @@ export class CssImportScanner implements HtmlScanner {
     await visit((node) => {
       if (isCssImportNode(node)) {
         const href = dom5.getAttribute(node, 'href')!;
-        const importUrl = resolveUrl(document.url, href);
+        const importUrl = resolveUrl(document.baseUrl, href);
         imports.push(new ScannedImport(
             'css-import',
             importUrl,

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -43,6 +43,22 @@ suite('HtmlImportScanner', () => {
       assert.equal(features[0].url, 'polymer.html');
     });
 
+    test('resolves HTML Import URLs relative to baseUrl', async() => {
+      const contents = `<html><head><base href="/aybabtu/">
+          <link rel="import" href="polymer.html">
+          <link rel="import" type="css" href="polymer.css">
+          <script src="foo.js"></script>
+          <link rel="stylesheet" href="foo.css"></link>
+        </head></html>`;
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const features = await scanner.scan(document, visit);
+      assert.equal(features.length, 1);
+      assert.equal(features[0].type, 'html-import');
+      assert.equal(features[0].url, '/aybabtu/polymer.html');
+    });
+
     test('finds lazy HTML Imports', async() => {
       const contents = `<html><head>
           <link rel="import" href="polymer.html">
@@ -59,7 +75,6 @@ suite('HtmlImportScanner', () => {
       assert.equal(features[1].type, 'lazy-html-import');
       assert.equal(features[1].url, 'lazy-polymer.html');
     });
-
   });
 
   suite('scan() with lazy import map', () => {

--- a/src/test/html/html-parser_test.ts
+++ b/src/test/html/html-parser_test.ts
@@ -21,8 +21,6 @@ import {HtmlParser} from '../../html/html-parser';
 suite('HtmlParser', () => {
 
   suite('parse()', () => {
-    const file = fs.readFileSync(
-        path.resolve(__dirname, '../static/html-parse-target.html'), 'utf8');
 
     let parser: HtmlParser;
 
@@ -30,16 +28,29 @@ suite('HtmlParser', () => {
       parser = new HtmlParser();
     });
 
-    test('parses a well-formed document', () => {
-      const document = parser.parse(file, '/static/html-parse-target.html');
-      assert.equal(document.url, '/static/html-parse-target.html');
+    suite('on a well-formed document', () => {
+      const file = fs.readFileSync(
+          path.resolve(__dirname, '../static/html-parse-target.html'), 'utf8');
+
+      test('parses a well-formed document', () => {
+        const document = parser.parse(file, '/static/html-parse-target.html');
+        assert.equal(document.url, '/static/html-parse-target.html');
+      });
+
+      test('can stringify back a well-formed document', () => {
+        const document = parser.parse(file, '/static/html-parse-target.html');
+        assert.deepEqual(document.stringify(), file);
+      });
     });
 
-    test('can stringify back a well-formed document', () => {
-      const document = parser.parse(file, '/static/html-parse-target.html');
-      assert.deepEqual(document.stringify(), file);
+    test('can properly determine the base url of a document', () => {
+      const file = fs.readFileSync(
+          path.resolve(__dirname, '../static/base-href/doc-with-base.html'),
+          'utf8');
+      const document =
+          parser.parse(file, '/static/base-href/doc-with-base.html');
+      assert.equal(document.url, '/static/base-href/doc-with-base.html');
+      assert.equal(document.baseUrl, '/static/');
     });
-
   });
-
 });

--- a/src/test/html/html-style-scanner_test.ts
+++ b/src/test/html/html-style-scanner_test.ts
@@ -16,22 +16,22 @@ import {assert} from 'chai';
 
 import {HtmlVisitor} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
-import {HtmlScriptScanner} from '../../html/html-script-scanner';
+import {HtmlStyleScanner} from '../../html/html-style-scanner';
 import {ScannedImport, ScannedInlineDocument} from '../../model/model';
 
-suite('HtmlScriptScanner', () => {
+suite('HtmlStyleScanner', () => {
 
   suite('scan()', () => {
-    let scanner: HtmlScriptScanner;
+    let scanner: HtmlStyleScanner;
 
     setup(() => {
-      scanner = new HtmlScriptScanner();
+      scanner = new HtmlStyleScanner();
     });
 
-    test('finds external and inline scripts', async() => {
+    test('finds external and inline styles', async() => {
       const contents = `<html><head>
-          <script src="foo.js"></script>
-          <script>console.log('hi')</script>
+          <link rel="stylesheet" type="text/css" href="foo.css">
+          <style>h1 { color: green; }</style>
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
@@ -40,18 +40,18 @@ suite('HtmlScriptScanner', () => {
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];
-      assert.equal(feature0.type, 'html-script');
-      assert.equal(feature0.url, 'foo.js');
+      assert.equal(feature0.type, 'html-style');
+      assert.equal(feature0.url, 'foo.css');
       assert.instanceOf(features[1], ScannedInlineDocument);
       const feature1 = <ScannedInlineDocument>features[1];
-      assert.equal(feature1.type, 'js');
-      assert.equal(feature1.contents, `console.log('hi')`);
-      assert.deepEqual(feature1.locationOffset, {line: 2, col: 19});
+      assert.equal(feature1.type, 'css');
+      assert.equal(feature1.contents, `h1 { color: green; }`);
+      assert.deepEqual(feature1.locationOffset, {line: 2, col: 18});
     });
 
-    test('finds external scripts relative to baseUrl', async() => {
+    test('finds external styles relative to baseUrl', async() => {
       const contents = `<html><head><base href="/aybabtu/">
-          <script src="foo.js"></script>
+          <link rel="stylesheet" type="text/css" href="foo.css">
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
@@ -60,8 +60,8 @@ suite('HtmlScriptScanner', () => {
       assert.equal(features.length, 1);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];
-      assert.equal(feature0.type, 'html-script');
-      assert.equal(feature0.url, '/aybabtu/foo.js');
+      assert.equal(feature0.type, 'html-style');
+      assert.equal(feature0.url, '/aybabtu/foo.css');
     });
   });
 });

--- a/src/test/polymer/css-import-scanner_test.ts
+++ b/src/test/polymer/css-import-scanner_test.ts
@@ -53,6 +53,24 @@ suite('CssImportScanner', () => {
       assert.equal(features[0].url, 'polymer.css');
     });
 
+    test('adjusts CSS Import urls relative to baseUrl', async() => {
+      const contents = `<html><head><base href="/aybabtu/">
+        </head>
+        <body>
+          <dom-module>
+            <link rel="import" type="css" href="polymer.css">
+          </dom-module>
+        </body>
+        </html>`;
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const features = await scanner.scan(document, visit);
+      assert.equal(features.length, 1);
+      assert.equal(features[0].type, 'css-import');
+      assert.equal(features[0].url, '/aybabtu/polymer.css');
+    });
+
   });
 
 });

--- a/src/test/static/base-href/doc-with-base.html
+++ b/src/test/static/base-href/doc-with-base.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <base href="../">
+    <link rel="import" href="dependencies/inline-and-imports.html">
+    <link rel="stylesheet" type="text/css" href="stylesheet.css">
+  </head>
+  <body>
+    <script src="polymer2/test-element.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Document now includes a `baseUrl` property which is properly resolved from an HTML document's `<base href="...">` tag, when present.