### PR TITLE
Update version of dom5 to fix undefined function

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "clone": "^2.0.0",
     "cssbeautify": "^0.3.1",
     "doctrine": "^2.0.0",
-    "dom5": "^2.0.0",
+    "dom5": "^2.1.0",
     "escodegen": "^1.7.0",
     "espree": "^3.1.7",
     "estraverse": "^3.1.0",


### PR DESCRIPTION
`dom5` 2.1.0 introduced a new function `defaultChildNodes` which is used in the `polymer/dom-module-scanner` per #470.
However the dependency was not updated in `package.json`, meaning that an installation of `polymer-analyzer` might fail and resolve the incorrect version of `dom5`.

 - [ ] CHANGELOG.md has been updated
