### PR TITLE
Modified CHANGELOG to prepare for 2.0.0-alpha.24 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * HTML Documents now include a `baseUrl` property which is properly resolved
   from a `<base href="...">` tag, when present.
 * Add `localIds` to `PolymerElement`, tracking elements in its template by their id attributes.
-* Document now includes a `baseUrl` property which is properly resolved from an HTML document's `<base href="...">` tag, when present.
+
+### Fixed
+
+* [Polymer] Better handle unexpected behavior reference syntax.
 
 ## [2.0.0-alpha.23] - 2017-02-10
 
@@ -30,7 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Properly cache warning for incorrect imports or when failing parsing an import.
 * Notice references to elements within `<template>` tags.
-* [Polymer] Better handle unexpected behavior reference syntax.
 
 ## [2.0.0-alpha.22] - 2017-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 ### Added
- * Add `localIds` to `PolymerElement`, tracking elements in its template by their id attributes.
-
-
-
-* Document now includes a `baseUrl` property which is properly resolved
-  from an HTML document's `<base href="...">` tag, when present.
+* HTML Documents now include a `baseUrl` property which is properly resolved
+  from a `<base href="...">` tag, when present.
+* Add `localIds` to `PolymerElement`, tracking elements in its template by their id attributes.
+* Document now includes a `baseUrl` property which is properly resolved from an HTML document's `<base href="...">` tag, when present.
 
 ## [2.0.0-alpha.23] - 2017-02-10
 


### PR DESCRIPTION
Cutting release so bundler can depend on analyzer's new baseUrl-based import url resolution for transitive dependencies.

 - [x] CHANGELOG.md has been updated
