### PR TITLE
fix the mixing description problem, fix bad description formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0-alpha.28] - 2017-02-24
 * Support for `@memberof` jsdoc tag
+* Fix bad mixin descriptions
+
 
 ### Fixed
 * PackageUrlResolver encodes URIs returned from `resolve` method.

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -29,9 +29,9 @@ export interface Tag {
 
 /**
  * The parsed representation of a JSDoc comment.
- * If no description is found, the description property will be an empty string.
  */
 export interface Annotation {
+  // If no description is found, the property will be an empty string.
   description: string;
   tags: Tag[]|null;
 }

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -29,9 +29,10 @@ export interface Tag {
 
 /**
  * The parsed representation of a JSDoc comment.
+ * If no description is found, the description property will be an empty string.
  */
 export interface Annotation {
-  description?: string;
+  description: string;
   tags: Tag[]|null;
 }
 
@@ -143,15 +144,15 @@ export function removeLeadingAsterisks(description: string): string {
 /**
  * Given a JSDoc string (minus opening/closing comment delimiters), extract its
  * description and tags.
- *
- * @param {string} docs
- * @return {?Annotation}
  */
 export function parseJsdoc(docs: string): Annotation {
   docs = removeLeadingAsterisks(docs);
   const d = doctrine.parse(
       docs, {unwrap: false, lineNumbers: true, preserveWhitespace: true});
-  return {description: d.description, tags: _tagsToHydroTags(d.tags)};
+  // Strip any leading and trailing newline characters in the
+  // description of multiline comments for readibility.
+  const description = d.description && d.description.replace(/^\n+|\n+$/g, '');
+  return {description: description, tags: _tagsToHydroTags(d.tags)};
 }
 
 // Utility

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -61,7 +61,7 @@ class MixinVisitor implements Visitor {
       this._currentMixin = new ScannedPolymerElementMixin({
         name: namespacedName,
         sourceRange,
-        description: docs.description,
+        description: parentJsDocs.description,
       });
       this._currentMixinNode = node;
       this._mixins.push(this._currentMixin);
@@ -81,7 +81,7 @@ class MixinVisitor implements Visitor {
       this._currentMixin = new ScannedPolymerElementMixin({
         name: namespacedName,
         sourceRange,
-        description: docs.description,
+        description: nodeJsDocs.description,
       });
       this._currentMixinNode = node;
       this._mixins.push(this._currentMixin);

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -61,8 +61,7 @@ class MixinVisitor implements Visitor {
       this._currentMixin = new ScannedPolymerElementMixin({
         name: namespacedName,
         sourceRange,
-        // TODO(justinfagnani): fix descriptions correctly in parseJsdoc
-        // description: docs.description,
+        description: docs.description,
       });
       this._currentMixinNode = node;
       this._mixins.push(this._currentMixin);
@@ -82,8 +81,7 @@ class MixinVisitor implements Visitor {
       this._currentMixin = new ScannedPolymerElementMixin({
         name: namespacedName,
         sourceRange,
-        // TODO(justinfagnani): fix descriptions correctly in parseJsdoc
-        // description: docs.description,
+        description: docs.description,
       });
       this._currentMixinNode = node;
       this._mixins.push(this._currentMixin);
@@ -106,10 +104,10 @@ class MixinVisitor implements Visitor {
     const isMixin = this._hasPolymerMixinDocTag(docs);
     const sourceRange = this._document.sourceRangeForNode(node);
     if (isMixin) {
+      console.log('C', cmment, docs);
       this._currentMixin = new ScannedPolymerElementMixin({
-          sourceRange,
-          // TODO(justinfagnani): fix descriptions correctly in parseJsdoc
-          // description: docs.description,
+        sourceRange,
+        description: docs.description,
       });
       this._currentMixinNode = node;
       this._mixins.push(this._currentMixin);
@@ -171,11 +169,8 @@ class MixinVisitor implements Visitor {
     if (mixin == null) {
       return;
     }
-    const comment = esutil.getAttachedComment(node) || '';
-    const docs = jsdoc.parseJsdoc(comment);
     const properties = getProperties(node, this._document);
 
-    mixin.description = docs.description ? docs.description.trim() : '';
     mixin.events = esutil.getEventComments(node);
     // mixin.sourceRange = this._document.sourceRangeForNode(node);
     if (properties) {

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -104,7 +104,6 @@ class MixinVisitor implements Visitor {
     const isMixin = this._hasPolymerMixinDocTag(docs);
     const sourceRange = this._document.sourceRangeForNode(node);
     if (isMixin) {
-      console.log('C', cmment, docs);
       this._currentMixin = new ScannedPolymerElementMixin({
         sourceRange,
         description: docs.description,

--- a/src/test/javascript/jsdoc_test.ts
+++ b/src/test/javascript/jsdoc_test.ts
@@ -81,7 +81,7 @@ suite('jsdoc', function() {
 
     test('handles empty lines', function() {
       const parsed = jsdoc.parseJsdoc('*\n *\n * Foo\n   *\n * Bar');
-      assert.deepEqual(parsed.description, '\n\nFoo\n\nBar');
+      assert.deepEqual(parsed.description, 'Foo\n\nBar');
     });
 
   });

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -46,7 +46,7 @@ suite('NamespaceScanner', () => {
     assert.equal(namespaces.length, 2);
 
     assert.equal(namespaces[0].name, 'ExplicitlyNamedNamespace');
-    assert.equal(namespaces[0].description, '\n');
+    assert.equal(namespaces[0].description, '');
     assert.deepEqual(namespaces[0].warnings, []);
     assert.equal(await underliner.underline(namespaces[0].sourceRange), `
 var ExplicitlyNamedNamespace = {};
@@ -54,7 +54,7 @@ var ExplicitlyNamedNamespace = {};
 
     assert.equal(
         namespaces[1].name, 'ExplicitlyNamedNamespace.NestedNamespace');
-    assert.equal(namespaces[1].description, '\n');
+    assert.equal(namespaces[1].description, '');
     assert.deepEqual(namespaces[1].warnings, []);
     assert.equal(await underliner.underline(namespaces[1].sourceRange), `
 ExplicitlyNamedNamespace.NestedNamespace = {
@@ -70,7 +70,7 @@ ExplicitlyNamedNamespace.NestedNamespace = {
     assert.equal(namespaces.length, 4);
 
     assert.equal(namespaces[0].name, 'ImplicitlyNamedNamespace');
-    assert.equal(namespaces[0].description, '\n');
+    assert.equal(namespaces[0].description, '');
     assert.deepEqual(namespaces[0].warnings, []);
     assert.equal(await underliner.underline(namespaces[0].sourceRange), `
 var ImplicitlyNamedNamespace = {};
@@ -78,7 +78,7 @@ var ImplicitlyNamedNamespace = {};
 
     assert.equal(
         namespaces[1].name, 'ImplicitlyNamedNamespace.NestedNamespace');
-    assert.equal(namespaces[1].description, '\n');
+    assert.equal(namespaces[1].description, '');
     assert.deepEqual(namespaces[1].warnings, []);
     assert.equal(await underliner.underline(namespaces[1].sourceRange), `
 ImplicitlyNamedNamespace.NestedNamespace = {
@@ -116,7 +116,7 @@ ParentNamespace.BarNamespace = {
     assert.equal(namespaces.length, 3);
 
     assert.equal(namespaces[0].name, 'DynamicNamespace.ArrayNotation');
-    assert.equal(namespaces[0].description, '\n');
+    assert.equal(namespaces[0].description, '');
     assert.deepEqual(namespaces[0].warnings, []);
     assert.equal(await underliner.underline(namespaces[0].sourceRange), `
 DynamicNamespace[\'ArrayNotation\'] = {
@@ -127,7 +127,7 @@ DynamicNamespace[\'ArrayNotation\'] = {
 ~~`);
 
     assert.equal(namespaces[1].name, 'DynamicNamespace.DynamicArrayNotation');
-    assert.equal(namespaces[1].description, '\n');
+    assert.equal(namespaces[1].description, '');
     assert.deepEqual(namespaces[1].warnings, []);
     assert.equal(await underliner.underline(namespaces[1].sourceRange), `
 DynamicNamespace[baz] = {
@@ -138,7 +138,7 @@ DynamicNamespace[baz] = {
 ~~`);
 
     assert.equal(namespaces[2].name, 'DynamicNamespace.Aliased');
-    assert.equal(namespaces[2].description, '\n');
+    assert.equal(namespaces[2].description, '');
     assert.deepEqual(namespaces[2].warnings, []);
     assert.equal(await underliner.underline(namespaces[2].sourceRange), `
 aliasToNamespace = {
@@ -154,7 +154,7 @@ aliasToNamespace = {
     assert.equal(namespaces.length, 2);
 
     assert.equal(namespaces[0].name, 'DynamicNamespace.ArrayNotation');
-    assert.equal(namespaces[0].description, '\n');
+    assert.equal(namespaces[0].description, '');
     assert.deepEqual(namespaces[0].warnings, []);
     assert.equal(await underliner.underline(namespaces[0].sourceRange), `
 DynamicNamespace['ArrayNotation'] = {
@@ -165,7 +165,7 @@ DynamicNamespace['ArrayNotation'] = {
 ~~`);
 
     assert.equal(namespaces[1].name, 'DynamicNamespace.baz');
-    assert.equal(namespaces[1].description, '\n');
+    assert.equal(namespaces[1].description, '');
     assert.deepEqual(namespaces[1].warnings, []);
     assert.equal(await underliner.underline(namespaces[1].sourceRange), `
 DynamicNamespace[baz] = {

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -89,7 +89,7 @@ ImplicitlyNamedNamespace.NestedNamespace = {
 ~~`);
 
     assert.equal(namespaces[2].name, 'ParentNamespace.FooNamespace');
-    assert.equal(namespaces[2].description, '\n');
+    assert.equal(namespaces[2].description, '');
     assert.deepEqual(namespaces[2].warnings, []);
     assert.equal(await underliner.underline(namespaces[2].sourceRange), `
 FooNamespace = {
@@ -100,7 +100,7 @@ FooNamespace = {
 ~~`);
 
     assert.equal(namespaces[3].name, 'ParentNamespace.BarNamespace');
-    assert.equal(namespaces[3].description, '\n');
+    assert.equal(namespaces[3].description, '');
     assert.deepEqual(namespaces[3].warnings, []);
     assert.equal(await underliner.underline(namespaces[3].sourceRange), `
 ParentNamespace.BarNamespace = {

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -61,9 +61,7 @@ suite('Polymer2MixinScanner', () => {
     const mixinData = mixins.map(getTestProps);
     assert.deepEqual(mixinData, [{
                        name: 'TestMixin',
-                       // TODO(justinfagnani): enable when descriptions work
-                       //  description: 'A description',
-                       description: '',
+                       description: 'A mixin',
                        properties: [{
                          name: 'foo',
                        }],


### PR DESCRIPTION
- Fixes #501 (Fix good descriptions being overwritten in the mixin scanner.)
- Fixes bad formatting with extra newlines in jsdoc descriptions. There still may be some weirdness going on with how this happens, to be investigated later.
- Changelog updated.
