### PR TITLE
Moved the polymer behaviors from Analysis.mixins => Analysis.metadata.polymer.behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* `generateAnalysis()` now includes PolymerBehavior information in its `mixins` collection.  Identified by `metadata.polymer.isBehavior`.
+* `generateAnalysis()` now includes PolymerBehavior information in `metadata.polymer.behaviors` collection.
 
 ## [2.0.0-alpha.34] - 2017-03-20
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "chalk": "^1.1.3",
     "clone": "^2.0.0",
     "cssbeautify": "^0.3.1",
-    "defaults-deep": "^0.2.3",
     "doctrine": "^2.0.0",
     "dom5": "^2.1.0",
     "escodegen": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "chalk": "^1.1.3",
     "clone": "^2.0.0",
     "cssbeautify": "^0.3.1",
+    "defaults-deep": "^0.2.3",
     "doctrine": "^2.0.0",
     "dom5": "^2.1.0",
     "escodegen": "^1.7.0",

--- a/src/analysis-format.ts
+++ b/src/analysis-format.ts
@@ -30,6 +30,17 @@ export interface Analysis {
   functions?: Function[];
   mixins?: ElementMixin[];
   namespaces?: Namespace[];
+
+  /**
+   * An extension point for framework-specific metadata, as well as any
+   * metadata not yet standardized here such as what polyfills are needed,
+   * behaviors and mixins used, the framework that the package was written in,
+   * tags/categories, framework config files, etc.
+   *
+   * Framework-specific metadata should be put into a sub-object with the name
+   * of that framework.
+   */
+  metadata?: any;
 }
 
 /**

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -21,8 +21,9 @@ import {Function as ResolvedFunction} from './javascript/function';
 import {Namespace as ResolvedNamespace} from './javascript/namespace';
 import {Document} from './model/document';
 import {Feature} from './model/feature';
-import {Attribute as ResolvedAttribute, Element as ResolvedElement, ElementMixin as ResolvedMixin, Event as ResolvedEvent, Method as ResolvedMethod, PolymerBehavior as ResolvedPolymerBehavior, Property as ResolvedProperty, SourceRange as ResolvedSourceRange} from './model/model';
+import {Attribute as ResolvedAttribute, Element as ResolvedElement, ElementMixin as ResolvedMixin, Event as ResolvedEvent, Method as ResolvedMethod, Property as ResolvedProperty, SourceRange as ResolvedSourceRange} from './model/model';
 import {Package} from './model/package';
+import {Behavior as ResolvedPolymerBehavior} from './polymer/behavior';
 
 export type ElementOrMixin = ResolvedElement | ResolvedMixin;
 

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -28,8 +28,6 @@ export type ElementOrMixin = ResolvedElement | ResolvedMixin;
 
 export type Filter = (feature: Feature) => boolean;
 
-const setDefaults = require('defaults-deep');
-
 interface Members {
   elements: Set<ResolvedElement>;
   mixins: Set<ResolvedMixin>;
@@ -130,7 +128,10 @@ function buildAnalysis(members: Members, packagePath: string): Analysis {
   for (const behavior of members.polymerBehaviors) {
     const namespaceName = getNamespaceName(behavior.name);
     const namespace = namespaces.get(namespaceName) || analysis;
-    setDefaults(namespace, {metadata: {polymer: {behaviors: []}}});
+    namespace.metadata = namespace.metadata || {};
+    namespace.metadata.polymer = namespace.metadata.polymer || {};
+    namespace.metadata.polymer.behaviors =
+        namespace.metadata.polymer.behaviors || [];
     namespace.metadata.polymer.behaviors.push(
         serializePolymerBehaviorAsElementMixin(behavior, packagePath));
   }

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -28,6 +28,8 @@ export type ElementOrMixin = ResolvedElement | ResolvedMixin;
 
 export type Filter = (feature: Feature) => boolean;
 
+const setDefaults = require('defaults-deep');
+
 interface Members {
   elements: Set<ResolvedElement>;
   mixins: Set<ResolvedMixin>;
@@ -124,11 +126,12 @@ function buildAnalysis(members: Members, packagePath: string): Analysis {
     namespace.functions.push(serializeFunction(_function, packagePath));
   }
 
+  // TODO(usergenic): Consider moving framework-specific code to separate file.
   for (const behavior of members.polymerBehaviors) {
     const namespaceName = getNamespaceName(behavior.name);
     const namespace = namespaces.get(namespaceName) || analysis;
-    namespace.mixins = namespace.mixins || [];
-    namespace.mixins.push(
+    setDefaults(namespace, {metadata: {polymer: {behaviors: []}}});
+    namespace.metadata.polymer.behaviors.push(
         serializePolymerBehaviorAsElementMixin(behavior, packagePath));
   }
 
@@ -255,7 +258,6 @@ function serializePolymerBehaviorAsElementMixin(
   const metadata = serializeElementLike(behavior, packagePath) as ElementMixin;
   metadata.name = behavior.className;
   metadata.privacy = behavior.privacy;
-  metadata.metadata.polymer = {isBehavior: true};
   if (behavior.mixins.length > 0) {
     metadata.mixins = behavior.mixins.map((m) => m.identifier);
   }

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -127,7 +127,7 @@ function buildAnalysis(members: Members, packagePath: string): Analysis {
 
   // TODO(usergenic): Consider moving framework-specific code to separate file.
   for (const behavior of members.polymerBehaviors) {
-    const namespaceName = getNamespaceName(behavior.name);
+    const namespaceName = getNamespaceName(behavior.className);
     const namespace = namespaces.get(namespaceName) || analysis;
     namespace.metadata = namespace.metadata || {};
     namespace.metadata.polymer = namespace.metadata.polymer || {};

--- a/src/test/static/analysis/behaviors/analysis.json
+++ b/src/test/static/analysis/behaviors/analysis.json
@@ -234,164 +234,160 @@
       }
     }
   ],
-  "mixins": [
-    {
-      "attributes": [
+  "metadata": {
+    "polymer": {
+      "behaviors": [
         {
-          "description": "A property provided by SimpleBehavior.",
-          "metadata": {},
-          "name": "inherit-please",
-          "sourceRange": {
-            "end": {
-              "column": 7,
-              "line": 15
-            },
-            "start": {
-              "column": 6,
-              "line": 11
+          "attributes": [
+            {
+              "description": "A property provided by SimpleBehavior.",
+              "metadata": {},
+              "name": "inherit-please",
+              "sourceRange": {
+                "end": {
+                  "column": 7,
+                  "line": 15
+                },
+                "start": {
+                  "column": 6,
+                  "line": 11
+                }
+              },
+              "type": "number"
             }
-          },
-          "type": "number"
-        }
-      ],
-      "demos": [],
-      "description": "A simple behavior description.",
-      "events": [
-        {
-          "description": "Fired when the `inheritPlease` property changes.",
-          "metadata": {},
-          "name": "inherit-please-changed",
-          "type": "CustomEvent"
-        }
-      ],
-      "metadata": {
-        "polymer": {
-          "isBehavior": true
-        }
-      },
-      "methods": [],
-      "name": "MyNamespace.SimpleBehavior",
-      "path": "behavior.html",
-      "privacy": "public",
-      "properties": [
-        {
-          "defaultValue": "10",
-          "description": "A property provided by SimpleBehavior.",
-          "metadata": {
-            "polymer": {
-              "notify": true
+          ],
+          "demos": [],
+          "description": "A simple behavior description.",
+          "events": [
+            {
+              "description": "Fired when the `inheritPlease` property changes.",
+              "metadata": {},
+              "name": "inherit-please-changed",
+              "type": "CustomEvent"
             }
-          },
-          "name": "inheritPlease",
+          ],
+          "metadata": {},
+          "methods": [],
+          "name": "MyNamespace.SimpleBehavior",
+          "path": "behavior.html",
           "privacy": "public",
+          "properties": [
+            {
+              "defaultValue": "10",
+              "description": "A property provided by SimpleBehavior.",
+              "metadata": {
+                "polymer": {
+                  "notify": true
+                }
+              },
+              "name": "inheritPlease",
+              "privacy": "public",
+              "sourceRange": {
+                "end": {
+                  "column": 7,
+                  "line": 15
+                },
+                "start": {
+                  "column": 6,
+                  "line": 11
+                }
+              },
+              "type": "number"
+            }
+          ],
+          "slots": [],
           "sourceRange": {
             "end": {
-              "column": 7,
-              "line": 15
+              "column": 4,
+              "line": 17
             },
             "start": {
-              "column": 6,
-              "line": 11
+              "column": 2,
+              "line": 7
             }
           },
-          "type": "number"
-        }
-      ],
-      "slots": [],
-      "sourceRange": {
-        "end": {
-          "column": 4,
-          "line": 17
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "summary": ""
         },
-        "start": {
-          "column": 2,
-          "line": 7
-        }
-      },
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "summary": ""
-    },
-    {
-      "attributes": [
         {
-          "description": "This is a deeply inherited property.",
-          "metadata": {},
-          "name": "deeply-inherited-property",
-          "sourceRange": {
-            "end": {
-              "column": 7,
-              "line": 14
-            },
-            "start": {
-              "column": 6,
-              "line": 8
+          "attributes": [
+            {
+              "description": "This is a deeply inherited property.",
+              "metadata": {},
+              "name": "deeply-inherited-property",
+              "sourceRange": {
+                "end": {
+                  "column": 7,
+                  "line": 14
+                },
+                "start": {
+                  "column": 6,
+                  "line": 8
+                }
+              },
+              "type": "Array"
             }
-          },
-          "type": "Array"
-        }
-      ],
-      "demos": [],
-      "description": "A simple sub-behavior description.",
-      "events": [
-        {
-          "description": "Fired when the `deeplyInheritedProperty` property changes.",
-          "metadata": {},
-          "name": "deeply-inherited-property-changed",
-          "type": "CustomEvent"
-        }
-      ],
-      "metadata": {
-        "polymer": {
-          "isBehavior": true
-        }
-      },
-      "methods": [],
-      "name": "MyNamespace.SubBehavior",
-      "path": "subdir/subbehavior.html",
-      "privacy": "public",
-      "properties": [
-        {
-          "defaultValue": "[]",
-          "description": "This is a deeply inherited property.",
-          "metadata": {
-            "polymer": {
-              "notify": true
+          ],
+          "demos": [],
+          "description": "A simple sub-behavior description.",
+          "events": [
+            {
+              "description": "Fired when the `deeplyInheritedProperty` property changes.",
+              "metadata": {},
+              "name": "deeply-inherited-property-changed",
+              "type": "CustomEvent"
             }
-          },
-          "name": "deeplyInheritedProperty",
+          ],
+          "metadata": {},
+          "methods": [],
+          "name": "MyNamespace.SubBehavior",
+          "path": "subdir/subbehavior.html",
           "privacy": "public",
+          "properties": [
+            {
+              "defaultValue": "[]",
+              "description": "This is a deeply inherited property.",
+              "metadata": {
+                "polymer": {
+                  "notify": true
+                }
+              },
+              "name": "deeplyInheritedProperty",
+              "privacy": "public",
+              "sourceRange": {
+                "end": {
+                  "column": 7,
+                  "line": 14
+                },
+                "start": {
+                  "column": 6,
+                  "line": 8
+                }
+              },
+              "type": "Array"
+            }
+          ],
+          "slots": [],
           "sourceRange": {
             "end": {
-              "column": 7,
-              "line": 14
+              "column": 3,
+              "line": 16
             },
             "start": {
-              "column": 6,
-              "line": 8
+              "column": 2,
+              "line": 5
             }
           },
-          "type": "Array"
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "summary": ""
         }
-      ],
-      "slots": [],
-      "sourceRange": {
-        "end": {
-          "column": 3,
-          "line": 16
-        },
-        "start": {
-          "column": 2,
-          "line": 5
-        }
-      },
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "summary": ""
+      ]
     }
-  ]
+  }
 }


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Prior PR (merged) had PolymerBehaviors serialized as ElementMixins and put into Analysis.mixins.
 - That was iffy, so we decided to move them into Analysis.metadata.polymer.behaviors which feels better.
 - Required addition of Analysis.metadata?: any in the analysis-format.
 - Still serializing them as ElementMixin.  That's open to negotiation, but I had no opinion due to lack of deep familiarity with Behaviors.
