### PR TITLE
Fix the typescript part at least of `npm link`

### DIFF
--- a/custom_typings/estraverse.d.ts
+++ b/custom_typings/estraverse.d.ts
@@ -1,0 +1,15 @@
+declare module 'estraverse' {
+  import * as estree from 'estree';
+  export interface Visitor {
+    enter?: (node: estree.Node, parentNode: estree.Node) => (void|
+                                                             VisitorOption);
+    leave?: (node: estree.Node, parentNode: estree.Node) => (void|
+                                                             VisitorOption);
+
+    fallback?: 'iteration';
+  }
+
+  export enum VisitorOption {Skip, Break, Remove}
+
+  export function traverse(ast: estree.Node, visitor: Visitor): any;
+}

--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="./chai.d.ts" />
 /// <reference path="./espree.d.ts" />
+/// <reference path="./estraverse.d.ts" />
 /// <reference path="./shady-css-parser.d.ts" />
 /// <reference path="./strip-indent.d.ts" />

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@types/cssbeautify": "^0.3.1",
     "@types/doctrine": "^0.0.1",
     "@types/escodegen": "^0.0.2",
-    "@types/estraverse": "^0.0.2",
     "@types/estree": "^0.0.34",
     "@types/node": "^6.0.0",
     "@types/parse5": "^2.2.34",

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -126,8 +126,7 @@ export function getEventComments(node: estree.Node): ScannedEvent[] {
           .map((commentAST) => commentAST.value)
           .filter((comment) => comment.indexOf('@event') !== -1)
           .forEach((comment) => eventComments.add(comment));
-    },
-    keys: {Super: []}
+    }
   });
   return Array.from(eventComments)
       .map(function(comment) {


### PR DESCRIPTION
This is a known bug in typescript: https://github.com/Microsoft/TypeScript/issues/6496#issuecomment-281852127

This workaround adds minimal estraverse typings for our use case as a local custom typing so that no compiler instance sees both definitions.

I put together a minimal repro here for further investigation and to quickly evaluate fixes: https://github.com/rictic/repro-npm-link-typescript-issue

 - [x] CHANGELOG.md not updated
