### PR TITLE
add support to understand the @memberof jsdoc tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!--## Unreleased-->
 
 ## [2.0.0-alpha.28] - 2017-02-24
+* Support for `@memberof` jsdoc tag
 
 ### Fixed
 * PackageUrlResolver encodes URIs returned from `resolve` method.

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -15,7 +15,6 @@
 import * as estree from 'estree';
 
 import {LiteralObj, LiteralValue} from '../model/model';
-import * as esutil from './esutil';
 import * as jsdoc from './jsdoc';
 
 /**

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -206,9 +206,10 @@ export function getNamespacedIdentifier(
   if (!docs) {
     return name;
   }
-  const namespaceName = jsdoc.getTag(docs, 'memberof', 'description');
-  if (namespaceName) {
-    return namespaceName + '.' + name;
+  const namespace = jsdoc.getTag(docs, 'memberof', 'description');
+  if (namespace) {
+    const rightMostIdentifierName = name.substring(name.lastIndexOf('.') + 1);
+    return namespace + '.' + rightMostIdentifierName;
   } else {
     return name;
   }

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -202,10 +202,11 @@ export function getIdentifierName(node: estree.Node): string|undefined {
  * Formats the given identifier name under a namespace, if one is mentioned in
  * the commentedNode's comment. Otherwise, name is returned.
  */
