### PR TITLE
Parse inline Polymer databinding expressions.

### DIFF
--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -48,35 +48,51 @@ export function getAllDataBindingTemplates(node: parse5.ASTNode) {
       dom5.childNodesIncludeTemplate) as Template[];
 }
 
-
 /**
- * Databinding into an attribute/property.
+ * A databinding expression.
  */
-export class ScannedAttributeExpression implements ScannedFeature {
-  /** The element whose attribute is being assigned to.*/
-  astNode: parse5.ASTNode;
-  /** The HTML element attribute that's being assigned to.*/
-  attribute: parse5.ASTAttribute;
-  sourceRange: SourceRange;
-  warnings: Warning[] = [];
-  direction: '{'|'[';
-  expressionText: string;
-  expressionAst: estree.Program;
+export class ScannedDatabindingExpression implements ScannedFeature {
+  /**
+   * If databinding into an attribute this is the element whose attribute is
+   * assigned to. If databinding into a text node, this is that text node.
+   */
+  readonly astNode: parse5.ASTNode;
+  readonly sourceRange: SourceRange;
+  readonly warnings: Warning[] = [];
+
+  /**
+   * The databinding syntax used. If {{}} then it's bidirectional, if [[]] then
+   * it's down-only.
+   */
+  readonly direction: '{'|'[';
+  readonly expressionText: string;
+  readonly expressionAst: estree.Program;
+
+
+  readonly databindingInto: 'string-interpolation'|'attribute';
+
+  /**
+   * If databindingInto is 'attribute' this will hold the HTML element
+   * attribute that's being assigned to. Otherwise it's undefined.
+   */
+  readonly attribute: parse5.ASTAttribute|undefined;
 
   /**
    * If this is a bidirectional data binding, and an event name was specified
    * (using ::eventName syntax), this is that event name.
    */
-  eventName: string|undefined;
+  readonly eventName: string|undefined;
 
   constructor(
-      astNode: parse5.ASTNode, attribute: parse5.ASTAttribute,
+      astNode: parse5.ASTNode, attribute: parse5.ASTAttribute|undefined,
       sourceRange: SourceRange, direction: '{'|'[', expressionText: string,
-      eventName: string|undefined) {
+      eventName: string|undefined,
+      databindingInto: 'string-interpolation'|'attribute') {
     this.astNode = astNode;
     this.attribute = attribute;
     this.sourceRange = sourceRange;
     this.direction = direction;
+    this.databindingInto = databindingInto;
     this.expressionText = expressionText;
     this.eventName = eventName;
     this.expressionAst = espree.parse(
@@ -89,52 +105,59 @@ export class ScannedAttributeExpression implements ScannedFeature {
  * Find and parse Polymer databinding expressions in HTML.
  *
  * TODO(rictic):
- *  - parse expressions inline in strings rather than entire attributes
- *  - parse expressions in text nodes
+ *  - more precise source ranges for databinding expressions
  *  - allow getting source ranges inside of a databinding expression.
  *  - surface parse errors in expressions as warnings.
  */
 export class ExpressionScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument, _: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedAttributeExpression[]> {
-    const results: ScannedAttributeExpression[] = [];
+      Promise<ScannedDatabindingExpression[]> {
+    const results: ScannedDatabindingExpression[] = [];
     const dataBindingTemplates = getAllDataBindingTemplates(document.ast);
     for (const template of dataBindingTemplates) {
       dom5.nodeWalkAll(template.content, (node) => {
+        if (dom5.isTextNode(node)) {
+          const dataBindings = findDatabindingInString(node.value || '');
+          for (const dataBinding of dataBindings) {
+            results.push(new ScannedDatabindingExpression(
+                node,
+                undefined,
+                document.sourceRangeForNode(node)!,
+                dataBinding.direction,
+                dataBinding.expressionText,
+                undefined,
+                'string-interpolation'));
+          }
+        }
         if (node.attrs) {
           for (const attr of node.attrs) {
             if (!attr.value) {
               continue;
             }
-            const oneWayMatch = attr.value.match(/^\s*\[\[\s*(.*?)\s*\]\]\s*$/);
-            const bidiMatch = attr.value.match(/^\s*{{\s*(.*?)}}\s*$/);
-            if (oneWayMatch) {
-              const expressionText = oneWayMatch[1];
-              results.push(new ScannedAttributeExpression(
-                  node,
-                  attr,
-                  document.sourceRangeForAttributeValue(node, attr.name)!,
-                  '[',
-                  expressionText,
-                  undefined));
-            } else if (bidiMatch) {
-              let expressionText = bidiMatch[1];
-              const match = expressionText.match(/(.*)::(.*)/);
+            const dataBindings = findDatabindingInString(attr.value);
+            for (const dataBinding of dataBindings) {
+              const isFullAttributeBinding = dataBinding.startIndex === 2 &&
+                  dataBinding.endIndex + 2 === attr.value.length;
+              const databindingInto =
+                  isFullAttributeBinding ? 'attribute' : 'string-interpolation';
+              let expressionText = dataBinding.expressionText;
               let eventName = undefined;
-              if (match) {
-                expressionText = match[1];
-                eventName = match[2];
+              if (dataBinding.direction === '{') {
+                const match = expressionText.match(/(.*)::(.*)/);
+                if (match) {
+                  expressionText = match[1];
+                  eventName = match[2];
+                }
               }
-              results.push(new ScannedAttributeExpression(
+              results.push(new ScannedDatabindingExpression(
                   node,
                   attr,
                   document.sourceRangeForAttributeValue(node, attr.name)!,
-                  '{',
+                  dataBinding.direction,
                   expressionText,
-                  eventName));
-            } else {
-              continue;
+                  eventName,
+                  databindingInto));
             }
           }
         }
@@ -144,4 +167,36 @@ export class ExpressionScanner implements HtmlScanner {
     }
     return results;
   }
+}
+
+interface RawDatabinding {
+  readonly expressionText: string;
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly direction: '{'|'[';
+}
+function findDatabindingInString(str: string) {
+  const expressions: RawDatabinding[] = [];
+  const openers = /{{|\[\[/g;
+  let match = openers.exec(str);
+  while (match) {
+    const matchedOpeners = match[0];
+    const startIndex = match.index + 2;
+    const direction = matchedOpeners === '{{' ? '{' : '[';
+    const closers = matchedOpeners === '{{' ? '}}' : ']]';
+    const endIndex = str.indexOf(closers, startIndex);
+    if (endIndex === -1) {
+      // No closers, this wasn't an expression after all.
+      break;
+    }
+    const expressionText = str.slice(startIndex, endIndex);
+    expressions.push({startIndex, endIndex, expressionText, direction});
+
+    // Start looking for the next expression after the end of this one.
+    openers.lastIndex = endIndex + 2;
+
+    // Look for the next openers
+    match = openers.exec(str);
+  }
+  return expressions;
 }

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -153,7 +153,6 @@ class MixinVisitor implements Visitor {
     const docs = jsdoc.parseJsdoc(comment);
     const isMixinClass = this._hasPolymerMixinClassDocTag(docs);
     if (isMixinClass) {
-      console.log('annotated mixin class!');
       this._handleClass(node);
     }
   }

--- a/src/test/generate_elements_test.ts
+++ b/src/test/generate_elements_test.ts
@@ -83,12 +83,12 @@ suite('elements.json generation', function() {
 
   test('throws when validating valid elements.json', function() {
     try {
-      validateElements(<any>{});
+      validateElements({} as any);
     } catch (err) {
       assert.instanceOf(err, ValidationError);
       const valError: ValidationError = err;
       assert(valError.errors.length > 0);
-      assert.include(valError.message, `requires property "elements"`);
+      assert.include(valError.message, `requires property "schema_version"`);
       return;
     }
     throw new Error('expected Analysis validation to fail!');

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -20,7 +20,7 @@ import {HtmlParser} from '../../html/html-parser';
 import {ExpressionScanner} from '../../polymer/expression-scanner';
 import {CodeUnderliner} from '../test-utils';
 
-suite('DomModuleScanner', () => {
+suite('ExpressionScanner', () => {
 
   suite('scan()', () => {
     let scanner: ExpressionScanner;
@@ -29,7 +29,7 @@ suite('DomModuleScanner', () => {
       scanner = new ExpressionScanner();
     });
 
-    test('finds expressions', async() => {
+    test('finds whole-attribute expressions', async() => {
       const contents = `
         <dom-module id="foo-elem">
           <template>
@@ -81,10 +81,123 @@ suite('DomModuleScanner', () => {
           expressions.map((e) => e.eventName),
           [undefined, 'changed', undefined, undefined]);
       assert.deepEqual(
-          expressions.map((e) => e.attribute.name),
+          expressions.map((e) => e.attribute && e.attribute.name),
           ['id', 'value', 'id', 'id']);
+      assert.deepEqual(
+          expressions.map((e) => e.databindingInto),
+          ['attribute', 'attribute', 'attribute', 'attribute']);
     });
 
+    test('finds interpolated attribute expressions', async() => {
+      const contents = `
+        <template is="dom-bind">
+          <div id=" {{foo}}"></div>
+          <div id="bar {{val}} baz">
+          <div id=" [[x]]{{y}}"></div>
+        </template>
+      `;
+      const underliner = CodeUnderliner.withMapping('test.html', contents);
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const expressions = await scanner.scan(document, visit);
+
+      // TODO(rictic): improve these source ranges.
+      assert.deepEqual(
+          await underliner.underline(expressions.map((e) => e.sourceRange)), [
+            `
+          <div id=" {{foo}}"></div>
+                  ~~~~~~~~~~`,
+            `
+          <div id="bar {{val}} baz">
+                  ~~~~~~~~~~~~~~~~~`,
+            `
+          <div id=" [[x]]{{y}}"></div>
+                  ~~~~~~~~~~~~~`,
+            `
+          <div id=" [[x]]{{y}}"></div>
+                  ~~~~~~~~~~~~~`
+          ]);
+      assert.deepEqual(
+          expressions.map((e) => e.direction), ['{', '{', '[', '{']);
+      assert.deepEqual(
+          expressions.map((e) => e.expressionText), ['foo', 'val', 'x', 'y']);
+      assert.deepEqual(
+          expressions.map((e) => e.eventName),
+          [undefined, undefined, undefined, undefined]);
+      assert.deepEqual(
+          expressions.map((e) => e.attribute && e.attribute.name),
+          ['id', 'id', 'id', 'id']);
+      assert.deepEqual(expressions.map((e) => e.databindingInto), [
+        'string-interpolation',
+        'string-interpolation',
+        'string-interpolation',
+        'string-interpolation'
+      ]);
+    });
+
+    test('finds expressions in text nodes', async() => {
+      const contents = `
+        <template is="dom-bind">
+          <div>{{foo}}</div>
+          <div>
+            {{bar}} + {{baz}}[[zod]]
+          </div>
+        </template>
+      `;
+
+      const underliner = CodeUnderliner.withMapping('test.html', contents);
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const expressions = await scanner.scan(document, visit);
+
+      // TODO(rictic): improve these source ranges.
+      assert.deepEqual(
+          await underliner.underline(expressions.map((e) => e.sourceRange)), [
+            `
+          <div>{{foo}}</div>
+               ~~~~~~~`,
+            `
+          <div>
+               ~
+            {{bar}} + {{baz}}[[zod]]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          </div>
+~~~~~~~~~~`,
+            `
+          <div>
+               ~
+            {{bar}} + {{baz}}[[zod]]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          </div>
+~~~~~~~~~~`,
+            `
+          <div>
+               ~
+            {{bar}} + {{baz}}[[zod]]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          </div>
+~~~~~~~~~~`,
+          ]);
+      assert.deepEqual(
+          expressions.map((e) => e.direction), ['{', '{', '{', '[']);
+      assert.deepEqual(
+          expressions.map((e) => e.expressionText),
+          ['foo', 'bar', 'baz', 'zod']);
+      assert.deepEqual(
+          expressions.map((e) => e.eventName),
+          [undefined, undefined, undefined, undefined]);
+      assert.deepEqual(
+          expressions.map((e) => e.attribute && e.attribute.name),
+          [undefined, undefined, undefined, undefined]);
+      assert.deepEqual(expressions.map((e) => e.databindingInto), [
+        'string-interpolation',
+        'string-interpolation',
+        'string-interpolation',
+        'string-interpolation'
+      ]);
+    });
   });
 
 });

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -14,7 +14,6 @@
 
 
 import {assert} from 'chai';
-// import * as fs from 'fs';
 import * as path from 'path';
 
 import {Visitor} from '../../javascript/estree-visitor';
@@ -231,7 +230,7 @@ function TestMixin() {
 ~`);
   });
 
-  test.only('finds mixin assigned to a namespace', async() => {
+  test('finds mixin assigned to a namespace', async() => {
     const mixins = await getMixins('test-mixin-7.js');
     const mixinData = mixins.map(getTestProps);
     assert.deepEqual(mixinData, [{


### PR DESCRIPTION
 - Builds on top of #467
 - [x] CHANGELOG.md not updated yet, this is incomplete and not yet hooked up.

I'm not super happy with ScannedDatabindingExpression. There's too many fields that are sometimes present, sometimes absent, etc. Considering breaking it up into a few related types but I don't quite see a super clean breakdown yet.
