### PR TITLE
Make Polymer Analyzer (and tests!) work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-## Unreleased
+<!--## Unreleased-->
+
+## [2.0.0-alpha.34] - 2017-03-20
 
 * All Documents, ParsedDocuments, and ScannedDocuments now have correct SourceRanges. This also fixes a bug whereby `getByKind('document')` would fail to filter out package-external Documents.
 * Fix an issue where package-external features could be included in queries that dot not ask for them. Specifically we were filtering based on the text in files  like `../paper-button/paper-button.html` rather than the path to the file on disk like `bower_components/paper-button/paper-button.html` when determining externality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * `generateAnalysis()` now includes PolymerBehavior information in its `mixins` collection.  Identified by `metadata.polymer.isBehavior`.
+* Running AppVeyor now for continuous-integration for Windows platform support.
 
 ## [2.0.0-alpha.34] - 2017-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * `generateAnalysis()` now includes PolymerBehavior information in its `mixins` collection.  Identified by `metadata.polymer.isBehavior`.
 * Running AppVeyor now for continuous-integration for Windows platform support.
+* Analyzer now supports Windows-based development.
 
 ## [2.0.0-alpha.34] - 2017-03-20
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against this version of Node.js
+environment:
+  nodejs_version: "4.8.0"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "6.10.0"
+  nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "6.10.2"
+  nodejs_version: "6.10.0"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ test_script:
   - npm --version
   # run tests
   - npm run test
+  - npm run benchmark
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "4.8.0"
+  nodejs_version: "6.10.2"
 
 # Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js or io.js
+  # install node
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm install
@@ -15,7 +15,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm run test
+  - npm test
   - npm run benchmark
 
 # Don't actually build.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,62 +32,62 @@ const typescript_lib = require('typescript');
 function task(name, deps, impl) {
   if (gulp.hasTask(name)) {
     throw new Error(
-      `A task with the name ${JSON.stringify(name)} already exists!`);
+        `A task with the name ${JSON.stringify(name)} already exists!`);
   }
   gulp.task(name, deps, impl);
 }
 
 task('init');
 
-task('depcheck', function () {
+task('depcheck', function() {
   return new Promise((resolve, reject) => {
-    depcheck_lib(
-      __dirname,
-      { ignoreDirs: [], ignoreMatches: ['@types/*'] },
-      resolve);
-  })
-    .then((result) => {
-      const invalidFiles = Object.keys(result.invalidFiles) || [];
-      const invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
+           depcheck_lib(
+               __dirname,
+               {ignoreDirs: [], ignoreMatches: ['@types/*']},
+               resolve);
+         })
+      .then((result) => {
+        const invalidFiles = Object.keys(result.invalidFiles) || [];
+        const invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
 
-      const unused = new Set(result.dependencies);
-      if (unused.size > 0) {
-        console.log('Unused dependencies:', unused);
-        throw new Error('Unused dependencies');
-      }
-    });
+        const unused = new Set(result.dependencies);
+        if (unused.size > 0) {
+          console.log('Unused dependencies:', unused);
+          throw new Error('Unused dependencies');
+        }
+      });
 });
 
 task('lint', ['tslint', 'depcheck']);
 
