### PR TITLE
Added options to the `_fork` method and also made `_fork` public and experimental on AnalysisContext.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!--## Unreleased-->
+## Unreleased
+
+* Added options argument for Analyzer `_fork` method, supporting individual property overrides.
 
 ## [2.0.0-alpha.30] - 2017-03-03
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -102,6 +102,10 @@ export class Analyzer {
    * is also forked and individual properties are overridden by the options.
    * is forked with the given options.
    *
+   * When the analysis context is forked, its cache is preserved, so any files
+   * loaded prior to the fork will remain in the cache until otherwise
+   * invalidated.
+   *
    * Note: this feature is experimental.
    */
   _fork(options?: ForkOptions): Analyzer {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -102,9 +102,9 @@ export class Analyzer {
    * is also forked and individual properties are overridden by the options.
    * is forked with the given options.
    *
-   * When the analysis context is forked, its cache is preserved, so any files
-   * loaded prior to the fork will remain in the cache until otherwise
-   * invalidated.
+   * When the analysis context is forked, its cache is preserved, so you will
+   * see a mixture of pre-fork and post-fork contents when you analyze with a
+   * forked analyzer.
    *
    * Note: this feature is experimental.
    */

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -34,15 +34,10 @@ export interface Options {
 }
 
 /**
- * Mirror of the Options interface, except that all properties are optional.
+ * These are the options available to the `_fork` method.  Currently, only the
+ * `urlLoader` override is implemented.
  */
-export interface ForkOptions {
-  urlLoader?: UrlLoader;
-  urlResolver?: UrlResolver;
-  parsers?: Map<string, Parser<any>>;
-  scanners?: ScannerTable;
-  lazyEdges?: LazyEdgeMap;
-}
+export interface ForkOptions { urlLoader?: UrlLoader; }
 
 export class NoKnownParserError extends Error {};
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -33,6 +33,17 @@ export interface Options {
   lazyEdges?: LazyEdgeMap;
 }
 
+/**
+ * Mirror of the Options interface, except that all properties are optional.
+ */
+export interface ForkOptions {
+  urlLoader?: UrlLoader;
+  urlResolver?: UrlResolver;
+  parsers?: Map<string, Parser<any>>;
+  scanners?: ScannerTable;
+  lazyEdges?: LazyEdgeMap;
+}
+
 export class NoKnownParserError extends Error {};
 
 export type ScannerTable = Map<string, Scanner<any, any, any>[]>;
@@ -92,13 +103,16 @@ export class Analyzer {
   }
 
   /**
-   * Returns a clone of the analyzer, with the same context, suitable for
-   * running in parallel.
+   * Returns a copy of the analyzer.  If options are given, the AnalysisContext
+   * is also forked and individual properties are overridden by the options.
+   * is forked with the given options.
    *
    * Note: this feature is experimental.
    */
-  _fork(): Analyzer {
-    return new Analyzer(this._context);
+  _fork(options?: ForkOptions): Analyzer {
+    const context =
+        options ? this._context._fork(undefined, options) : this._context;
+    return new Analyzer(context);
   }
 
   /**

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -260,8 +260,8 @@ export class AnalysisContext {
       urlLoader: this._loader,
       urlResolver: this._resolver,
     };
-    if (options) {
-      Object.assign(contextOptions, options);
+    if (options && options.urlLoader) {
+      contextOptions.urlLoader = options.urlLoader;
     }
     const copy = new AnalysisContext(contextOptions);
     if (!cache) {

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -14,7 +14,7 @@
 
 import * as path from 'path';
 
-import {LazyEdgeMap, NoKnownParserError, Options, ScannerTable} from '../analyzer';
+import {ForkOptions, LazyEdgeMap, NoKnownParserError, Options, ScannerTable} from '../analyzer';
 import {CssParser} from '../css/css-parser';
 import {HtmlCustomElementReferenceScanner} from '../html/html-element-reference-scanner';
 import {HtmlImportScanner} from '../html/html-import-scanner';
@@ -247,16 +247,26 @@ export class AnalysisContext {
   }
 
   /**
-   * Return a copy, but with the given cache.
+   * Returns a copy of the context but with optional replacements of cache or
+   * constructor options.
+   *
+   * Note: this feature is experimental.
    */
-  private _fork(cache: AnalysisCache): AnalysisContext {
-    const copy = new AnalysisContext({
+  _fork(cache?: AnalysisCache, options?: ForkOptions): AnalysisContext {
+    const contextOptions: Options = {
       lazyEdges: this._lazyEdges,
       parsers: this._parsers,
       scanners: this._scanners,
       urlLoader: this._loader,
-      urlResolver: this._resolver
-    });
+      urlResolver: this._resolver,
+    };
+    if (options) {
+      Object.assign(contextOptions, options);
+    }
+    const copy = new AnalysisContext(contextOptions);
+    if (!cache) {
+      cache = this._cache.invalidate([]);
+    }
     copy._cache = cache;
     copy._generation = this._generation + 1;
     return copy;

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -726,6 +726,20 @@ var DuplicateNamespace = {};
       assert.equal(b1.parsedDocument.contents, 'b for analyzer');
       assert.equal(b2.parsedDocument.contents, 'b for analyzer2');
     });
+
+    test('supports overriding of Analyzer options', async() => {
+      const loader1 = {canLoad: () => true, load: async(u: string) => `${u} 1`};
+      const loader2 = {canLoad: () => true, load: async(u: string) => `${u} 2`};
+      const analyzer1 = new Analyzer({urlLoader: loader1});
+      const a1 = await analyzer1.analyze('a.html');
+      const analyzer2 = analyzer1._fork({urlLoader: loader2});
+      const a2 = await analyzer2.analyze('a.html');
+      const b2 = await analyzer2.analyze('b.html');
+
+      assert.equal(a1.parsedDocument.contents, 'a.html 1');
+      assert.equal(a2.parsedDocument.contents, 'a.html 1');
+      assert.equal(b2.parsedDocument.contents, 'b.html 2');
+    });
   });
 
   suite('race conditions and caching', () => {

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -727,18 +727,20 @@ var DuplicateNamespace = {};
       assert.equal(b2.parsedDocument.contents, 'b for analyzer2');
     });
 
-    test('supports overriding of Analyzer options', async() => {
+    test('supports overriding of urlLoader', async() => {
       const loader1 = {canLoad: () => true, load: async(u: string) => `${u} 1`};
       const loader2 = {canLoad: () => true, load: async(u: string) => `${u} 2`};
       const analyzer1 = new Analyzer({urlLoader: loader1});
       const a1 = await analyzer1.analyze('a.html');
       const analyzer2 = analyzer1._fork({urlLoader: loader2});
       const a2 = await analyzer2.analyze('a.html');
+      const b1 = await analyzer1.analyze('b.html');
       const b2 = await analyzer2.analyze('b.html');
 
-      assert.equal(a1.parsedDocument.contents, 'a.html 1');
-      assert.equal(a2.parsedDocument.contents, 'a.html 1');
-      assert.equal(b2.parsedDocument.contents, 'b.html 2');
+      assert.equal(a1.parsedDocument.contents, 'a.html 1', 'a.html, loader 1');
+      assert.equal(a2.parsedDocument.contents, 'a.html 1', 'a.html, in cache');
+      assert.equal(b1.parsedDocument.contents, 'b.html 1', 'b.html, loader 1');
+      assert.equal(b2.parsedDocument.contents, 'b.html 2', 'b.html, loader 2');
     });
   });
 


### PR DESCRIPTION
 - Addresses #547 supporting line-item property forking by letting `_fork()` take options.
 - [x] CHANGELOG.md has been updated
