### PR TITLE
Add a `parseUrl` utility function to address shortcomings in Node's `url.parse` function with protocol-less URLs aka `//host/path`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Polymer 2.0 mixin scanner
 * [polymer] Parse polymer databinding expressions.
   Give accurate warnings on parse errors.
+* Protocol-less URLs such as `//host/path` are properly handled instead of treated as absolute paths.
 
 ## [2.0.0-alpha.24] - 2017-02-14
 

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -36,8 +36,9 @@ suite('PackageUrlResolver', function() {
     });
 
     test('canResolve is false for URL with a hostname', () => {
-      assert.isFalse(
-          new PackageUrlResolver().canResolve('http://abc.xyz/foo.html'));
+      const r = new PackageUrlResolver();
+      assert.isFalse(r.canResolve('http://abc.xyz/foo.html'));
+      assert.isFalse(r.canResolve('//abc.xyz/foo.html'));
     });
 
     test('canResolve is true for a URL with the right hostname', () => {
@@ -48,6 +49,7 @@ suite('PackageUrlResolver', function() {
       assert.isTrue(r.canResolve('http://abc.xyz/./foo.html'));
       assert.isTrue(r.canResolve('http://abc.xyz/../foo.html'));
       assert.isTrue(r.canResolve('http://abc.xyz/foo/../foo.html'));
+      assert.isTrue(r.canResolve('//abc.xyz/foo.html'));
     });
 
   });

--- a/src/test/utils_test.ts
+++ b/src/test/utils_test.ts
@@ -15,10 +15,56 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 
 import {assert, use} from 'chai';
-import {Deferred} from '../utils';
+import {Deferred, parseUrl} from '../utils';
 
 import chaiAsPromised = require('chai-as-promised');
 use(chaiAsPromised);
+
+suite('parseUrl', () => {
+
+  function testUrl(url: string, properties: {[s: string]: any}) {
+    const urlObject = parseUrl(url);
+    for (const key in properties) {
+      if (!properties.hasOwnProperty(key)) {
+        continue;
+      }
+      assert.equal(urlObject[key], properties[key], `${url} property ${key}`);
+    }
+  }
+
+  test('parses urls that are absolute paths', () => {
+    testUrl(
+        '/abs/path', {protocol: null, hostname: null, pathname: '/abs/path'});
+    testUrl('/abs/path?query=string#hash', {
+      protocol: null,
+      hostname: null,
+      pathname: '/abs/path',
+      hash: '#hash',
+      search: '?query=string',
+    });
+  });
+
+  test('parses urls without protocol', () => {
+    testUrl('//host/path', {
+      protocol: undefined,
+      hostname: 'host',
+      pathname: '/path',
+    });
+    testUrl('//host', {
+      protocol: undefined,
+      hostname: 'host',
+      pathname: null,
+    });
+  });
+
+  test('parses urls that have protocols', () => {
+    testUrl('https://host/path', {
+      protocol: 'https:',
+      hostname: 'host',
+      pathname: '/path',
+    });
+  });
+});
 
 suite('Deferred', () => {
 

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -14,7 +14,9 @@
 
 import * as fs from 'fs';
 import * as pathlib from 'path';
-import {parse as parseUrl, Url} from 'url';
+import {Url} from 'url';
+
+import {parseUrl} from '../utils';
 
 import {UrlLoader} from './url-loader';
 

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -13,7 +13,9 @@
  */
 
 import {posix as pathlib} from 'path';
-import {parse as parseUrl, Url} from 'url';
+import {Url} from 'url';
+
+import {parseUrl} from '../utils';
 
 import {UrlResolver} from './url-resolver';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,19 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import {parse as parseUrl_, Url} from 'url';
+
+const unspecifiedProtocol = '-:';
+
+export function parseUrl(url: string): Url {
+  if (!url.startsWith('//')) {
+    return parseUrl_(url);
+  }
+  const urlObject = parseUrl_(`${unspecifiedProtocol}${url}`);
+  urlObject.protocol = undefined;
+  urlObject.href = urlObject.href!.replace(/^-:/, '');
+  return urlObject;
+}
 
 export function trimLeft(str: string, char: string): string {
   let leftEdge = 0;


### PR DESCRIPTION
Analyzer believes that `//host/path` is an absolute path that is loadable by FSUrlLoader, for example, instead of it being a protocol-less URL pointing to `/path` on `host`.  Added a `parseUrl` drop-in replacement function for `url.parse` and am using it now in the places it needs to be used, such as `FSUrlLoader` and `PackageUrlResolver`.

 - [x] CHANGELOG.md has been updated
