### PR TITLE
Updated CHANGELOG.md in preparation for 2.0.0-alpha.28 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 <!--## Unreleased-->
+
+## [2.0.0-alpha.28] - 2017-02-24
+
 ### Fixed
 * PackageUrlResolver encodes URIs returned from `resolve` method.
 


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Addresses the URL handling issue so that bundler wont get a regression preventing bundling files with unsafe chars in names and this hopefully resolves build's existing issue with same.
