### PR TITLE
Fix a subtle issue in getIdentifierName

### DIFF
--- a/src/javascript/ast-value.ts
+++ b/src/javascript/ast-value.ts
@@ -185,12 +185,14 @@ export function getIdentifierName(node: estree.Node): string|undefined {
   if (node.type === 'Identifier') {
     return node.name;
   }
-  if (node.type === 'Literal') {
-    return String(node.value);
-  }
   if (node.type === 'MemberExpression') {
     const object = getIdentifierName(node.object);
-    const property = getIdentifierName(node.property);
+    let property;
+    if (node.computed) {
+      property = expressionToValue(node.property);
+    } else {
+      property = getIdentifierName(node.property);
+    }
     if (object != null && property != null) {
       return `${object}.${property}`;
     }

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -618,7 +618,6 @@ suite('Analyzer', () => {
       'DynamicNamespace.ArrayNotation',
       'DynamicNamespace.DynamicArrayNotation',
       'DynamicNamespace.Aliased',
-      'DynamicNamespace.baz',
     ]);
   });
 

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -152,7 +152,7 @@ aliasToNamespace = {
 
   test('scans unnamed, dynamic namespaces', async() => {
     const namespaces = await getNamespaces('namespace-dynamic-unnamed.js');
-    assert.equal(namespaces.length, 2);
+    assert.equal(namespaces.length, 1);
 
     assert.equal(namespaces[0].name, 'DynamicNamespace.ArrayNotation');
     assert.equal(namespaces[0].description, '');
@@ -160,17 +160,6 @@ aliasToNamespace = {
     assert.equal(await underliner.underline(namespaces[0].sourceRange), `
 DynamicNamespace['ArrayNotation'] = {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  foo: 'bar'
-~~~~~~~~~~~~
-};
-~~`);
-
-    assert.equal(namespaces[1].name, 'DynamicNamespace.baz');
-    assert.equal(namespaces[1].description, '');
-    assert.deepEqual(namespaces[1].warnings, []);
-    assert.equal(await underliner.underline(namespaces[1].sourceRange), `
-DynamicNamespace[baz] = {
-~~~~~~~~~~~~~~~~~~~~~~~~~
   foo: 'bar'
 ~~~~~~~~~~~~
 };

--- a/src/test/static/namespaces/namespace-dynamic-unnamed.js
+++ b/src/test/static/namespaces/namespace-dynamic-unnamed.js
@@ -7,6 +7,7 @@ DynamicNamespace['ArrayNotation'] = {
 
 var baz = 'abc';
 /**
+ * We can't look this up yet.
  * @namespace
  */
 DynamicNamespace[baz] = {


### PR DESCRIPTION
It was treating `foo[bar]` the same as `foo.bar` and `foo['bar']`.

 - [x] Minor bugfix. Not CHANGELOG.md worthy
