### PR TITLE
Add css-import to the FeatureKinds for Import

### DIFF
--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -100,6 +100,7 @@ export interface FeatureKinds {
   'html-script': Import;
   'html-style': Import;
   'js-import': Import;
+  'css-import': Import;
 }
 
 export interface QueryOptionsInterface extends BaseQueryOptions {


### PR DESCRIPTION
`css-import` was omitted from the `FeatureKinds` list for Imports.  Added because bundler needs it cast this way from the Analyzer.
