### PR TITLE
Use a fast and simple method to convert between offsets and source ranges

### DIFF
--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -166,7 +166,7 @@ export interface StringifyOptions {
  * The variant of binary search that returns the number of elements in the
  * array that is strictly less than the target.
  */
-export function binarySearch(target: number, arr: number[]) {
+function binarySearch(target: number, arr: number[]) {
   let lower = 0;
   let upper = arr.length - 1;
   while (true) {

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -111,18 +111,18 @@ export abstract class ParsedDocument<AstNode, Visitor> {
   }
 
   sourcePositionToOffset(position: SourcePosition): number {
+    const line = Math.max(0, position.line);
     let lineOffset;
-    if (position.line === 0) {
+    if (line === 0) {
       lineOffset = -1;
+    } else if (line > this.newlineIndexes.length) {
+      lineOffset = this.contents.length - 1;
     } else {
-      lineOffset = this.newlineIndexes[position.line - 1];
+      lineOffset = this.newlineIndexes[line - 1];
     }
-    if (lineOffset == null) {
-      throw new Error(
-          `Asked for line ${position.line} of ` +
-          `${this.newlineIndexes.length} line ${this.toString()}`);
-    }
-    return position.column + lineOffset + 1;
+    const result = position.column + lineOffset + 1;
+    // Clamp within bounds.
+    return Math.min(Math.max(0, result), this.contents.length);
   }
 
   sourceRangeToOffsets(range: SourceRange): [number, number] {

--- a/src/test/parser/document_test.ts
+++ b/src/test/parser/document_test.ts
@@ -29,6 +29,17 @@ class TestDocument extends ParsedDocument<null, null> {
   stringify(_options: StringifyOptions): string {
     throw new Error('Method not implemented.');
   }
+
+  constructor(contents: string) {
+    super({
+      ast: null,
+      astNode: null,
+      baseUrl: 'test-document', contents,
+      isInline: false,
+      locationOffset: undefined,
+      url: 'test-document'
+    });
+  }
 }
 
 suite('ParsedDocument', () => {
@@ -44,15 +55,7 @@ suite('ParsedDocument', () => {
   test(testName, async() => {
     const contents = [``, `asdf`, `a\na`, `asdf\n\nasdf`, `\nasdf\n`];
     for (const content of contents) {
-      const document = new TestDocument({
-        ast: null,
-        astNode: null,
-        baseUrl: 'test-document',
-        contents: content,
-        isInline: false,
-        locationOffset: undefined,
-        url: 'test-document'
-      });
+      const document = new TestDocument(content);
       for (let start = 0; start < contents.length; start++) {
         for (let end = start; end < contents.length; end++) {
           const range = document.offsetsToSourceRange(start, end);
@@ -61,5 +64,23 @@ suite('ParsedDocument', () => {
         }
       }
     }
+  });
+
+  test('sourceRangeToOffsets works for simple cases', async() => {
+    let document = new TestDocument('ab');
+    assert.deepEqual(document.offsetToSourcePosition(0), {line: 0, column: 0});
+    assert.deepEqual(document.offsetToSourcePosition(1), {line: 0, column: 1});
+    assert.deepEqual(document.offsetToSourcePosition(2), {line: 0, column: 2});
+    document = new TestDocument('\n\n');
+    assert.deepEqual(document.offsetToSourcePosition(0), {line: 0, column: 0});
+    assert.deepEqual(document.offsetToSourcePosition(1), {line: 1, column: 0});
+    assert.deepEqual(document.offsetToSourcePosition(2), {line: 2, column: 0});
+    document = new TestDocument('a\nb\nc');
+    assert.deepEqual(document.offsetToSourcePosition(0), {line: 0, column: 0});
+    assert.deepEqual(document.offsetToSourcePosition(1), {line: 0, column: 1});
+    assert.deepEqual(document.offsetToSourcePosition(2), {line: 1, column: 0});
+    assert.deepEqual(document.offsetToSourcePosition(3), {line: 1, column: 1});
+    assert.deepEqual(document.offsetToSourcePosition(4), {line: 2, column: 0});
+    assert.deepEqual(document.offsetToSourcePosition(5), {line: 2, column: 1});
   });
 });

--- a/src/test/parser/document_test.ts
+++ b/src/test/parser/document_test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {assert} from 'chai';
+import {SourceRange} from '../../model/model';
+import {ParsedDocument, StringifyOptions} from '../../parser/document';
+
+class TestDocument extends ParsedDocument<null, null> {
+  type: string;
+  visit(_visitors: null[]): void {
+    throw new Error('Method not implemented.');
+  }
+  forEachNode(_callback: (node: null) => void): void {
+    throw new Error('Method not implemented.');
+  }
+  protected _sourceRangeForNode(_node: null): SourceRange|undefined {
+    throw new Error('Method not implemented.');
+  }
+  stringify(_options: StringifyOptions): string {
+    throw new Error('Method not implemented.');
+  }
+}
+
+suite('ParsedDocument', () => {
+
+  /**
+   * We have pretty great tests of offsetsToSourceRange just because it's used
+   * so much in ParsedHtmlDocument, which has tons of tests. So we can get good
+   * tests of sourceRangeToOffsets by ensuring that they're inverses of one
+   * another.
+   */
+  const testName =
+      'offsetsToSourceRange is the inverse of sourceRangeToOffsets';
+  test(testName, async() => {
+    const contents = [``, `asdf`, `a\na`, `asdf\n\nasdf`, `\nasdf\n`];
+    for (const content of contents) {
+      const document = new TestDocument({
+        ast: null,
+        astNode: null,
+        baseUrl: 'test-document',
+        contents: content,
+        isInline: false,
+        locationOffset: undefined,
+        url: 'test-document'
+      });
+      for (let start = 0; start < contents.length; start++) {
+        for (let end = start; end < contents.length; end++) {
+          const range = document.offsetsToSourceRange(start, end);
+          const offsets = document.sourceRangeToOffsets(range);
+          assert.deepEqual(offsets, [start, end]);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
 - [x] CHANGELOG.md not updated, no visible changes

Builds on top of #569 

This change deletes a bunch of code, but fortunately there's really good tests of the deleted code, so we can be confident that the replacement is equivalent. See the tests for html document and polymer expressions.