### PR TITLE
Use new upstreamed performance-now typings.

### DIFF
--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -1,5 +1,4 @@
 /// <reference path="./chai.d.ts" />
 /// <reference path="./espree.d.ts" />
-/// <reference path="./performance-now.d.ts" />
 /// <reference path="./shady-css-parser.d.ts" />
 /// <reference path="./strip-indent.d.ts" />

--- a/custom_typings/performance-now.d.ts
+++ b/custom_typings/performance-now.d.ts
@@ -1,7 +1,0 @@
-// Delete this once https://github.com/braveg1rl/performance-now/pull/8 lands.
-
-declare module 'performance-now' {
-  function now(): number;
-  namespace now {}
-  export = now;
-}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "temp": "^0.8.3",
     "tslint": "^4.1.1",
     "typescript-json-schema": "^0.1.1",
-    "watchy": "^0.6.6"
+    "watchy": "^0.6.6",
+    "performance-now": "^2.1.0"
   },
   "dependencies": {
     "@types/chalk": "^0.4.30",
@@ -81,7 +82,6 @@
     "estraverse": "^3.1.0",
     "jsonschema": "^1.1.0",
     "parse5": "^2.2.1",
-    "performance-now": "^0.2.0",
     "shady-css-parser": "0.0.8",
     "split": "^1.0.0",
     "strip-indent": "^2.0.0",

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -14,10 +14,11 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as now from 'performance-now';
 
 import {Analyzer} from '../analyzer';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
+
+import now = require('performance-now');
 
 const bowerDir = path.resolve(__dirname, `../../bower_components`);
 const analyzer = new Analyzer({urlLoader: new FSUrlLoader(bowerDir)});


### PR DESCRIPTION
Landed in https://github.com/braveg1rl/performance-now/pull/8

 - [x] CHANGELOG.md not updated, internal change.
