### PR TITLE
Recover from undefined source ranges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Added `canLoad` method to `Analyzer`.
+* Handle undefined source ranges more gracefully in WarningPrinter.
 
 ## [2.0.0-alpha.36] - 2017-04-07
 

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -52,6 +52,13 @@ export class WarningPrinter {
   async printWarning(warning: Warning) {
     const severity = this._severityToString(warning.severity);
     const range = warning.sourceRange;
+    if (!range) {
+      this._outStream.write(
+          `INTERNAL ERROR: Tried to print a '${warning.code}' ` +
+          `warning without a source range. Please report this!\n` +
+          `     https://github.com/Polymer/polymer-analyzer/issues/new\n`);
+      return;
+    }
 
     if (this._options.verbosity === 'full') {
       this._outStream.write('\n\n');

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -57,6 +57,9 @@ export class WarningPrinter {
           `INTERNAL ERROR: Tried to print a '${warning.code}' ` +
           `warning without a source range. Please report this!\n` +
           `     https://github.com/Polymer/polymer-analyzer/issues/new\n`);
+      this._outStream.write(
+          `${this._severityToString(warning.severity)} ` +
+          `[${warning.code}] - ${warning.message}\n`);
       return;
     }
 
@@ -84,9 +87,8 @@ export class WarningPrinter {
       default:
         const never: never = severity;
         throw new Error(
-            `Unknown severity value - ${
-                                        never
-                                      } - encountered while printing warning.`);
+            `Unknown severity value - ${never} - ` +
+            `encountered while printing warning.`);
     }
   }
 


### PR DESCRIPTION
I've seen this a couple times, working to track it down but it's way easier with the warning code (and we don't want to disrupt users too much in this sort of situation).

I'll be looking into this in more detail.

 - [x] CHANGELOG.md has been updated
