### PR TITLE
Handle tab prefix in Warning Printer getSquiggleUnderline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!--## Unreleased-->
+## Unreleased
+
+* The warning printer displays the squiggle underline in the correct place on lines indented by tabs.
 
 ## [2.0.0-alpha.35] - 2017-04-05
 

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -137,7 +137,7 @@ function getSquiggleUnderline(
     const endColumn = sourceRange.end.line === sourceRange.start.line ?
         sourceRange.end.column :
         lineText.length;
-    const prefix = ' '.repeat(startColumn);
+    const prefix = lineText.slice(0, startColumn).replace(/[^\t]/g, ' ');
     if (startColumn === endColumn) {
       return prefix + '~';  // always draw at least one squiggle
     }


### PR DESCRIPTION
This change deals with output of warnings for lines that are indented by tabs.  Previously tabs were counted as a single character causing the squiggle underline to be indented by a single space.  Now the prefix uses tabs to prefix the squiggle where tabs were used on the source line.

 - [x] CHANGELOG.md has been updated