-export function namespaceIdentifierName(
-    name: string, commentedNode: estree.Node): string {
-  const comment = esutil.getAttachedComment(commentedNode) || '';
-  const docs = jsdoc.parseJsdoc(comment);
+export function getNamespacedIdentifier(
+    name: string, docs?: jsdoc.Annotation): string {
+  if (!docs) {
+    return name;
+  }
   const namespaceName = jsdoc.getTag(docs, 'memberof', 'description');
   if (namespaceName) {
     return namespaceName + '.' + name;

--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -15,6 +15,8 @@
 import * as estree from 'estree';
 
 import {LiteralObj, LiteralValue} from '../model/model';
+import * as esutil from './esutil';
+import * as jsdoc from './jsdoc';
 
 /**
  * Converts an ast literal to its underlying valie.
@@ -195,5 +197,22 @@ export function getIdentifierName(node: estree.Node): string|undefined {
     }
   }
 }
+
+/**
+ * Formats the given identifier name under a namespace, if one is mentioned in
+ * the commentedNode's comment. Otherwise, name is returned.
+ */
+export function namespaceIdentifierName(
+    name: string, commentedNode: estree.Node): string {
+  const comment = esutil.getAttachedComment(commentedNode) || '';
+  const docs = jsdoc.parseJsdoc(comment);
+  const namespaceName = jsdoc.getTag(docs, 'memberof', 'description');
+  if (namespaceName) {
+    return namespaceName + '.' + name;
+  } else {
+    return name;
+  }
+}
+
 
 export const CANT_CONVERT = 'UNKNOWN';

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -14,7 +14,7 @@
 
 import * as estree from 'estree';
 
-import {getIdentifierName, namespaceIdentifierName} from '../javascript/ast-value';
+import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
@@ -173,7 +173,7 @@ class BehaviorVisitor implements Visitor {
 
     behavior.className =
         jsdoc.getTag(behavior.jsdoc, 'polymerBehavior', 'name') ||
-        namespaceIdentifierName(symbol, node);
+        getNamespacedIdentifier(symbol, behavior.jsdoc);
     if (!behavior.className) {
       throw new Error(
           `Unable to determine name for @polymerBehavior: ${comment}`);

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -14,7 +14,7 @@
 
 import * as estree from 'estree';
 
-import * as astValue from '../javascript/ast-value';
+import {getIdentifierName, namespaceIdentifierName} from '../javascript/ast-value';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
@@ -171,9 +171,9 @@ class BehaviorVisitor implements Visitor {
       return;
     }
 
-    const explicitName =
-        jsdoc.getTag(behavior.jsdoc, 'polymerBehavior', 'name');
-    behavior.className = explicitName || symbol;
+    behavior.className =
+        jsdoc.getTag(behavior.jsdoc, 'polymerBehavior', 'name') ||
+        namespaceIdentifierName(symbol, node);
     if (!behavior.className) {
       throw new Error(
           `Unable to determine name for @polymerBehavior: ${comment}`);
@@ -247,7 +247,7 @@ class BehaviorVisitor implements Visitor {
     const chained: Array<ScannedBehaviorAssignment> = [];
     if (expression && expression.type === 'ArrayExpression') {
       for (const arrElement of expression.elements) {
-        const behaviorName = astValue.getIdentifierName(arrElement);
+        const behaviorName = getIdentifierName(arrElement);
         if (behaviorName) {
           chained.push({
             name: behaviorName,

--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -15,7 +15,7 @@
 import * as estree from 'estree';
 
 import * as astValue from '../javascript/ast-value';
-import {getIdentifierName} from '../javascript/ast-value';
+import {getIdentifierName, namespaceIdentifierName} from '../javascript/ast-value';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
@@ -65,16 +65,25 @@ class ElementVisitor implements Visitor {
     }
     const element = this._handleClass(node);
     if (element) {
-      element.className = className;
-      this._possibleElements.set(element.className, element);
+      const namespacedClassName = namespaceIdentifierName(className, node);
+      element.className = namespacedClassName;
+      // Set the element on both the namespaced & unnamespaced names so that we
+      // can detect registration by either name.
+      this._possibleElements.set(namespacedClassName, element);
+      this._possibleElements.set(className, element);
     }
   }
 
   enterClassDeclaration(node: estree.ClassDeclaration) {
     const element = this._handleClass(node);
     if (element) {
-      element.className = node.id.name;
-      this._possibleElements.set(element.className, element);
+      const className = node.id.name;
+      const namespacedClassName = namespaceIdentifierName(className, node);
+      element.className = namespacedClassName;
+      // Set the element on both the namespaced & unnamespaced names so that we
+      // can detect registration by either name.
+      this._possibleElements.set(className, element);
+      this._possibleElements.set(namespacedClassName, element);
     }
   }
 

--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -15,7 +15,7 @@
 import * as estree from 'estree';
 
 import * as astValue from '../javascript/ast-value';
-import {getIdentifierName, namespaceIdentifierName} from '../javascript/ast-value';
+import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
@@ -65,7 +65,10 @@ class ElementVisitor implements Visitor {
     }
     const element = this._handleClass(node);
     if (element) {
-      const namespacedClassName = namespaceIdentifierName(className, node);
+      const nodeComments = esutil.getAttachedComment(node) || '';
+      const nodeJsDocs = jsdoc.parseJsdoc(nodeComments);
+      const namespacedClassName =
+          getNamespacedIdentifier(className, nodeJsDocs);
       element.className = namespacedClassName;
       // Set the element on both the namespaced & unnamespaced names so that we
       // can detect registration by either name.
@@ -78,7 +81,10 @@ class ElementVisitor implements Visitor {
     const element = this._handleClass(node);
     if (element) {
       const className = node.id.name;
-      const namespacedClassName = namespaceIdentifierName(className, node);
+      const nodeComments = esutil.getAttachedComment(node) || '';
+      const nodeJsDocs = jsdoc.parseJsdoc(nodeComments);
+      const namespacedClassName =
+          getNamespacedIdentifier(className, nodeJsDocs);
       element.className = namespacedClassName;
       // Set the element on both the namespaced & unnamespaced names so that we
       // can detect registration by either name.

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -14,7 +14,7 @@
 
 import * as estree from 'estree';
 
-import {getIdentifierName, namespaceIdentifierName} from '../javascript/ast-value';
+import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
@@ -51,12 +51,12 @@ class MixinVisitor implements Visitor {
     if (parent.type !== 'ExpressionStatement') {
       return;
     }
-    const comment = esutil.getAttachedComment(parent) || '';
-    const docs = jsdoc.parseJsdoc(comment);
-    if (this._hasPolymerMixinDocTag(docs)) {
+    const parentComments = esutil.getAttachedComment(parent) || '';
+    const parentJsDocs = jsdoc.parseJsdoc(parentComments);
+    if (this._hasPolymerMixinDocTag(parentJsDocs)) {
       const name = getIdentifierName(node.left);
       const namespacedName =
-          name ? namespaceIdentifierName(name, parent) : undefined;
+          name ? getNamespacedIdentifier(name, parentJsDocs) : undefined;
       const sourceRange = this._document.sourceRangeForNode(node);
       this._currentMixin = new ScannedPolymerElementMixin({
         name: namespacedName,
@@ -71,12 +71,12 @@ class MixinVisitor implements Visitor {
 
   enterFunctionDeclaration(
       node: estree.FunctionDeclaration, _parent: estree.Node) {
-    const comment = esutil.getAttachedComment(node) || '';
-    const docs = jsdoc.parseJsdoc(comment);
-    if (this._hasPolymerMixinDocTag(docs)) {
+    const nodeComments = esutil.getAttachedComment(node) || '';
+    const nodeJsDocs = jsdoc.parseJsdoc(nodeComments);
+    if (this._hasPolymerMixinDocTag(nodeJsDocs)) {
       const name = node.id.name;
       const namespacedName =
-          name ? namespaceIdentifierName(name, node) : undefined;
+          name ? getNamespacedIdentifier(name, nodeJsDocs) : undefined;
       const sourceRange = this._document.sourceRangeForNode(node);
       this._currentMixinFunction = node;
       this._currentMixin = new ScannedPolymerElementMixin({
@@ -129,8 +129,9 @@ class MixinVisitor implements Visitor {
       node: estree.VariableDeclarator, parent: estree.Node) {
     if (this._currentMixin != null && this._currentMixinFunction == null) {
       const name = (node.id as estree.Identifier).name;
-      const namespacedName = namespaceIdentifierName(name, parent);
-      this._currentMixin.name = namespacedName;
+      const parentComments = esutil.getAttachedComment(parent) || '';
+      const parentJsDocs = jsdoc.parseJsdoc(parentComments);
+      this._currentMixin.name = getNamespacedIdentifier(name, parentJsDocs);
     }
   }
 

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -613,6 +613,8 @@ suite('Analyzer', () => {
       'ExplicitlyNamedNamespace.NestedNamespace',
       'ImplicitlyNamedNamespace',
       'ImplicitlyNamedNamespace.NestedNamespace',
+      'ParentNamespace.FooNamespace',
+      'ParentNamespace.BarNamespace',
       'DynamicNamespace.ArrayNotation',
       'DynamicNamespace.DynamicArrayNotation',
       'DynamicNamespace.Aliased',

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -67,7 +67,7 @@ ExplicitlyNamedNamespace.NestedNamespace = {
 
   test('scans unnamed namespaces', async() => {
     const namespaces = await getNamespaces('namespace-unnamed.js');
-    assert.equal(namespaces.length, 2);
+    assert.equal(namespaces.length, 4);
 
     assert.equal(namespaces[0].name, 'ImplicitlyNamedNamespace');
     assert.equal(namespaces[0].description, '\n');
@@ -83,6 +83,28 @@ var ImplicitlyNamedNamespace = {};
     assert.equal(await underliner.underline(namespaces[1].sourceRange), `
 ImplicitlyNamedNamespace.NestedNamespace = {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  foo: \'bar\'
+~~~~~~~~~~~~
+};
+~~`);
+
+    assert.equal(namespaces[2].name, 'ParentNamespace.FooNamespace');
+    assert.equal(namespaces[2].description, '\n');
+    assert.deepEqual(namespaces[2].warnings, []);
+    assert.equal(await underliner.underline(namespaces[2].sourceRange), `
+FooNamespace = {
+~~~~~~~~~~~~~~~~
+  foo: \'bar\'
+~~~~~~~~~~~~
+};
+~~`);
+
+    assert.equal(namespaces[3].name, 'ParentNamespace.BarNamespace');
+    assert.equal(namespaces[3].description, '\n');
+    assert.deepEqual(namespaces[3].warnings, []);
+    assert.equal(await underliner.underline(namespaces[3].sourceRange), `
+ParentNamespace.BarNamespace = {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   foo: \'bar\'
 ~~~~~~~~~~~~
 };

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -51,7 +51,9 @@ suite('BehaviorScanner', () => {
   test('Finds behavior object assignments', () => {
     assert.deepEqual(behaviorsList.map((b) => b.className).sort(), [
       'SimpleBehavior',
+      'Polymer.SimpleNamespacedBehavior',
       'AwesomeBehavior',
+      'Polymer.AwesomeNamespacedBehavior',
       'Really.Really.Deep.Behavior',
       'CustomBehaviorList'
     ].sort());

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -203,7 +203,7 @@ class BaseElement extends Polymer.Element {
   });
 
   test('properly sets className for elements with the memberof tag', async() => {
-    const elements = await getElements('test-element-6.js');
+    const elements = await getElements('test-element-8.js');
     const elementData = elements.map(getTestProps);
     assert.containSubset(elementData, [
       {
@@ -238,7 +238,7 @@ namespaced name.`,
   });
 
   test('Read mixes annotations', async() => {
-    const elements = await getElements('test-element-8.js');
+    const elements = await getElements('test-element-6.js');
     const elementData = elements.map(getTestProps);
 
     assert.deepEqual(elementData, [

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -210,7 +210,7 @@ class BaseElement extends Polymer.Element {
     ]);
   });
 
-  test('Properly sets className for elements with the memberof tag', async() => {
+  test('properly sets className for elements with the memberof tag', async() => {
     const elements = await getElements('test-element-6.js');
     const elementData = elements.map(getTestProps);
     assert.containSubset(elementData, [
@@ -219,7 +219,7 @@ class BaseElement extends Polymer.Element {
         className: 'Polymer.TestElementOne',
         superClass: 'Polymer.Element',
         description:
-            `This element is a member of Polymer namespace and is defined with its
+            `This element is a member of Polymer namespace and is registered with its
 namespaced name.`,
         properties: [{
           name: 'foo',
@@ -233,7 +233,7 @@ namespaced name.`,
         className: 'Polymer.TestElementTwo',
         superClass: 'Polymer.Element',
         description:
-            `This element is a member of Polymer namespace and is defined without its
+            `This element is a member of Polymer namespace and is registered without its
 namespaced name.`,
         properties: [{
           name: 'foo',

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -206,4 +206,40 @@ class BaseElement extends Polymer.Element {
     ]);
   });
 
+  test('Properly sets className for elements with the memberof tag', async() => {
+    const elements = await getElements('test-element-6.js');
+    const elementData = elements.map(getTestProps);
+    assert.containSubset(elementData, [
+      {
+        tagName: 'test-element-one',
+        className: 'Polymer.TestElementOne',
+        superClass: 'Polymer.Element',
+        description:
+            `This element is a member of Polymer namespace and is defined with its
+namespaced name.`,
+        properties: [{
+          name: 'foo',
+        }],
+        attributes: [{
+          name: 'foo',
+        }],
+      },
+      {
+        tagName: 'test-element-two',
+        className: 'Polymer.TestElementTwo',
+        superClass: 'Polymer.Element',
+        description:
+            `This element is a member of Polymer namespace and is defined without its
+namespaced name.`,
+        properties: [{
+          name: 'foo',
+        }],
+        attributes: [{
+          name: 'foo',
+        }],
+      },
+    ]);
+  });
+
+
 });

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -279,4 +279,22 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
 ~~`);
   });
 
+  test(
+      'properly analyzes nested mixin assignments with memberof tags',
+      async() => {
+        const mixins = await getMixins('test-mixin-8.js');
+        const mixinData = mixins.map(getTestProps);
+        assert.deepEqual(mixinData, [{
+                           name: 'Polymer.TestMixin',
+                           description: '',
+                           properties: [{
+                             name: 'foo',
+                           }],
+                           attributes: [{
+                             name: 'foo',
+                           }],
+                         }]);
+
+      });
+
 });

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -107,7 +107,7 @@ function TestMixin(superclass) {
     const mixins = await getMixins('test-mixin-2.js');
     const mixinData = mixins.map(getTestProps);
     assert.deepEqual(mixinData, [{
-                       name: 'TestMixin',
+                       name: 'Polymer.TestMixin',
                        description: '',
                        properties: [{
                          name: 'foo',
@@ -148,7 +148,7 @@ const TestMixin = (superclass) => class extends superclass {
     const mixins = await getMixins('test-mixin-3.js');
     const mixinData = mixins.map(getTestProps);
     assert.deepEqual(mixinData, [{
-                       name: 'TestMixin',
+                       name: 'Polymer.TestMixin',
                        description: '',
                        properties: [{
                          name: 'foo',
@@ -195,7 +195,7 @@ const TestMixin = function(superclass) {
         const mixins = await getMixins('test-mixin-4.js');
         const mixinData = mixins.map(getTestProps);
         assert.deepEqual(mixinData, [{
-                           name: 'TestMixin',
+                           name: 'Polymer.TestMixin',
                            description: '',
                            properties: [],
                            attributes: [],
@@ -217,7 +217,7 @@ let TestMixin;
     const mixins = await getMixins('test-mixin-6.js');
     const mixinData = mixins.map(getTestProps);
     assert.deepEqual(mixinData, [{
-                       name: 'TestMixin',
+                       name: 'Polymer.TestMixin',
                        description: '',
                        properties: [],
                        attributes: [],

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -3,8 +3,20 @@ var SimpleBehavior = {
   simple: true,
 };
 
+/**
+ * @polymerBehavior
+ * @memberof Polymer
+ * */
+var SimpleNamespacedBehavior = {
+  simple: true,
+};
+
+
 /** @polymerBehavior AwesomeBehavior */
 var CustomNamedBehavior = {custom: true, properties: {a: {value: 1}}};
+
+/** @polymerBehavior Polymer.AwesomeNamespacedBehavior */
+var CustomNamedBehaviorTwo = {custom: true, properties: {a: {value: 1}}};
 
 /**
 With a chained behavior

--- a/src/test/static/namespaces/namespace-unnamed.js
+++ b/src/test/static/namespaces/namespace-unnamed.js
@@ -9,3 +9,19 @@ var ImplicitlyNamedNamespace = {};
 ImplicitlyNamedNamespace.NestedNamespace = {
   foo: 'bar'
 };
+
+/**
+ * @namespace
+ * @memberof ParentNamespace
+ */
+FooNamespace = {
+  foo: 'bar'
+};
+
+/**
+ * @namespace
+ * @memberof ParentNamespace
+ */
+ParentNamespace.BarNamespace = {
+  foo: 'bar'
+};

--- a/src/test/static/polymer2/test-element-6.js
+++ b/src/test/static/polymer2/test-element-6.js
@@ -1,0 +1,39 @@
+/**
+ * This element is a member of Polymer namespace and is defined with its
+ * namespaced name.
+ * @memberof Polymer
+ */
+class TestElementOne extends Polymer.Element {
+  static get config() {
+    return {
+      properties: {
+        foo: {
+          notify: true,
+          type: String,
+        }
+      },
+    };
+  }
+}
+Polymer.TestElementOne = TestElementOne;
+window.customElements.define('test-element-one', Polymer.TestElementOne);
+
+/**
+ * This element is a member of Polymer namespace and is defined without its
+ * namespaced name.
+ * @memberof Polymer
+ */
+class TestElementTwo extends Polymer.Element {
+  static get config() {
+    return {
+      properties: {
+        foo: {
+          notify: true,
+          type: String,
+        }
+      },
+    };
+  }
+}
+Polymer.TestElementTwo = TestElementTwo;
+window.customElements.define('test-element-two', TestElementTwo);

--- a/src/test/static/polymer2/test-element-6.js
+++ b/src/test/static/polymer2/test-element-6.js
@@ -1,5 +1,5 @@
 /**
- * This element is a member of Polymer namespace and is defined with its
+ * This element is a member of Polymer namespace and is registered with its
  * namespaced name.
  * @memberof Polymer
  */
@@ -19,7 +19,7 @@ Polymer.TestElementOne = TestElementOne;
 window.customElements.define('test-element-one', Polymer.TestElementOne);
 
 /**
- * This element is a member of Polymer namespace and is defined without its
+ * This element is a member of Polymer namespace and is registered without its
  * namespaced name.
  * @memberof Polymer
  */

--- a/src/test/static/polymer2/test-element-6.js
+++ b/src/test/static/polymer2/test-element-6.js
@@ -1,39 +1,12 @@
 /**
- * This element is a member of Polymer namespace and is registered with its
- * namespaced name.
- * @memberof Polymer
+ * @polymerElement
+ * @extends Polymer.Element
+ * @mixes Mixin2
+ * @mixes Mixin1
  */
-class TestElementOne extends Polymer.Element {
-  static get config() {
-    return {
-      properties: {
-        foo: {
-          notify: true,
-          type: String,
-        }
-      },
-    };
+class TestElement extends Mixin1
+(Mixin2(Polymer.Element)) {
+  static get is() {
+    return 'test-element';
   }
 }
-Polymer.TestElementOne = TestElementOne;
-window.customElements.define('test-element-one', Polymer.TestElementOne);
-
-/**
- * This element is a member of Polymer namespace and is registered without its
- * namespaced name.
- * @memberof Polymer
- */
-class TestElementTwo extends Polymer.Element {
-  static get config() {
-    return {
-      properties: {
-        foo: {
-          notify: true,
-          type: String,
-        }
-      },
-    };
-  }
-}
-Polymer.TestElementTwo = TestElementTwo;
-window.customElements.define('test-element-two', TestElementTwo);

--- a/src/test/static/polymer2/test-element-8.js
+++ b/src/test/static/polymer2/test-element-8.js
@@ -1,12 +1,39 @@
 /**
- * @polymerElement
- * @extends Polymer.Element
- * @mixes Mixin2
- * @mixes Mixin1
+ * This element is a member of Polymer namespace and is registered with its
+ * namespaced name.
+ * @memberof Polymer
  */
-class TestElement extends Mixin1
-(Mixin2(Polymer.Element)) {
-  static get is() {
-    return 'test-element';
+class TestElementOne extends Polymer.Element {
+  static get config() {
+    return {
+      properties: {
+        foo: {
+          notify: true,
+          type: String,
+        }
+      },
+    };
   }
 }
+Polymer.TestElementOne = TestElementOne;
+window.customElements.define('test-element-one', Polymer.TestElementOne);
+
+/**
+ * This element is a member of Polymer namespace and is registered without its
+ * namespaced name.
+ * @memberof Polymer
+ */
+class TestElementTwo extends Polymer.Element {
+  static get config() {
+    return {
+      properties: {
+        foo: {
+          notify: true,
+          type: String,
+        }
+      },
+    };
+  }
+}
+Polymer.TestElementTwo = TestElementTwo;
+window.customElements.define('test-element-two', TestElementTwo);

--- a/src/test/static/polymer2/test-element-8.js
+++ b/src/test/static/polymer2/test-element-8.js
@@ -4,14 +4,12 @@
  * @memberof Polymer
  */
 class TestElementOne extends Polymer.Element {
-  static get config() {
+  static get properties() {
     return {
-      properties: {
-        foo: {
-          notify: true,
-          type: String,
-        }
-      },
+      foo: {
+        notify: true,
+        type: String,
+      }
     };
   }
 }
@@ -24,14 +22,12 @@ window.customElements.define('test-element-one', Polymer.TestElementOne);
  * @memberof Polymer
  */
 class TestElementTwo extends Polymer.Element {
-  static get config() {
+  static get properties() {
     return {
-      properties: {
-        foo: {
-          notify: true,
-          type: String,
-        }
-      },
+      foo: {
+        notify: true,
+        type: String,
+      }
     };
   }
 }

--- a/src/test/static/polymer2/test-mixin-2.js
+++ b/src/test/static/polymer2/test-mixin-2.js
@@ -1,5 +1,6 @@
 /**
  * @polymerMixin
+ * @memberof Polymer
  */
 const TestMixin = (superclass) => class extends superclass {
   static get config() {

--- a/src/test/static/polymer2/test-mixin-3.js
+++ b/src/test/static/polymer2/test-mixin-3.js
@@ -1,5 +1,6 @@
 /**
  * @polymerMixin
+ * @memberof Polymer
  */
 const TestMixin = function(superclass) {
   return class extends superclass {

--- a/src/test/static/polymer2/test-mixin-4.js
+++ b/src/test/static/polymer2/test-mixin-4.js
@@ -1,5 +1,6 @@
 /**
  * @polymerMixin
+ * @memberof Polymer
  */
 let TestMixin;
 

--- a/src/test/static/polymer2/test-mixin-5.js
+++ b/src/test/static/polymer2/test-mixin-5.js
@@ -1,5 +1,6 @@
 /**
  * @polymerMixin
+ * @memberof Polymer
  */
 class TestMixin extends superclass {
   static get config() {

--- a/src/test/static/polymer2/test-mixin-6.js
+++ b/src/test/static/polymer2/test-mixin-6.js
@@ -1,5 +1,6 @@
 /**
  * @polymerMixin
+ * @memberof Polymer
  */
 function TestMixin() {
 }

--- a/src/test/static/polymer2/test-mixin-8.js
+++ b/src/test/static/polymer2/test-mixin-8.js
@@ -1,0 +1,16 @@
+/**
+ * @polymerMixin
+ * @memberof Polymer
+ */
+Polymer.TestMixin = (superclass) => class extends superclass {
+  static get config() {
+    return {
+      properties: {
+        foo: {
+          notify: true,
+          type: String,
+        }
+      },
+    };
+  }
+}

--- a/src/test/static/polymer2/test-mixin-8.js
+++ b/src/test/static/polymer2/test-mixin-8.js
@@ -3,14 +3,12 @@
  * @memberof Polymer
  */
 Polymer.TestMixin = (superclass) => class extends superclass {
-  static get config() {
+  static get properties() {
     return {
-      properties: {
-        foo: {
-          notify: true,
-          type: String,
-        }
-      },
+      foo: {
+        notify: true,
+        type: String,
+      }
     };
   }
 }


### PR DESCRIPTION
- Polymer 2.0 Elements: className inherits from `@memberof` value if one is given
- Polymer 2.0 Mixins: name inherits from `@memberof` value if one is given
- Behaviors: name inherits from `@memberof` value if one is given (If no explicit full name is given to `@polymerBehavior`)
- Polymer 1.0 Elements: No change / no `@memberof` support
- Polymer 1.0 Mixins: No change / no `@memberof` support

---

 - [X] CHANGELOG.md has been updated
- Resolves #495

/cc @justinfagnani @usergenic 