### PR TITLE
IncompleteFeature: unattached scan-time warnings

### DIFF
--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -12,7 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Document} from './document';
+import {Feature, ScannedFeature} from './feature';
+import {Resolvable} from './resolvable';
 import {SourceRange} from './source-range';
+
 export interface Warning {
   message: string;
   sourceRange: SourceRange;
@@ -32,5 +36,37 @@ export class WarningCarryingException extends Error {
   constructor(warning: Warning) {
     super(warning.message);
     this.warning = warning;
+  }
+}
+
+const emptySet = new Set();
+/**
+ * Used for passing along a Warning discovered while scanning that can't be
+ * placed on a complete feature.
+ */
+export class IncompleteFeature implements ScannedFeature, Feature, Resolvable {
+  readonly warning: Warning;
+
+  // No kinds or identifiers as we only want people to find these warnings by
+  // calling getWarnings on documents/packages.
+  readonly kinds: Set<string> = emptySet;
+  readonly identifiers: Set<string> = emptySet;
+
+  readonly description: undefined = undefined;
+  readonly jsdoc: undefined = undefined;
+  readonly astNode: undefined = undefined;
+
+  constructor(warning: Warning) {
+    this.warning = warning;
+  }
+
+  get sourceRange() {
+    return this.warning.sourceRange;
+  }
+  get warnings() {
+    return [this.warning];
+  }
+  resolve(_document: Document) {
+    return this;
   }
 }


### PR DESCRIPTION
 - [x] CHANGELOG.md not updated, internal change.

Will use in a later PR.