### PR TITLE
Added setting to .vscode to ensure newline at EOF on save.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "clang-format.style": "file",
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
+  "files.insertFinalNewline": true,
   "search.exclude": {
     "node_modules/": true,
     "lib/": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "clang-format.style": "file",
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
+  "editor.detectIndentation": false,
+  "editor.tabSize": 2,
   "files.insertFinalNewline": true,
   "search.exclude": {
     "node_modules/": true,


### PR DESCRIPTION
Per feedback from @rictic to ensure newlines at end of file, I thought I'd add this to settings.json for vscode.