### PR TITLE
Treat `build` dir as external too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * All Documents, ParsedDocuments, and ScannedDocuments now have correct SourceRanges. This also fixes a bug whereby `getByKind('document')` would fail to filter out package-external Documents.
 * Fix an issue where package-external features could be included in queries that dot not ask for them. Specifically we were filtering based on the text in files  like `../paper-button/paper-button.html` rather than the path to the file on disk like `bower_components/paper-button/paper-button.html` when determining externality.
+* Treat a directory named `build` as external, same as we do ones named `bower_components.*` or `node_modules.*`
 
 ## [2.0.0-alpha.33] - 2017-03-14
 

--- a/src/model/package.ts
+++ b/src/model/package.ts
@@ -21,7 +21,7 @@ export type QueryOptions = object & BaseQueryOptions;
 
 // A regexp that matches paths to external code.
 // TODO(rictic): Make this extensible (polymer.json?).
-const MATCHES_EXTERNAL = /(^|\/)(bower_components|node_modules)/;
+const MATCHES_EXTERNAL = /(^|\/)(bower_components|node_modules|build($|\/))/;
 
 /**
  * Represents a queryable interface over all documents in a package/project.

--- a/src/model/package.ts
+++ b/src/model/package.ts
@@ -21,6 +21,9 @@ export type QueryOptions = object & BaseQueryOptions;
 
 // A regexp that matches paths to external code.
 // TODO(rictic): Make this extensible (polymer.json?).
+// Note that we match directories named exactly `build`, but will match any
+// directory name prefixed by `bower_components` or `node_modules`, in order to
+// ignore `polymer install`'s variants, which look like bower_components-foo
 const MATCHES_EXTERNAL = /(^|\/)(bower_components|node_modules|build($|\/))/;
 
 /**

--- a/src/test/static/project-with-errors/build/output.html
+++ b/src/test/static/project-with-errors/build/output.html
@@ -1,0 +1,1 @@
+<link rel="import" href="built-nonexistant-import.html">

--- a/src/test/static/project/build/output.html
+++ b/src/test/static/project/build/output.html
@@ -1,0 +1,4 @@
+<script>
+  customElements.define('build-output', class extends HTMLElement { });
+
+</script>


### PR DESCRIPTION
Seems like a reasonable default.

Fixes https://github.com/Polymer/polymer-cli/issues/616

- [x] CHANGELOG.md has been updated