-task('tslint', function () {
+task('tslint', function() {
   return gulp.src('src/**/*.ts')
-    .pipe(tslint_lib({
-      configuration: 'tslint.json',
-      formatter: 'verbose',
-    }))
-    .pipe(tslint_lib.report());
+      .pipe(tslint_lib({
+        configuration: 'tslint.json',
+        formatter: 'verbose',
+      }))
+      .pipe(tslint_lib.report());
 });
 
 const tsProject =
-  typescript.createProject('tsconfig.json', { typescript: typescript_lib });
+    typescript.createProject('tsconfig.json', {typescript: typescript_lib});
 
 task('build', ['compile', 'json-schema']);
 
-task('compile', function () {
+task('compile', function() {
   const srcs =
-    gulp.src('src/**/*.ts');  //.pipe(newer({dest: 'lib', ext: '.js'}));
+      gulp.src('src/**/*.ts');  //.pipe(newer({dest: 'lib', ext: '.js'}));
   const tsResult =
-    srcs.pipe(sourcemaps.init())
-      .pipe(typescript(tsProject, [], typescript.reporter.fullReporter()));
+      srcs.pipe(sourcemaps.init())
+          .pipe(typescript(tsProject, [], typescript.reporter.fullReporter()));
 
   // Use this once typescript-gulp supports `include` in tsconfig:
   // const srcs = tsProject.src();
   return mergeStream(
-    tsResult.js.pipe(sourcemaps.write('../lib')),
-    tsResult.dts,
-    gulp.src(['src/**/*', '!src/**/*.ts']))
-    .pipe(gulp.dest('lib'));
+             tsResult.js.pipe(sourcemaps.write('../lib')),
+             tsResult.dts,
+             gulp.src(['src/**/*', '!src/**/*.ts']))
+      .pipe(gulp.dest('lib'));
 });
 
 task('clean', () => {
@@ -101,13 +101,13 @@ task('build-all', (done) => {
 });
 
 task('test', ['build'], () => {
-  return gulp.src('test/**/*_test.js', { read: false }).pipe(mocha({
+  return gulp.src('test/**/*_test.js', {read: false}).pipe(mocha({
     ui: 'tdd',
     reporter: 'spec',
   }));
 });
 
-task('json-schema', function () {
+task('json-schema', function() {
   const inPath = 'src/analysis-format.ts';
   const outPath = 'lib/analysis.schema.json';
   return gulp.src(inPath).pipe(newer(outPath)).pipe(shell([

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,62 +32,62 @@ const typescript_lib = require('typescript');
 function task(name, deps, impl) {
   if (gulp.hasTask(name)) {
     throw new Error(
-        `A task with the name ${JSON.stringify(name)} already exists!`);
+      `A task with the name ${JSON.stringify(name)} already exists!`);
   }
   gulp.task(name, deps, impl);
 }
 
 task('init');
 
-task('depcheck', function() {
+task('depcheck', function () {
   return new Promise((resolve, reject) => {
-           depcheck_lib(
-               __dirname,
-               {ignoreDirs: [], ignoreMatches: ['@types/*']},
-               resolve);
-         })
-      .then((result) => {
-        const invalidFiles = Object.keys(result.invalidFiles) || [];
-        const invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
+    depcheck_lib(
+      __dirname,
+      { ignoreDirs: [], ignoreMatches: ['@types/*'] },
+      resolve);
+  })
+    .then((result) => {
+      const invalidFiles = Object.keys(result.invalidFiles) || [];
+      const invalidJsFiles = invalidFiles.filter((f) => f.endsWith('.js'));
 
-        const unused = new Set(result.dependencies);
-        if (unused.size > 0) {
-          console.log('Unused dependencies:', unused);
-          throw new Error('Unused dependencies');
-        }
-      });
+      const unused = new Set(result.dependencies);
+      if (unused.size > 0) {
+        console.log('Unused dependencies:', unused);
+        throw new Error('Unused dependencies');
+      }
+    });
 });
 
 task('lint', ['tslint', 'depcheck']);
 
-task('tslint', function() {
+task('tslint', function () {
   return gulp.src('src/**/*.ts')
-      .pipe(tslint_lib({
-        configuration: 'tslint.json',
-        formatter: 'verbose',
-      }))
-      .pipe(tslint_lib.report());
+    .pipe(tslint_lib({
+      configuration: 'tslint.json',
+      formatter: 'verbose',
+    }))
+    .pipe(tslint_lib.report());
 });
 
 const tsProject =
-    typescript.createProject('tsconfig.json', {typescript: typescript_lib});
+  typescript.createProject('tsconfig.json', { typescript: typescript_lib });
 
 task('build', ['compile', 'json-schema']);
 
-task('compile', function() {
+task('compile', function () {
   const srcs =
-      gulp.src('src/**/*.ts');  //.pipe(newer({dest: 'lib', ext: '.js'}));
+    gulp.src('src/**/*.ts');  //.pipe(newer({dest: 'lib', ext: '.js'}));
   const tsResult =
-      srcs.pipe(sourcemaps.init())
-          .pipe(typescript(tsProject, [], typescript.reporter.fullReporter()));
+    srcs.pipe(sourcemaps.init())
+      .pipe(typescript(tsProject, [], typescript.reporter.fullReporter()));
 
   // Use this once typescript-gulp supports `include` in tsconfig:
   // const srcs = tsProject.src();
   return mergeStream(
-             tsResult.js.pipe(sourcemaps.write('../lib')),
-             tsResult.dts,
-             gulp.src(['src/**/*', '!src/**/*.ts']))
-      .pipe(gulp.dest('lib'));
+    tsResult.js.pipe(sourcemaps.write('../lib')),
+    tsResult.dts,
+    gulp.src(['src/**/*', '!src/**/*.ts']))
+    .pipe(gulp.dest('lib'));
 });
 
 task('clean', () => {
@@ -101,18 +101,18 @@ task('build-all', (done) => {
 });
 
 task('test', ['build'], () => {
-  return gulp.src('test/**/*_test.js', {read: false}).pipe(mocha({
+  return gulp.src('test/**/*_test.js', { read: false }).pipe(mocha({
     ui: 'tdd',
     reporter: 'spec',
   }));
 });
 
-task('json-schema', function() {
+task('json-schema', function () {
   const inPath = 'src/analysis-format.ts';
   const outPath = 'lib/analysis.schema.json';
   return gulp.src(inPath).pipe(newer(outPath)).pipe(shell([
-    `./node_modules/.bin/typescript-json-schema --required ${inPath
-    } Analysis > ${outPath}.temp`,
+    `sh -c "./node_modules/.bin/typescript-json-schema --required ${inPath
+    } Analysis > ${outPath}.temp"`,
     `mv ${outPath}.temp ${outPath}`
   ]));
 });

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "cssbeautify": "^0.3.1",
     "doctrine": "^2.0.0",
     "dom5": "^2.1.0",
-    "eol": "^0.8.1",
     "escodegen": "^1.7.0",
     "espree": "^3.1.7",
     "estraverse": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "lint": "gulp lint",
     "test": "npm run clean && npm run build && npm run lint && mocha",
     "quicktest": "export QUICK_TESTS=true; npm run build && mocha",
-    "initBench": "if [ ! -d bower_components ]; then bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi",
-    "benchmark": "npm run build && npm run initBench && node --expose-gc lib/perf/parse-all-benchmark.js",
+    "initBench": "sh -c \"if [ -d bower_components ]; then echo; else bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi\"",
+    "benchmark": "sh -c \"npm run build && npm run initBench && node --expose-gc lib/perf/parse-all-benchmark.js\"",
     "test:watch": "watchy -w src/ -- npm run quicktest --loglevel=silent",
     "format": "sh -c \"find src | grep '\\.ts$' | xargs clang-format --style=file -i\"",
     "prepublishOnly": "tsc && npm test"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bin/"
   ],
   "scripts": {
-    "clean": "sh -c \"mkdir -p lib/ && rm -R lib/\"",
+    "clean": "sh -c \"mkdir -p lib/ && rm -rf lib/\"",
     "build": "gulp build",
     "release": "npm run compile",
     "lint": "gulp lint",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "cssbeautify": "^0.3.1",
     "doctrine": "^2.0.0",
     "dom5": "^2.1.0",
+    "eol": "^0.8.1",
     "escodegen": "^1.7.0",
     "espree": "^3.1.7",
     "estraverse": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bin/"
   ],
   "scripts": {
-    "clean": "mkdir -p lib/ && rm -rf lib/",
+    "clean": "mkdir -p lib/ && rm -R lib/",
     "build": "gulp build",
     "release": "npm run compile",
     "lint": "gulp lint",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "initBench": "if [ ! -d bower_components ]; then bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi",
     "benchmark": "npm run build && npm run initBench && node --expose-gc lib/perf/parse-all-benchmark.js",
     "test:watch": "watchy -w src/ -- npm run quicktest --loglevel=silent",
-    "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
+    "format": "sh -c \"find src | grep '\\.ts$' | xargs clang-format --style=file -i\"",
     "prepublishOnly": "tsc && npm test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-analyzer",
-  "version": "2.0.0-alpha.33",
+  "version": "2.0.0-alpha.34",
   "description": "Static analysis for Web Components",
   "homepage": "https://github.com/Polymer/polymer-analyzer",
   "bugs": "https://github.com/Polymer/polymer-analyzer/issues",

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -16,6 +16,7 @@ import * as shady from 'shady-css-parser';
 
 import {SourceRange} from '../model/model';
 import {Options, ParsedDocument, StringifyOptions} from '../parser/document';
+import {EOL} from '../utils';
 
 import cssbeautify = require('cssbeautify');
 
@@ -97,8 +98,8 @@ export class ParsedCssDocument extends ParsedDocument<shady.Node, Visitor> {
 
     const indent = '  '.repeat(options.indent || 0);
 
-    return beautifulResults.split('\n')
-               .map((line) => line === '' ? '' : indent + line)
+    return beautifulResults.split(EOL)
+               .map((line: string) => line === '' ? '' : indent + line)
                .join('\n') +
         '\n';
   }

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -126,7 +126,7 @@ function buildAnalysis(members: Members, packagePath: string): Analysis {
   }
 
   for (const behavior of members.polymerBehaviors) {
-    const namespaceName = getNamespaceName(behavior.name);
+    const namespaceName = getNamespaceName(behavior.className);
     const namespace = namespaces.get(namespaceName) || analysis;
     namespace.mixins = namespace.mixins || [];
     namespace.mixins.push(

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -21,8 +21,9 @@ import {Function as ResolvedFunction} from './javascript/function';
 import {Namespace as ResolvedNamespace} from './javascript/namespace';
 import {Document} from './model/document';
 import {Feature} from './model/feature';
-import {Attribute as ResolvedAttribute, Element as ResolvedElement, ElementMixin as ResolvedMixin, Event as ResolvedEvent, Method as ResolvedMethod, PolymerBehavior as ResolvedPolymerBehavior, Property as ResolvedProperty, SourceRange as ResolvedSourceRange} from './model/model';
+import {Attribute as ResolvedAttribute, Element as ResolvedElement, ElementMixin as ResolvedMixin, Event as ResolvedEvent, Method as ResolvedMethod, Property as ResolvedProperty, SourceRange as ResolvedSourceRange} from './model/model';
 import {Package} from './model/package';
+import {Behavior as ResolvedPolymerBehavior} from './polymer/behavior';
 
 export type ElementOrMixin = ResolvedElement | ResolvedMixin;
 

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -24,6 +24,7 @@ import {Feature} from './model/feature';
 import {Attribute as ResolvedAttribute, Element as ResolvedElement, ElementMixin as ResolvedMixin, Event as ResolvedEvent, Method as ResolvedMethod, Property as ResolvedProperty, SourceRange as ResolvedSourceRange} from './model/model';
 import {Package} from './model/package';
 import {Behavior as ResolvedPolymerBehavior} from './polymer/behavior';
+import {posixify} from './utils';
 
 export type ElementOrMixin = ResolvedElement | ResolvedMixin;
 
@@ -83,7 +84,7 @@ export function generateAnalysis(
     };
   }
 
-  return buildAnalysis(members, packagePath);
+  return buildAnalysis(members, posixify(packagePath));
 }
 
 function buildAnalysis(members: Members, packagePath: string): Analysis {
@@ -190,7 +191,7 @@ export function validateAnalysis(analyzedPackage: Analysis|null|undefined) {
 function serializeNamespace(
     namespace: ResolvedNamespace, packagePath: string): Namespace {
   const packageRelativePath =
-      pathLib.relative(packagePath, namespace.sourceRange.file);
+      pathLib.posix.relative(packagePath, posixify(namespace.sourceRange.file));
   const metadata = {
     name: namespace.name,
     description: namespace.description,
@@ -207,7 +208,7 @@ function serializeNamespace(
 function serializeFunction(
     fn: ResolvedFunction, packagePath: string): Function {
   const packageRelativePath =
-      pathLib.relative(packagePath, fn.sourceRange.file);
+      pathLib.posix.relative(packagePath, posixify(fn.sourceRange.file));
   const metadata: Function = {
     name: fn.name,
     description: fn.description,
@@ -270,8 +271,8 @@ function serializePolymerBehaviorAsElementMixin(
 function serializeElementLike(
     elementOrMixin: ElementOrMixin, packagePath: string): ElementLike {
   const path = elementOrMixin.sourceRange.file;
-  const packageRelativePath =
-      pathLib.relative(packagePath, elementOrMixin.sourceRange.file);
+  const packageRelativePath = pathLib.posix.relative(
+      packagePath, posixify(elementOrMixin.sourceRange.file));
 
   const attributes = elementOrMixin.attributes.map(
       (a) => serializeAttribute(elementOrMixin, path, a));
@@ -400,7 +401,7 @@ function resolveSourceRangePath(
   }
   // The source location's path is relative to file resolver's base, so first
   // we need to make it relative to the element.
-  const filePath =
-      pathLib.relative(pathLib.dirname(elementPath), sourceRange.file);
+  const filePath = pathLib.posix.relative(
+      posixify(pathLib.dirname(elementPath)), posixify(sourceRange.file));
   return {file: filePath, start: sourceRange.start, end: sourceRange.end};
 }

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -128,7 +128,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
       return undefined;
     }
     const whitespaceAfterEquals =
-        fullAttribute.substring(equalsIndex + 1).match(/[\s\n]*/)![0]!;
+        fullAttribute.substring(equalsIndex + 1).match(/\s*/m)![0]!;
     let endOfTextToSkip =
         // the beginning of the attribute key value pair
         location.startOffset +

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -17,6 +17,7 @@ import * as estree from 'estree';
 
 import {correctSourceRange, InlineDocInfo, LocationOffset, Severity, Warning, WarningCarryingException} from '../model/model';
 import {Parser} from '../parser/parser';
+import {EOL} from '../utils';
 
 import {JavaScriptDocument} from './javascript-document';
 
@@ -98,7 +99,7 @@ export function parseJs(
         return {
           type: 'failure',
           warning: {
-            message: err.message.split('\n')[0],
+            message: err.message.split(EOL)[0],
             severity: Severity.ERROR,
             code: warningCode,
             sourceRange: correctSourceRange(

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -18,6 +18,7 @@ import * as estree from 'estree';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {Privacy} from '../model/model';
 import {ScannedReference, Severity, Warning} from '../model/model';
+import {EOL} from '../utils';
 
 /**
  * An annotated JSDoc block tag, all fields are optionally processed except for
@@ -199,7 +200,7 @@ export function getTag(
 export function unindent(text: string): string {
   if (!text)
     return text;
-  const lines = text.replace(/\t/g, '  ').split('\n');
+  const lines = text.replace(/\t/g, '  ').split(EOL);
   const indent = lines.reduce<number>(function(prev, line) {
     if (/^\s*$/.test(line))
       return prev;  // Completely ignore blank lines.

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -138,7 +138,7 @@ export function removeLeadingAsterisks(description: string): string {
   if ((typeof description) !== 'string')
     return description;
 
-  return description.split('\n')
+  return description.split(EOL)
       .map(function(line) {
         // remove leading '\s*' from each line
         const match = line.match(/^[\s]*\*\s?(.*)$/);

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -159,7 +159,8 @@ export function parseJsdoc(docs: string): Annotation {
   // description of multiline comments for readibility.
   // TODO(rictic): figure out if we can trim() here or not. Something something
   //     markdown?
-  const description = d.description && d.description.replace(/^\n+|\n+$/g, '');
+  const description =
+      d.description && d.description.replace(/^[\r\n]+|[\r\n]+$/g, '');
   return {description: description, tags: _tagsToHydroTags(d.tags)};
 }
 

--- a/src/model/package.ts
+++ b/src/model/package.ts
@@ -24,7 +24,8 @@ export type QueryOptions = object & BaseQueryOptions;
 // Note that we match directories named exactly `build`, but will match any
 // directory name prefixed by `bower_components` or `node_modules`, in order to
 // ignore `polymer install`'s variants, which look like bower_components-foo
-const MATCHES_EXTERNAL = /(^|\/)(bower_components|node_modules|build($|\/))/;
+const MATCHES_EXTERNAL =
+    /(^|\/|\\)(bower_components|node_modules|build($|\/|\\))/;
 
 /**
  * Represents a queryable interface over all documents in a package/project.

--- a/src/test/css/css-parser_test.ts
+++ b/src/test/css/css-parser_test.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 
 import {ParsedCssDocument} from '../../css/css-document';
 import {CssParser} from '../../css/css-parser';
-import {lfify} from '../../utils';
+import {normalizeNewlines} from '../../utils';
 
 suite('CssParser', () => {
 
@@ -41,7 +41,7 @@ suite('CssParser', () => {
 
     test('stringifies css', () => {
       const document = parser.parse(fileContents, '/static/stylesheet.css');
-      assert.deepEqual(document.stringify(), lfify(fileContents));
+      assert.deepEqual(document.stringify(), normalizeNewlines(fileContents));
     });
   });
 

--- a/src/test/editor-service/ast-from-source-position_test.ts
+++ b/src/test/editor-service/ast-from-source-position_test.ts
@@ -16,6 +16,7 @@ import {assert} from 'chai';
 import {getLocationInfoForPosition} from '../../editor-service/ast-from-source-position';
 import {HtmlParser} from '../../html/html-parser';
 import {SourcePosition} from '../../model/model';
+import {EOL} from '../../utils';
 
 suite('getLocationInfoForPosition', () => {
   const parser = new HtmlParser();
@@ -178,7 +179,7 @@ suite('getLocationInfoForPosition', () => {
 function getEveryPosition(source: string): SourcePosition[] {
   const results: SourcePosition[] = [];
   let lineNum = 0;
-  for (const line of source.split('\n')) {
+  for (const line of source.split(EOL)) {
     let columnNum = 0;
     for (const _ of line) {
       _.big;  // TODO(rictic): tsc complains about unused _

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -45,7 +45,8 @@ suite('generate-elements', () => {
           }
         } else if (typeof target === 'object') {
           for (const key in target) {
-            if (target.hasOwnProperty(key) && ['file', 'path'].includes(key)) {
+            if (target.hasOwnProperty(key) &&
+                ['file', 'path'].indexOf(key) > -1) {
               target[key] = target[key].replace(/\/|\\/g, path.sep);
             }
           }

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -21,6 +21,7 @@ import {generateAnalysis, validateAnalysis, ValidationError} from '../generate-a
 import {Document} from '../model/document';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {PackageUrlResolver} from '../url-loader/package-url-resolver';
+import {usePathSep} from '../utils';
 
 const onlyTests = new Set<string>([]);  // Should be empty when not debugging.
 
@@ -38,19 +39,19 @@ suite('generate-elements', () => {
       // Utility function to convert 'file' and 'path' values to use
       // the current platform separator when comparing golden file to
       // actual file.
-      function usePlatformSep(target: any): any {
+      function transformPathsDeep(target: any): any {
         if (Array.isArray(target)) {
           for (let i = 0; i < target.length; ++i) {
-            usePlatformSep(target[i]);
+            transformPathsDeep(target[i]);
           }
         } else if (typeof target === 'object') {
           for (const key in target) {
             if (target.hasOwnProperty(key)) {
               const value = target[key];
               if (['file', 'path'].indexOf(key) > -1) {
-                target[key] = value.replace(/\/|\\/g, path.sep);
+                target[key] = usePathSep(value);
               } else {
-                usePlatformSep(value);
+                transformPathsDeep(value);
               }
             }
           }
@@ -97,7 +98,7 @@ suite('generate-elements', () => {
 
             const goldenAnalysis =
                 JSON.parse(fs.readFileSync(pathToGolden, 'utf-8'));
-            usePlatformSep(goldenAnalysis);
+            transformPathsDeep(goldenAnalysis);
 
             try {
               assert.deepEqual(

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -36,28 +36,6 @@ suite('generate-elements', () => {
 
     suite('generates for Document array from fixtures', () => {
 
-      // Utility function to convert 'file' and 'path' values to use
-      // the current platform separator when comparing golden file to
-      // actual file.
-      function transformPathsDeep(target: any): any {
-        if (Array.isArray(target)) {
-          for (let i = 0; i < target.length; ++i) {
-            transformPathsDeep(target[i]);
-          }
-        } else if (typeof target === 'object') {
-          for (const key in target) {
-            if (target.hasOwnProperty(key)) {
-              const value = target[key];
-              if (['file', 'path'].indexOf(key) > -1) {
-                target[key] = normalizePathSeparators(value);
-              } else {
-                transformPathsDeep(value);
-              }
-            }
-          }
-        }
-      }
-
       const basedir = path.join(__dirname, 'static', 'analysis');
       const analysisFixtureDirs =
           fs.readdirSync(basedir)
@@ -98,7 +76,6 @@ suite('generate-elements', () => {
 
             const goldenAnalysis =
                 JSON.parse(fs.readFileSync(pathToGolden, 'utf-8'));
-            transformPathsDeep(goldenAnalysis);
 
             try {
               assert.deepEqual(

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -34,6 +34,24 @@ suite('generate-elements', () => {
   suite('generateAnalysisMetadata', () => {
 
     suite('generates for Document array from fixtures', () => {
+
+      // Utility function to convert 'file' and 'path' values to use
+      // the current platform separator when comparing golden file to
+      // actual file.
+      function usePlatformSep(target: any): any {
+        if (Array.isArray(target)) {
+          for (const i = 0; i < target.length; ++i) {
+            usePlatformSep(target[i]);
+          }
+        } else if (typeof target === 'object') {
+          for (const key in target) {
+            if (target.hasOwnProperty(key) && ['file', 'path'].includes(key)) {
+              target[key] = target[key].replace(/\/|\\/g, path.sep);
+            }
+          }
+        }
+      }
+
       const basedir = path.join(__dirname, 'static', 'analysis');
       const analysisFixtureDirs =
           fs.readdirSync(basedir)
@@ -72,12 +90,16 @@ suite('generate-elements', () => {
                 generateAnalysis(documents, renormedPackagePath);
             validateAnalysis(analyzedPackages);
 
+            const goldenAnalysis =
+                JSON.parse(fs.readFileSync(pathToGolden, 'utf-8'));
+            usePlatformSep(goldenAnalysis);
+
             try {
               assert.deepEqual(
                   analyzedPackages,
-                  JSON.parse(fs.readFileSync(pathToGolden, 'utf-8')),
+                  goldenAnalysis,
                   `Generated form of ${
-                                       path.relative(__dirname, pathToGolden)
+              path.relative(__dirname, pathToGolden)
                                      } ` +
                       `differs from the golden at that path`);
             } catch (e) {

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -21,7 +21,7 @@ import {generateAnalysis, validateAnalysis, ValidationError} from '../generate-a
 import {Document} from '../model/document';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {PackageUrlResolver} from '../url-loader/package-url-resolver';
-import {usePathSep} from '../utils';
+import {normalizePathSeparators} from '../utils';
 
 const onlyTests = new Set<string>([]);  // Should be empty when not debugging.
 
@@ -49,7 +49,7 @@ suite('generate-elements', () => {
             if (target.hasOwnProperty(key)) {
               const value = target[key];
               if (['file', 'path'].indexOf(key) > -1) {
-                target[key] = usePathSep(value);
+                target[key] = normalizePathSeparators(value);
               } else {
                 transformPathsDeep(value);
               }

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -105,7 +105,7 @@ suite('generate-elements', () => {
                   analyzedPackages,
                   goldenAnalysis,
                   `Generated form of ${
-              path.relative(__dirname, pathToGolden)
+                                       path.relative(__dirname, pathToGolden)
                                      } ` +
                       `differs from the golden at that path`);
             } catch (e) {

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -40,14 +40,18 @@ suite('generate-elements', () => {
       // actual file.
       function usePlatformSep(target: any): any {
         if (Array.isArray(target)) {
-          for (const i = 0; i < target.length; ++i) {
+          for (let i = 0; i < target.length; ++i) {
             usePlatformSep(target[i]);
           }
         } else if (typeof target === 'object') {
           for (const key in target) {
-            if (target.hasOwnProperty(key) &&
-                ['file', 'path'].indexOf(key) > -1) {
-              target[key] = target[key].replace(/\/|\\/g, path.sep);
+            if (target.hasOwnProperty(key)) {
+              const value = target[key];
+              if (['file', 'path'].indexOf(key) > -1) {
+                target[key] = value.replace(/\/|\\/g, path.sep);
+              } else {
+                usePlatformSep(value);
+              }
             }
           }
         }

--- a/src/test/generate_analysis_test.ts
+++ b/src/test/generate_analysis_test.ts
@@ -21,7 +21,6 @@ import {generateAnalysis, validateAnalysis, ValidationError} from '../generate-a
 import {Document} from '../model/document';
 import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {PackageUrlResolver} from '../url-loader/package-url-resolver';
-import {normalizePathSeparators} from '../utils';
 
 const onlyTests = new Set<string>([]);  // Should be empty when not debugging.
 

--- a/src/test/html/html-parser_test.ts
+++ b/src/test/html/html-parser_test.ts
@@ -17,6 +17,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {HtmlParser} from '../../html/html-parser';
+import {lfify} from '../../utils';
 
 suite('HtmlParser', () => {
 
@@ -39,7 +40,7 @@ suite('HtmlParser', () => {
 
       test('can stringify back a well-formed document', () => {
         const document = parser.parse(file, '/static/html-parse-target.html');
-        assert.deepEqual(document.stringify(), file);
+        assert.deepEqual(document.stringify(), lfify(file));
       });
     });
 

--- a/src/test/html/html-parser_test.ts
+++ b/src/test/html/html-parser_test.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {HtmlParser} from '../../html/html-parser';
-import {lfify} from '../../utils';
+import {normalizeNewlines} from '../../utils';
 
 suite('HtmlParser', () => {
 
@@ -40,7 +40,7 @@ suite('HtmlParser', () => {
 
       test('can stringify back a well-formed document', () => {
         const document = parser.parse(file, '/static/html-parse-target.html');
-        assert.deepEqual(document.stringify(), lfify(file));
+        assert.deepEqual(document.stringify(), normalizeNewlines(file));
       });
     });
 

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -15,6 +15,7 @@
 import {assert} from 'chai';
 
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {usePathSep} from '../../utils';
 
 suite('FSUrlLoader', function() {
 
@@ -46,7 +47,8 @@ suite('FSUrlLoader', function() {
 
     test('resolves an in-package URL', () => {
       assert.equal(
-          new FSUrlLoader('root').getFilePath('foo.html'), 'root/foo.html');
+          new FSUrlLoader('root').getFilePath('foo.html'),
+          usePathSep('root/foo.html'));
     });
 
     test('throws for a sibling URL', () => {

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -15,7 +15,7 @@
 import {assert} from 'chai';
 
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {normalizePathSeparators} from '../../utils';
+import {convertToPlatformsPathSeparators} from '../../utils';
 
 suite('FSUrlLoader', function() {
 
@@ -48,7 +48,7 @@ suite('FSUrlLoader', function() {
     test('resolves an in-package URL', () => {
       assert.equal(
           new FSUrlLoader('root').getFilePath('foo.html'),
-          normalizePathSeparators('root/foo.html'));
+          convertToPlatformsPathSeparators('root/foo.html'));
     });
 
     test('throws for a sibling URL', () => {

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -15,7 +15,7 @@
 import {assert} from 'chai';
 
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {usePathSep} from '../../utils';
+import {normalizePathSeparators} from '../../utils';
 
 suite('FSUrlLoader', function() {
 
@@ -48,7 +48,7 @@ suite('FSUrlLoader', function() {
     test('resolves an in-package URL', () => {
       assert.equal(
           new FSUrlLoader('root').getFilePath('foo.html'),
-          usePathSep('root/foo.html'));
+          normalizePathSeparators('root/foo.html'));
     });
 
     test('throws for a sibling URL', () => {

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -16,7 +16,7 @@ import * as fs from 'fs';
 import * as pathlib from 'path';
 import {Url} from 'url';
 
-import {normalizePathSeparators, parseUrl} from '../utils';
+import {convertToPlatformsPathSeparators, parseUrl} from '../utils';
 
 import {UrlLoader} from './url-loader';
 
@@ -29,7 +29,7 @@ export class FSUrlLoader implements UrlLoader {
   root: string;
 
   constructor(root?: string) {
-    this.root = normalizePathSeparators(root || '');
+    this.root = convertToPlatformsPathSeparators(root || '');
   }
 
   canLoad(url: string): boolean {
@@ -65,21 +65,22 @@ export class FSUrlLoader implements UrlLoader {
       throw new Error(`Invalid URL ${url}`);
     }
     return this.root ?
-        pathlib.join(this.root, normalizePathSeparators(pathname)) :
-        normalizePathSeparators(pathname);
+        pathlib.join(this.root, convertToPlatformsPathSeparators(pathname)) :
+        convertToPlatformsPathSeparators(pathname);
   }
 
   async readDirectory(pathFromRoot: string, deep?: boolean): Promise<string[]> {
     const files = await new Promise<string[]>((resolve, reject) => {
       fs.readdir(
-          pathlib.join(this.root, normalizePathSeparators(pathFromRoot)),
+          pathlib.join(
+              this.root, convertToPlatformsPathSeparators(pathFromRoot)),
           (err, files) => err ? reject(err) : resolve(files));
     });
     const results = [];
     const subDirResultPromises = [];
     for (const basename of files) {
-      const file =
-          pathlib.join(normalizePathSeparators(pathFromRoot), basename);
+      const file = pathlib.join(
+          convertToPlatformsPathSeparators(pathFromRoot), basename);
       const stat = await new Promise<fs.Stats>(
           (resolve, reject) => fs.stat(
               pathlib.join(this.root, file),

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -59,12 +59,13 @@ export class FSUrlLoader implements UrlLoader {
 
   getFilePath(url: string): string {
     const urlObject = parseUrl(url);
-    const pathname = usePathSep(
-        pathlib.posix.normalize(decodeURIComponent(urlObject.pathname || '')));
+    const pathname =
+        pathlib.posix.normalize(decodeURIComponent(urlObject.pathname || ''));
     if (!this._isValid(urlObject, pathname)) {
       throw new Error(`Invalid URL ${url}`);
     }
-    return this.root ? pathlib.join(this.root, pathname) : pathname;
+    return this.root ? pathlib.join(this.root, usePathSep(pathname)) :
+                       usePathSep(pathname);
   }
 
   async readDirectory(pathFromRoot: string, deep?: boolean): Promise<string[]> {

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -29,7 +29,7 @@ export class FSUrlLoader implements UrlLoader {
   root: string;
 
   constructor(root?: string) {
-    this.root = usePathSep(root) || '';
+    this.root = usePathSep(root || '');
   }
 
   canLoad(url: string): boolean {

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -29,7 +29,7 @@ export class FSUrlLoader implements UrlLoader {
   root: string;
 
   constructor(root?: string) {
-    this.root = root || '';
+    this.root = usePathSep(root) || '';
   }
 
   canLoad(url: string): boolean {
@@ -59,8 +59,8 @@ export class FSUrlLoader implements UrlLoader {
 
   getFilePath(url: string): string {
     const urlObject = parseUrl(url);
-    const pathname =
-        pathlib.posix.normalize(decodeURIComponent(urlObject.pathname || ''));
+    const pathname = usePathSep(
+        pathlib.posix.normalize(decodeURIComponent(urlObject.pathname || '')));
     if (!this._isValid(urlObject, pathname)) {
       throw new Error(`Invalid URL ${url}`);
     }

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -16,7 +16,7 @@ import * as fs from 'fs';
 import * as pathlib from 'path';
 import {Url} from 'url';
 
-import {parseUrl, usePathSep} from '../utils';
+import {normalizePathSeparators, parseUrl} from '../utils';
 
 import {UrlLoader} from './url-loader';
 
@@ -29,7 +29,7 @@ export class FSUrlLoader implements UrlLoader {
   root: string;
 
   constructor(root?: string) {
-    this.root = usePathSep(root || '');
+    this.root = normalizePathSeparators(root || '');
   }
 
   canLoad(url: string): boolean {
@@ -64,20 +64,22 @@ export class FSUrlLoader implements UrlLoader {
     if (!this._isValid(urlObject, pathname)) {
       throw new Error(`Invalid URL ${url}`);
     }
-    return this.root ? pathlib.join(this.root, usePathSep(pathname)) :
-                       usePathSep(pathname);
+    return this.root ?
+        pathlib.join(this.root, normalizePathSeparators(pathname)) :
+        normalizePathSeparators(pathname);
   }
 
   async readDirectory(pathFromRoot: string, deep?: boolean): Promise<string[]> {
     const files = await new Promise<string[]>((resolve, reject) => {
       fs.readdir(
-          pathlib.join(this.root, usePathSep(pathFromRoot)),
+          pathlib.join(this.root, normalizePathSeparators(pathFromRoot)),
           (err, files) => err ? reject(err) : resolve(files));
     });
     const results = [];
     const subDirResultPromises = [];
     for (const basename of files) {
-      const file = pathlib.join(usePathSep(pathFromRoot), basename);
+      const file =
+          pathlib.join(normalizePathSeparators(pathFromRoot), basename);
       const stat = await new Promise<fs.Stats>(
           (resolve, reject) => fs.stat(
               pathlib.join(this.root, file),

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as eol from 'eol';
 import * as fs from 'fs';
 import * as pathlib from 'path';
 import {Url} from 'url';
@@ -51,7 +52,7 @@ export class FSUrlLoader implements UrlLoader {
         if (error) {
           reject(error);
         } else {
-          resolve(contents);
+          resolve(eol.lf(contents));
         }
       });
     });

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -12,12 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as eol from 'eol';
 import * as fs from 'fs';
 import * as pathlib from 'path';
 import {Url} from 'url';
 
-import {parseUrl} from '../utils';
+import {lfify, parseUrl} from '../utils';
 
 import {UrlLoader} from './url-loader';
 
@@ -52,7 +51,7 @@ export class FSUrlLoader implements UrlLoader {
         if (error) {
           reject(error);
         } else {
-          resolve(eol.lf(contents));
+          resolve(lfify(contents));
         }
       });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,10 @@ export function normalizeNewlines(text: string|string[]): string {
  * environment, so this function is a no-op there.
  *
  * @param pathname - file path to transform.
+ *
+ * TODO(usergenic): Unify the filesystem and url path manipulating code
+ * into a common package.  Bundler, Build and Analyzer (at least) all have
+ * their own flavors of these functions now.
  */
 export function convertToPlatformsPathSeparators(pathname: string): string {
   if (path.sep === '\\') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,15 @@ import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
 
+/**
+ * Regular expression used to split multi-line strings.  Supports the common
+ * line-termination sequences of CRLF (windows) and just LF (*nix/osx)
+ */
 export const EOL = /\r\n|\n/g;
+
+/**
+ * LF (line-feed) aka Newline.  Using a constant to highlight its use.
+ */
 export const LF = '\n';
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function posixify(pathname: string): string {
 }
 
 export function usePathSep(pathname: string): string {
-  return pathname.replace(/\\\//g, path.sep);
+  return pathname.replace(/\\|\//g, path.sep);
 }
 
 export function trimLeft(str: string, char: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export function normalizeNewlines(text: string|string[]): string {
  *
  * @param pathname - file path to transform.
  */
-export function normalizePathSeparators(pathname: string): string {
+export function convertToPlatformsPathSeparators(pathname: string): string {
   if (path.sep === '\\') {
     return pathname.replace(/\\|\//g, path.sep);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,14 +16,33 @@ import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
 
-export const EOL = /\r\n|\r|\n/g;
+export const EOL = /\r\n|\n/g;
 export const LF = '\n';
 
-export function lfify(text: string|string[]): string {
+/**
+ * Replace all line-terminator sequences with newline `\n`.
+ *
+ * @param text - String to convert.
+ */
+export function normalizeNewlines(text: string|string[]): string {
   if (Array.isArray(text)) {
-    return text.map(lfify).join(LF);
+    return text.map(normalizeNewlines).join(LF);
   }
   return text.replace(EOL, LF);
+}
+
+/**
+ * Ensure path separators used match the platform's separator.
+ * Backslash *is* a valid filename character in a posix
+ * environment, so this function is a no-op there.
+ *
+ * @param pathname - file path to transform.
+ */
+export function normalizePathSeparators(pathname: string): string {
+  if (path.sep === '\\') {
+    return pathname.replace(/\\|\//g, path.sep);
+  }
+  return pathname;
 }
 
 export function parseUrl(url: string): Url {
@@ -36,12 +55,19 @@ export function parseUrl(url: string): Url {
   return urlObject;
 }
 
+/**
+ * Ensure path separators of the posix forward-slash form when
+ * running on environment (Windows) where path separator is a
+ * backslash.  Backslash *is* a valid filename character in a
+ * posix environment, so this function is a no-op there.
+ *
+ * @param pathname - file path to transform.
+ */
 export function posixify(pathname: string): string {
-  return pathname.replace(/\\/g, '/');
-}
-
-export function usePathSep(pathname: string): string {
-  return pathname.replace(/\\|\//g, path.sep);
+  if (path.sep === '\\') {
+    return pathname.replace(/\\/g, '/');
+  }
+  return pathname;
 }
 
 export function trimLeft(str: string, char: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import * as path from 'path';
 import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
@@ -33,6 +34,14 @@ export function parseUrl(url: string): Url {
   urlObject.protocol = undefined;
   urlObject.href = urlObject.href!.replace(/^-:/, '');
   return urlObject;
+}
+
+export function posixify(pathname: string): string {
+  return pathname.replace(/\\/g, '/');
+}
+
+export function usePathSep(pathname: string): string {
+  return pathname.replace(/\\\//g, path.sep);
 }
 
 export function trimLeft(str: string, char: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,16 @@ import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
 
+export const EOL = /\r\n|\r|\n/g;
+export const LF = '\n';
+
+export function lfify(text: string|string[]): string {
+  if (Array.isArray(text)) {
+    return text.map(lfify).join(LF);
+  }
+  return text.replace(EOL, LF);
+}
+
 export function parseUrl(url: string): Url {
   if (!url.startsWith('//')) {
     return parseUrl_(url);

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -16,6 +16,7 @@ import * as chalk from 'chalk';
 
 import {Analyzer} from '../analyzer';
 import {Severity, SourceRange, Warning} from '../model/model';
+import {EOL} from '../utils';
 
 export type Verbosity = 'one-line' | 'full';
 
@@ -118,7 +119,7 @@ export class WarningPrinter {
   private async _getLinesOfText(
       startLine: number, endLine: number, localPath: string) {
     const contents = await this._options.analyzer.load(localPath);
-    return contents.split('\n').slice(startLine, endLine + 1);
+    return contents.split(EOL).slice(startLine, endLine + 1);
   }
 }
 


### PR DESCRIPTION
 - Lots of subtle issues with Analyzer prevented passing tests on Windows and highlighted actual Windows-related bugs.
 - Mostly these were EOL differences (CRLF vs LF), path separator issues and npm script issues.
 - I learned also that if you change npm script from `x` to `sh -c "x"` you can pretty much keep `x` what it was.
 - [x] CHANGELOG.md has been updated
