### PR TITLE
Expression parsing all hooked up and usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * Polymer 2.0 mixin scanner
+* [polymer] Parse polymer databinding expressions.
+  Give accurate warnings on parse errors.
+
+## [2.0.0-alpha.24] - 2017-02-14
+
+### Added
 * HTML Documents now include a `baseUrl` property which is properly resolved
   from a `<base href="...">` tag, when present.
 * Add `localIds` to `PolymerElement`, tracking elements in its template by their id attributes.

--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -49,7 +49,7 @@ export function getAllDataBindingTemplates(node: parse5.ASTNode) {
 /**
  * A databinding expression.
  */
-export class ScannedDatabindingExpression {
+export class DatabindingExpression {
   /**
    * If databinding into an attribute this is the element whose attribute is
    * assigned to. If databinding into a text node, this is that text node.
@@ -122,7 +122,7 @@ export class ScannedDatabindingExpression {
  * Find and parse Polymer databinding expressions in HTML.
  */
 export function scanForExpressions(document: ParsedHtmlDocument) {
-  const results: ScannedDatabindingExpression[] = [];
+  const results: DatabindingExpression[] = [];
   const warnings: Warning[] = [];
   const dataBindingTemplates = getAllDataBindingTemplates(document.ast);
   for (const template of dataBindingTemplates) {
@@ -144,7 +144,7 @@ export function scanForExpressions(document: ParsedHtmlDocument) {
 function _extractDataBindingsFromTextNode(
     document: ParsedHtmlDocument,
     node: parse5.ASTNode,
-    results: ScannedDatabindingExpression[],
+    results: DatabindingExpression[],
     warnings: Warning[]) {
   const text = node.value || '';
   const dataBindings = findDatabindingInString(text);
@@ -181,7 +181,7 @@ function _extractDataBindingsFromTextNode(
     if (parseResult.type === 'failure') {
       warnings.push(parseResult.warning);
     } else {
-      results.push(new ScannedDatabindingExpression(
+      results.push(new DatabindingExpression(
           node,
           undefined,
           sourceRange,
@@ -200,7 +200,7 @@ function _extractDataBindingsFromAttr(
     document: ParsedHtmlDocument,
     node: parse5.ASTNode,
     attr: parse5.ASTAttribute,
-    results: ScannedDatabindingExpression[],
+    results: DatabindingExpression[],
     warnings: Warning[]) {
   if (!attr.value) {
     return;
@@ -246,7 +246,7 @@ function _extractDataBindingsFromAttr(
     if (parseResult.type === 'failure') {
       warnings.push(parseResult.warning);
     } else {
-      results.push(new ScannedDatabindingExpression(
+      results.push(new DatabindingExpression(
           node,
           attr,
           sourceRange,

--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -78,6 +78,8 @@ export class ScannedDatabindingExpression {
    */
   readonly eventName: string|undefined;
 
+  private readonly locationOffset: LocationOffset;
+
   constructor(
       astNode: parse5.ASTNode, attribute: parse5.ASTAttribute|undefined,
       sourceRange: SourceRange, direction: '{'|'[', expressionText: string,
@@ -92,6 +94,27 @@ export class ScannedDatabindingExpression {
     this.expressionText = expressionText;
     this.expressionAst = ast;
     this.eventName = eventName;
+    this.locationOffset = {
+      line: sourceRange.start.line,
+      col: sourceRange.start.column
+    };
+  }
+
+  /**
+   * Given an estree node in this databinding expression, give its source range.
+   */
+  sourceRangeForNode(node: estree.Node) {
+    if (!node || !node.loc) {
+      return;
+    }
+    const databindingRelativeSourceRange = {
+      file: this.sourceRange.file,
+      // Note: estree uses 1-indexed lines, but SourceRange uses 0 indexed.
+      start: {line: (node.loc.start.line - 1), column: node.loc.start.column},
+      end: {line: (node.loc.end.line - 1), column: node.loc.end.column}
+    };
+    return correctSourceRange(
+        databindingRelativeSourceRange, this.locationOffset);
   }
 }
 

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -16,7 +16,7 @@
 import {assert} from 'chai';
 
 import {HtmlParser} from '../../html/html-parser';
-import {scanForExpressions} from '../../polymer/expression-scanner';
+import {scanDocumentForExpressions} from '../../polymer/expression-scanner';
 import {CodeUnderliner} from '../test-utils';
 
 suite('ExpressionScanner', () => {
@@ -48,7 +48,7 @@ suite('ExpressionScanner', () => {
       const underliner = CodeUnderliner.withMapping('test.html', contents);
       const document = new HtmlParser().parse(contents, 'test.html');
 
-      const results = await scanForExpressions(document);
+      const results = await scanDocumentForExpressions(document);
       const expressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
@@ -94,7 +94,7 @@ suite('ExpressionScanner', () => {
       const underliner = CodeUnderliner.withMapping('test.html', contents);
       const document = new HtmlParser().parse(contents, 'test.html');
 
-      const results = await scanForExpressions(document);
+      const results = await scanDocumentForExpressions(document);
       const expressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
@@ -149,7 +149,7 @@ suite('ExpressionScanner', () => {
       const underliner = CodeUnderliner.withMapping('test.html', contents);
       const document = new HtmlParser().parse(contents, 'test.html');
 
-      const results = await scanForExpressions(document);
+      const results = await scanDocumentForExpressions(document);
       const expressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
@@ -221,7 +221,7 @@ suite('ExpressionScanner', () => {
       const underliner = CodeUnderliner.withMapping('test.html', contents);
       const document = new HtmlParser().parse(contents, 'test.html');
 
-      const results = await scanForExpressions(document);
+      const results = await scanDocumentForExpressions(document);
       assert.deepEqual(
           await underliner.underline(
               results.warnings.map((w) => w.sourceRange)),

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -215,6 +215,10 @@ suite('ExpressionScanner', () => {
             foo bar
           ]]'></div>
           {{]}}
+
+          <!-- ignores expressions that are invalid JS -->
+          <div id="{{foo(bar.*)}}"></div>
+          <div id="{{foo(bar.0)}}"></div>
         </template>
       `;
 


### PR DESCRIPTION
All hooked up and ready to go.

Builds on #469 

A few design notes:
  * We're currently only bothering to parse and track expressions off dom-module templates, though the code knows how to handle stuff like dom-bind as well.
  * Uses espree to parse the expressions, but that's actually a very small part of this code. It'd be fairly easy to swap out a different parser. I did discover a couple places where Polymer expressions are invalid javascript: `foo.*` and `arr.0`. Other than that and two (I think legit!) errors, this parses all of PolymerElements without a problem or noticeable performance impact.

 - [x] CHANGELOG.md has been updated

