### PR TITLE
Escape unsafe chars in urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 <!--## Unreleased-->
+### Fixed
+* PackageUrlResolver encodes URIs returned from `resolve` method.
 
 ## [2.0.0-alpha.27] - 2017-02-24
 

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -428,6 +428,23 @@ suite('Analyzer', () => {
           ]);
     });
 
+    test('handles documents with spaces in url', async() => {
+      const document = await analyzer.analyze('static/spaces in file.html');
+      const features = document.getFeatures({imported: true});
+      assert.deepEqual(
+          Array.from(features)
+              .filter((f) => f.kinds.has('document'))
+              .map((f) => (f as Document).url),
+          [
+            'static/spaces%20in%20file.html',
+            'static/dependencies/spaces%20in%20import.html'
+          ]);
+      assert.deepEqual(
+          Array.from(features)
+              .filter((f) => f.kinds.has('import'))
+              .map((f) => (f as Import).url),
+          ['static/dependencies/spaces%20in%20import.html']);
+    });
   });
 
   // TODO: reconsider whether we should test these private methods.

--- a/src/test/static/spaces in file.html
+++ b/src/test/static/spaces in file.html
@@ -1,0 +1,1 @@
+<link rel="import" href="dependencies/spaces in import.html">

--- a/src/test/static/spaces in file.html
+++ b/src/test/static/spaces in file.html
@@ -1,1 +1,5 @@
-<link rel="import" href="dependencies/spaces in import.html">
+<!--
+Note, one space is encoded, the other is not.  In the end, both should be
+treated as encoded '%20' values, because the ' ' value is technically invalid.
+--> 
+<link rel="import" href="dependencies/spaces in%20import.html">

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -101,6 +101,10 @@ suite('PackageUrlResolver', function() {
 
     });
 
+    test('resolves a URL with spaces', () => {
+      const r = new PackageUrlResolver();
+      assert.equal(r.resolve('spaced name.html'), 'spaced%20name.html');
+    });
   });
 
 });

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -39,8 +39,7 @@ export class PackageUrlResolver implements UrlResolver {
 
   canResolve(url: string): boolean {
     const urlObject = parseUrl(url);
-    const pathname =
-        pathlib.normalize(decodeURIComponent(urlObject.pathname || ''));
+    const pathname = pathlib.normalize(decodeURI(urlObject.pathname || ''));
     return this._isValid(urlObject, pathname);
   }
 
@@ -51,8 +50,7 @@ export class PackageUrlResolver implements UrlResolver {
 
   resolve(url: string): string {
     const urlObject = parseUrl(url);
-    let pathname =
-        pathlib.normalize(decodeURIComponent(urlObject.pathname || ''));
+    let pathname = pathlib.normalize(decodeURI(urlObject.pathname || ''));
 
     if (!this._isValid(urlObject, pathname)) {
       throw new Error(`Invalid URL ${url}`);
@@ -68,6 +66,8 @@ export class PackageUrlResolver implements UrlResolver {
     if (pathlib.isAbsolute(pathname)) {
       pathname = pathname.substring(1);
     }
-    return pathname;
+
+    // Re-encode URI, since it is expected we are emitting a relative URL.
+    return encodeURI(pathname);
   }
 }


### PR DESCRIPTION
When its a URL, it should be URI-encoded.  Also, `(decode|encode)URIComponent()` is too aggressive to normalize pathname.  Switched to `(decode|encode)URI()`
 - Fixes #496 
 - [x] CHANGELOG.md has been updated
