### PR TITLE
Parse databindings in JS string literals.

### DIFF
--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -20,7 +20,7 @@ import {HtmlScanner} from '../html/html-scanner';
 import {Feature, getAttachedCommentText, Resolvable, Slot, SourceRange} from '../model/model';
 import {Warning} from '../warning/warning';
 
-import {DatabindingExpression, scanDatabindingTemplateForExpressions, Template} from './expression-scanner';
+import {HtmlDatabindingExpression, scanDatabindingTemplateForExpressions, Template} from './expression-scanner';
 import {LocalId} from './polymer-element';
 
 const p = dom5.predicates;
@@ -37,12 +37,12 @@ export class ScannedDomModule implements Resolvable {
   'slots': Slot[];
   localIds: LocalId[];
   template: Template|undefined;
-  databindings: DatabindingExpression[];
+  databindings: HtmlDatabindingExpression[];
 
   constructor(
       id: string|null, node: ASTNode, sourceRange: SourceRange, ast: dom5.Node,
       warnings: Warning[], template: Template|undefined, slots: Slot[],
-      localIds: LocalId[], databindings: DatabindingExpression[]) {
+      localIds: LocalId[], databindings: HtmlDatabindingExpression[]) {
     this.id = id;
     this.node = node;
     this.comment = getAttachedCommentText(node);
@@ -83,13 +83,13 @@ export class DomModule implements Feature {
   Slot[];
   localIds: LocalId[];
   template: Template|undefined;
-  databindings: DatabindingExpression[];
+  databindings: HtmlDatabindingExpression[];
 
   constructor(
       node: ASTNode, id: string|null, comment: string|undefined,
       sourceRange: SourceRange, ast: dom5.Node, warnings: Warning[],
       slots: Slot[], localIds: LocalId[], template: Template|undefined,
-      databindings: DatabindingExpression[]) {
+      databindings: HtmlDatabindingExpression[]) {
     this.node = node;
     this.id = id;
     this.comment = comment;
@@ -120,7 +120,7 @@ export class DomModuleScanner implements HtmlScanner {
             dom5.predicates.hasTagName('template')) as (Template | undefined);
         let slots: Slot[] = [];
         let localIds: LocalId[] = [];
-        let databindings: DatabindingExpression[] = [];
+        let databindings: HtmlDatabindingExpression[] = [];
         let warnings: Warning[] = [];
         if (template) {
           const templateContent =

--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -17,9 +17,11 @@ import * as estree from 'estree';
 import * as parse5 from 'parse5';
 
 import {ParsedHtmlDocument} from '../html/html-document';
+import {JavaScriptDocument} from '../javascript/javascript-document';
 import {parseJs} from '../javascript/javascript-parser';
 import {correctSourceRange, LocationOffset, SourceRange} from '../model/model';
 import {Severity, Warning} from '../warning/warning';
+
 
 const p = dom5.predicates;
 const isTemplate = p.hasTagName('template');
@@ -55,38 +57,14 @@ export function getAllDataBindingTemplates(node: parse5.ASTNode) {
       dom5.childNodesIncludeTemplate) as Template[];
 }
 
-/**
- * A databinding expression.
- */
-export class DatabindingExpression {
-  /**
-   * If databinding into an attribute this is the element whose attribute is
-   * assigned to. If databinding into a text node, this is that text node.
-   */
-  readonly astNode: parse5.ASTNode;
-  /**
- * If databindingInto is 'attribute' this will hold the HTML element
- * attribute that's being assigned to. Otherwise it's undefined.
- */
-  readonly attribute: parse5.ASTAttribute|undefined;
-
+export type HtmlDatabindingExpression =
+    TextNodeDatabindingExpression | AttributeDatabindingExpression;
+export abstract class DatabindingExpression {
   readonly sourceRange: SourceRange;
   readonly warnings: Warning[] = [];
-
-  /** The databinding syntax used. */
-  readonly direction: '{'|'[';
   readonly expressionText: string;
+
   private readonly _expressionAst: estree.Program;
-
-
-  readonly databindingInto: 'string-interpolation'|'attribute';
-
-  /**
-   * If this is a two-way data binding, and an event name was specified
-   * (using ::eventName syntax), this is that event name.
-   */
-  readonly eventName: string|undefined;
-
   private readonly locationOffset: LocationOffset;
 
   /**
@@ -98,19 +76,10 @@ export class DatabindingExpression {
   properties: Array<{name: string, sourceRange: SourceRange}> = [];
 
   constructor(
-      astNode: parse5.ASTNode, attribute: parse5.ASTAttribute|undefined,
-      sourceRange: SourceRange, direction: '{'|'[', expressionText: string,
-      eventName: string|undefined,
-      databindingInto: 'string-interpolation'|'attribute',
-      ast: estree.Program) {
-    this.astNode = astNode;
-    this.attribute = attribute;
+      sourceRange: SourceRange, expressionText: string, ast: estree.Program) {
     this.sourceRange = sourceRange;
-    this.direction = direction;
-    this.databindingInto = databindingInto;
     this.expressionText = expressionText;
     this._expressionAst = ast;
-    this.eventName = eventName;
     this.locationOffset = {
       line: sourceRange.start.line,
       col: sourceRange.start.column
@@ -201,6 +170,85 @@ export class DatabindingExpression {
   }
 }
 
+export class AttributeDatabindingExpression extends DatabindingExpression {
+  /**
+   * The element whose attribute/property is assigned to.
+   */
+  readonly astNode: parse5.ASTNode;
+
+  readonly databindingInto = 'attribute';
+
+  /**
+   * If true, this is databinding into the complete attribute. Polymer treats
+   * such databindings specially, e.g. they're setting the property by default,
+   * not the attribute.
+   *
+   * e.g.
+   * foo="{{bar}}" is complete, foo="hello {{bar}} world" is not complete.
+   *
+   * An attribute may have multiple incomplete bindings. They will be separate
+   * AttributeDatabindingExpressions.
+   */
+  readonly isCompleteBinding: boolean;
+
+  /** The databinding syntax used. */
+  readonly direction: '{'|'[';
+
+  /**
+   * If this is a two-way data binding, and an event name was specified
+   * (using ::eventName syntax), this is that event name.
+   */
+  readonly eventName: string|undefined;
+
+  /** The attribute we're databinding into. */
+  readonly attribute: parse5.ASTAttribute;
+
+  constructor(
+      astNode: parse5.ASTNode, isCompleteBinding: boolean, direction: '{'|'[',
+      eventName: string|undefined, attribute: parse5.ASTAttribute,
+      sourceRange: SourceRange, expressionText: string, ast: estree.Program) {
+    super(sourceRange, expressionText, ast);
+    this.astNode = astNode;
+    this.isCompleteBinding = isCompleteBinding;
+    this.direction = direction;
+    this.eventName = eventName;
+    this.attribute = attribute;
+  }
+}
+
+export class TextNodeDatabindingExpression extends DatabindingExpression {
+  /** The databinding syntax used. */
+  readonly direction: '{'|'[';
+
+  /**
+   * The HTML text node that contains this databinding.
+   */
+  readonly astNode: parse5.ASTNode;
+
+  readonly databindingInto = 'text-node';
+
+  constructor(
+      direction: '{'|'[', astNode: parse5.ASTNode, sourceRange: SourceRange,
+      expressionText: string, ast: estree.Program) {
+    super(sourceRange, expressionText, ast);
+    this.direction = direction;
+    this.astNode = astNode;
+  }
+}
+
+export class JavascriptDatabindingExpression extends DatabindingExpression {
+  readonly astNode: estree.Node;
+
+  readonly databindingInto = 'javascript';
+
+  constructor(
+      astNode: estree.Node, sourceRange: SourceRange, expressionText: string,
+      ast: estree.Program) {
+    super(sourceRange, expressionText, ast);
+    this.astNode = astNode;
+  }
+}
+
 /**
  * Find and parse Polymer databinding expressions in HTML.
  */
@@ -218,7 +266,7 @@ export function scanDatabindingTemplateForExpressions(
 
 function extractDataBindingsFromTemplates(
     document: ParsedHtmlDocument, templates: Iterable<Template>) {
-  const results: DatabindingExpression[] = [];
+  const results: HtmlDatabindingExpression[] = [];
   const warnings: Warning[] = [];
   for (const template of templates) {
     dom5.nodeWalkAll(template.content, (node) => {
@@ -239,7 +287,7 @@ function extractDataBindingsFromTemplates(
 function extractDataBindingsFromTextNode(
     document: ParsedHtmlDocument,
     node: parse5.ASTNode,
-    results: DatabindingExpression[],
+    results: HtmlDatabindingExpression[],
     warnings: Warning[]) {
   const text = node.value || '';
   const dataBindings = findDatabindingInString(text);
@@ -275,14 +323,11 @@ function extractDataBindingsFromTextNode(
     if (parseResult.type === 'failure') {
       warnings.push(parseResult.warning);
     } else {
-      const expression = new DatabindingExpression(
-          node,
-          undefined,
-          sourceRange,
+      const expression = new TextNodeDatabindingExpression(
           dataBinding.direction,
+          node,
+          sourceRange,
           dataBinding.expressionText,
-          undefined,
-          'string-interpolation',
           parseResult.program);
       for (const warning of expression.warnings) {
         warnings.push(warning);
@@ -298,7 +343,7 @@ function extractDataBindingsFromAttr(
     document: ParsedHtmlDocument,
     node: parse5.ASTNode,
     attr: parse5.ASTAttribute,
-    results: DatabindingExpression[],
+    results: HtmlDatabindingExpression[],
     warnings: Warning[]) {
   if (!attr.value) {
     return;
@@ -317,8 +362,6 @@ function extractDataBindingsFromAttr(
   for (const dataBinding of dataBindings) {
     const isFullAttributeBinding = dataBinding.startIndex === 2 &&
         dataBinding.endIndex + 2 === attr.value.length;
-    const databindingInto =
-        isFullAttributeBinding ? 'attribute' : 'string-interpolation';
     let expressionText = dataBinding.expressionText;
     let eventName = undefined;
     if (dataBinding.direction === '{') {
@@ -342,14 +385,14 @@ function extractDataBindingsFromAttr(
     if (parseResult.type === 'failure') {
       warnings.push(parseResult.warning);
     } else {
-      const expression = new DatabindingExpression(
+      const expression = new AttributeDatabindingExpression(
           node,
+          isFullAttributeBinding,
+          dataBinding.direction,
+          eventName,
           attr,
           sourceRange,
-          dataBinding.direction,
           expressionText,
-          eventName,
-          databindingInto,
           parseResult.program);
       for (const warning of expression.warnings) {
         warnings.push(warning);
@@ -452,4 +495,55 @@ function parseExpression(content: string, expressionSourceRange: SourceRange) {
     return undefined;
   }
   return parseResult;
+}
+
+export function parseExpressionInJsStringLiteral(
+    document: JavaScriptDocument, stringLiteral: estree.Node) {
+  const warnings: Warning[] = [];
+  const result = {
+    databinding: undefined as undefined | JavascriptDatabindingExpression,
+    warnings
+  };
+  const sourceRangeForLiteral = document.sourceRangeForNode(stringLiteral)!;
+
+  if (stringLiteral.type !== 'Literal') {
+    // Should we warn here? It's potentially valid, just unanalyzable. Maybe
+    // just an info that someone could escalate to a warning/error?
+    warnings.push({
+      code: 'unanalyzable-polymer-expression',
+      message: `Can only analyze databinding expressions in string literals.`,
+      severity: Severity.INFO,
+      sourceRange: sourceRangeForLiteral,
+    });
+    return result;
+  }
+  const expressionText = stringLiteral.value;
+  if (typeof expressionText !== 'string') {
+    warnings.push({
+      code: 'invalid-polymer-expression',
+      message: `Expected a string, got a ${typeof expressionText}.`,
+      sourceRange: sourceRangeForLiteral,
+      severity: Severity.WARNING
+    });
+    return result;
+  }
+  const sourceRange: SourceRange = {
+    file: sourceRangeForLiteral.file,
+    start: {
+      column: sourceRangeForLiteral.start.column + 1,
+      line: sourceRangeForLiteral.start.line
+    },
+    end: {
+      column: sourceRangeForLiteral.end.column - 1,
+      line: sourceRangeForLiteral.end.line
+    }
+  };
+  const parsed = parseExpression(expressionText, sourceRange);
+  if (parsed && parsed.type === 'failure') {
+    warnings.push(parsed.warning);
+  } else if (parsed && parsed.type === 'success') {
+    result.databinding = new JavascriptDatabindingExpression(
+        stringLiteral, sourceRange, expressionText, parsed.program);
+  }
+  return result;
 }

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -42,6 +42,9 @@ suite('ExpressionScanner', () => {
         </dom-module>
 
         <div id="{{nope}}"></div>
+        <template>
+          <div id="{{notHereEither}}"></div>
+        </template>
 
         <template is="dom-bind">
           <div id="{{baz}}"></div>
@@ -105,6 +108,12 @@ suite('ExpressionScanner', () => {
           <div id="bar {{val}} baz">
           <div id=" [[x]]{{y}}"></div>
         </template>
+
+        <div id=" {{nope}}"></div>
+        <template>
+          <div id="{{notHereEither}}"></div>
+        </template>
+
       `;
       const underliner = CodeUnderliner.withMapping('test.html', contents);
       const document = new HtmlParser().parse(contents, 'test.html');
@@ -166,6 +175,11 @@ suite('ExpressionScanner', () => {
               )
             }}
           </div>
+        </template>
+
+        {{nope}}
+        <template>
+          <div id="{{notHereEither}}"></div>
         </template>
       `;
 

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -12,16 +12,17 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-
 import {assert} from 'chai';
+import * as estree from 'estree';
 
 import {HtmlParser} from '../../html/html-parser';
-import {scanDocumentForExpressions} from '../../polymer/expression-scanner';
+import {JavaScriptParser} from '../../javascript/javascript-parser';
+import {AttributeDatabindingExpression, parseExpressionInJsStringLiteral, scanDocumentForExpressions, TextNodeDatabindingExpression} from '../../polymer/expression-scanner';
 import {CodeUnderliner} from '../test-utils';
 
 suite('ExpressionScanner', () => {
 
-  suite('scan()', () => {
+  suite('scanning html for expressions', () => {
     test('finds whole-attribute expressions', async() => {
       const contents = `
         <dom-module id="foo-elem">
@@ -50,9 +51,14 @@ suite('ExpressionScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
 
       const results = await scanDocumentForExpressions(document);
-      const expressions = results.expressions;
+      const generalExpressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
+      assert.deepEqual(
+          generalExpressions.map((e) => e.databindingInto),
+          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
+      const expressions =
+          generalExpressions as AttributeDatabindingExpression[];
       assert.deepEqual(
           await underliner.underline(expressions.map((e) => e.sourceRange)), [
             `
@@ -88,8 +94,8 @@ suite('ExpressionScanner', () => {
       assert.deepEqual(
           expressions.map((e) => e.warnings), [[], [], [], [], []]);
       assert.deepEqual(
-          expressions.map((e) => e.databindingInto),
-          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
+          expressions.map((e) => e.isCompleteBinding),
+          [true, true, true, true, true]);
     });
 
     test('finds interpolated attribute expressions', async() => {
@@ -104,11 +110,13 @@ suite('ExpressionScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
 
       const results = await scanDocumentForExpressions(document);
-      const expressions = results.expressions;
+      const generalExpressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
       assert.deepEqual(
-          await underliner.underline(expressions.map((e) => e.sourceRange)), [
+          await underliner.underline(
+              generalExpressions.map((e) => e.sourceRange)),
+          [
             `
           <div id=" {{foo}}"></div>
                       ~~~`,
@@ -122,6 +130,11 @@ suite('ExpressionScanner', () => {
           <div id=" [[x]]{{y}}"></div>
                            ~`
           ]);
+      const expressions =
+          generalExpressions as AttributeDatabindingExpression[];
+      assert.deepEqual(
+          expressions.map((e) => e.isCompleteBinding),
+          [false, false, false, false]);
       assert.deepEqual(
           expressions.map((e) => e.direction), ['{', '{', '[', '{']);
       assert.deepEqual(
@@ -136,12 +149,9 @@ suite('ExpressionScanner', () => {
       assert.deepEqual(
           expressions.map((e) => e.attribute && e.attribute.name),
           ['id', 'id', 'id', 'id']);
-      assert.deepEqual(expressions.map((e) => e.databindingInto), [
-        'string-interpolation',
-        'string-interpolation',
-        'string-interpolation',
-        'string-interpolation'
-      ]);
+      assert.deepEqual(
+          expressions.map((e) => e.databindingInto),
+          ['attribute', 'attribute', 'attribute', 'attribute']);
     });
 
     test('finds expressions in text nodes', async() => {
@@ -163,9 +173,13 @@ suite('ExpressionScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
 
       const results = await scanDocumentForExpressions(document);
-      const expressions = results.expressions;
+      const generalExpressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
+      assert.deepEqual(
+          generalExpressions.map((e) => e.databindingInto),
+          ['text-node', 'text-node', 'text-node', 'text-node', 'text-node']);
+      const expressions = generalExpressions as TextNodeDatabindingExpression[];
       assert.deepEqual(
           await underliner.underline(expressions.map((e) => e.sourceRange)), [
             `
@@ -210,19 +224,6 @@ suite('ExpressionScanner', () => {
           [['foo'], ['bar'], ['baz'], ['zod'], ['multiline', 'expressions']]);
       assert.deepEqual(
           expressions.map((e) => e.warnings), [[], [], [], [], []]);
-      assert.deepEqual(
-          expressions.map((e) => e.eventName),
-          [undefined, undefined, undefined, undefined, undefined]);
-      assert.deepEqual(
-          expressions.map((e) => e.attribute && e.attribute.name),
-          [undefined, undefined, undefined, undefined, undefined]);
-      assert.deepEqual(expressions.map((e) => e.databindingInto), [
-        'string-interpolation',
-        'string-interpolation',
-        'string-interpolation',
-        'string-interpolation',
-        'string-interpolation'
-      ]);
     });
 
     test('gives accurate locations for parse errors', async() => {
@@ -274,4 +275,49 @@ suite('ExpressionScanner', () => {
     });
   });
 
+  suite('parsing expressions from javascript string literals', () => {
+    test('it succeeds and fails properly', async() => {
+      const contents = `
+        const observers = [
+          'foo(bar, baz)',
+          'foo(bar baz)',
+          'foo(bar.*)',
+          10,
+          observerAssignedElsewhere,
+        ];
+      `;
+      const underliner = CodeUnderliner.withMapping('test.js', contents);
+      const javascriptDocument =
+          new JavaScriptParser().parse(contents, 'test.js');
+      const literals: estree.Literal[] =
+          javascriptDocument.ast.body[0]['declarations'][0]['init']['elements'];
+
+      const parsedLiterals = literals.map(
+          (l) => parseExpressionInJsStringLiteral(javascriptDocument, l));
+      const warnings = parsedLiterals.map((pl) => pl.warnings)
+                           .reduce((p, n) => p.concat(n), []);
+      const expressionRanges = parsedLiterals.map(
+          (pl) => pl.databinding && pl.databinding.sourceRange);
+      assert.deepEqual(await underliner.underline(expressionRanges), [
+        `
+          'foo(bar, baz)',
+           ~~~~~~~~~~~~~`,
+        `No source range given.`,
+        `No source range given.`,
+        `No source range given.`,
+        `No source range given.`,
+      ]);
+      assert.deepEqual(await underliner.underline(warnings), [
+        `
+          'foo(bar baz)',
+                   ~`,
+        `
+          10,
+          ~~`,
+        `
+          observerAssignedElsewhere,
+          ~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
For stuff like the observers array, computed properties, etc.

Not hooked up anywhere yet, will do that in a followup PR.

 - [x] CHANGELOG.md not updated, internal change.
