### PR TITLE
Add support for lazy-imports of iron-lazy-pages

### DIFF
--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -48,7 +48,8 @@ export class HtmlScriptScanner implements HtmlScanner {
               importUrl,
               document.sourceRangeForNode(node)!,
               document.sourceRangeForAttributeValue(node, 'src')!,
-              node, false));
+              node,
+              false));
         } else {
           const locationOffset = getLocationOffsetOfStartOfTextContent(node);
           const attachedCommentText = getAttachedCommentText(node) || '';

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -50,7 +50,8 @@ export class ScannedScriptTagImport extends ScannedImport {
           this.sourceRange,
           this.urlSourceRange,
           this.astNode,
-          this.warnings, false);
+          this.warnings,
+          false);
     } else {
       // not found or syntax error
       const error = this.error ? (this.error.message || this.error) : '';

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -39,7 +39,8 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
             importUrl,
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.source)!,
-            node, false));
+            node,
+            false));
       }
     });
     return imports;

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -44,7 +44,8 @@ export class CssImportScanner implements HtmlScanner {
             importUrl,
             document.sourceRangeForNode(node)!,
             document.sourceRangeForAttributeValue(node, 'href')!,
-            node, false));
+            node,
+            false));
       }
     });
     return imports;

--- a/src/test/polymer/dom-module-scanner_test.ts
+++ b/src/test/polymer/dom-module-scanner_test.ts
@@ -86,6 +86,31 @@ suite('DomModuleScanner', () => {
               <other-elem prop="{{foo bar}}"></other-elem>
                                       ~`]);
     });
+
+    test('retrieves iron-lazy-pages imports', async() => {
+      const contents = `<html><head></head>
+        <body>
+          <dom-module>
+            <template>
+              <iron-lazy-pages attr-for-selected="data-route">
+                <div data-route="foo" data-path="foo.html"></div>
+                <section data-route="baz" data-path="bar/baz.html"></section>
+                <custom-element data-route="custom-element" data-path="my/custom/element.html"></custome-element>
+                <span data-route="404">404!</span>
+              </iron-lazy-pages>
+            </template>
+          </dom-module>
+        </body>
+        </html>`;
+
+      const document = new HtmlParser().parse(contents, 'test.html');
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
+
+      const domModules = await scanner.scan(document, visit);
+      assert.equal(domModules.length, 1);
+      assert.deepEqual(
+          domModules[0].imports.map((i) => i.url), ['foo.html', 'bar/baz.html', 'my/custom/element.html']);
+    });
   });
 
 });

--- a/src/test/static/analysis/dom-module/analysis.json
+++ b/src/test/static/analysis/dom-module/analysis.json
@@ -67,14 +67,43 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 12,
+          "line": 16,
           "column": 12
         },
         "end": {
-          "line": 14,
+          "line": 18,
           "column": 5
         }
       }
+    },
+    {
+      "attributes": [],
+      "demos": [],
+      "description": "",
+      "events": [],
+      "metadata": {},
+      "methods": [],
+      "path": "my-custom-element.html",
+      "privacy": "public",
+      "properties": [],
+      "slots": [],
+      "sourceRange": {
+        "end": {
+          "column": 5,
+          "line": 4
+        },
+        "start": {
+          "column": 12,
+          "line": 2
+        }
+      },
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "summary": "",
+      "superclass": "HTMLElement",
+      "tagname": "my-custom-element"
     }
   ]
 }

--- a/src/test/static/analysis/dom-module/documented.html
+++ b/src/test/static/analysis/dom-module/documented.html
@@ -7,6 +7,10 @@ This is a big comment on the element!
     <slot name="slot1"></slot>
     <slot name="slot2"></slot>
     <slot></slot>
+    <iron-lazy-pages attr-for-selected="data-route">
+      <custom-element data-route="custom-element" data-path="my-custom-element.html"></custome-element>
+      <span data-route="404">404!</span>
+    </iron-lazy-pages>
   </template>
 
   <script>

--- a/src/test/static/analysis/dom-module/my-custom-element.html
+++ b/src/test/static/analysis/dom-module/my-custom-element.html
@@ -1,0 +1,7 @@
+<dom-module id="my-custom-element">
+  <script>
+    Polymer({
+      is: 'my-custom-element',
+    });
+  </script>
+</dom-module>

--- a/src/typescript/typescript-import-scanner.ts
+++ b/src/typescript/typescript-import-scanner.ts
@@ -40,7 +40,8 @@ export class TypeScriptImportScanner implements
             // TODO(justinfagnani): make SourceRanges work
             null as any as SourceRange,
             null as any as SourceRange,
-            node, false));
+            node,
+            false));
       }
     }
     const visitor = new ImportVisitor();


### PR DESCRIPTION
@rictic So I was really excited about this PR and did not want to wait till my weekend 😂 

This pull request introduces lazy-import support for the analyzer. It takes the `iron-lazy-pages` definition and can determine what the lazy imports are (without extra `rel="lazy-import"` tags).

I have added 2 tests to verify the correct behavior. One is a unit test which just uses `DomModuleScanner`. The second one is an integration test, which I think works correct now. I have yet to try this out on a real application, but the edges/loading behavior of the analyzer is still vague for me.

Please let me know what you think!

 - [ ] CHANGELOG.md has been updated
