### PR TITLE
Tighten down our .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,23 @@ node_modules
 bower_components
 .DS_Store
 .idea
+.vscode
+.github
+.clang-format
+.editorconfig
+.gitattributes
+.travis.yml
+gulpfile.js
+tslint.json
 npm-debug.log
 
 # The raw typescript source
 src/
+
+# Tests and test fixtures
+lib/test/
+test/
+
+# Bits of code that demonstrate the API
+lib/demo
+


### PR DESCRIPTION
 - [x] CHANGELOG.md not updated

This will save >1.5MB for all downstream projects.
