### PR TITLE
Refactor Polymer 2.0 element scanner into phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added an `InMemoryOverlayLoader` UrlLoader, for cases like a text editor where you'd like to use an in memory source of truth for a subset of files.
 * The warning printer displays the squiggle underline in the correct place on lines indented by tabs.
 * Extract className from the form `var className = Polymer({...})`
+* Do a better job of matching comments up with Polymer 2 style element declarations.
 
 ## [2.0.0-alpha.35] - 2017-04-05
 

--- a/src/perf/parse-all-benchmark.ts
+++ b/src/perf/parse-all-benchmark.ts
@@ -44,6 +44,11 @@ for (const baseDir of fs.readdirSync(bowerDir)) {
   }
 }
 
+const fakeFileContents =
+    filesToAnalyze.map((fn) => `<link rel="import" href="${fn}">`).join('\n');
+
+inMemoryOverlay.urlContentsMap.set('ephemeral.html', fakeFileContents);
+
 
 function existsSync(fn: string): boolean {
   try {
@@ -54,10 +59,6 @@ function existsSync(fn: string): boolean {
   }
 }
 
-const fakeFileContents =
-    filesToAnalyze.map((fn) => `<link rel="import" href="${fn}">`).join('\n');
-
-inMemoryOverlay.urlContentsMap.set('ephemral.html', fakeFileContents);
 
 function padLeft(str: string, num: number): string {
   if (str.length < num) {

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -15,6 +15,7 @@
 import * as dom5 from 'dom5';
 import * as estree from 'estree';
 
+import * as jsdoc from '../javascript/jsdoc';
 import {Annotation as JsDocAnnotation} from '../javascript/jsdoc';
 import {Document, Element, ElementBase, LiteralValue, Method, Privacy, Property, ScannedAttribute, ScannedElement, ScannedElementBase, ScannedEvent, ScannedMethod, ScannedProperty, Severity, SourceRange, Warning} from '../model/model';
 import {ScannedReference} from '../model/reference';
@@ -167,6 +168,11 @@ export class ScannedPolymerElement extends ScannedElement implements
     }
     if (options && options.methods) {
       options.methods.forEach((m) => this.addMethod(m));
+    }
+    if (this.jsdoc) {
+      const summaryTag = jsdoc.getTag(this.jsdoc, 'summary');
+      this.summary =
+          this.summary || (summaryTag && summaryTag.description) || '';
     }
   }
 

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -170,9 +170,8 @@ export class ScannedPolymerElement extends ScannedElement implements
       options.methods.forEach((m) => this.addMethod(m));
     }
     if (this.jsdoc) {
-      const summaryTag = jsdoc.getTag(this.jsdoc, 'summary');
-      this.summary =
-          this.summary || (summaryTag && summaryTag.description) || '';
+      this.summary = this.summary ||
+          jsdoc.getTag(this.jsdoc, 'summary', 'description') || '';
     }
   }
 

--- a/src/polymer/polymer2-config.ts
+++ b/src/polymer/polymer2-config.ts
@@ -23,13 +23,12 @@ import * as docs from './docs';
 import {toScannedMethod} from './js-utils';
 import {ScannedPolymerProperty} from './polymer-element';
 
-function getStaticGetterValue(
+export function getStaticGetterValue(
     node: estree.ClassDeclaration|estree.ClassExpression,
     name: string): estree.Expression|undefined {
-  const candidates = node.body.body.filter(
+  const getter = node.body.body.find(
       (n) => n.type === 'MethodDefinition' && n.static === true &&
           n.kind === 'get' && getIdentifierName(n.key) === name);
-  const getter = candidates.length === 1 && candidates[0];
   if (!getter) {
     return undefined;
   }
@@ -40,13 +39,13 @@ function getStaticGetterValue(
     // not a single statement function
     return undefined;
   }
-  if (getterBody.body[0].type !== 'ReturnStatement') {
+  const statement = getterBody.body[0]!;
+  if (statement.type !== 'ReturnStatement') {
     // we only support a return statement
     return undefined;
   }
 
-  const returnStatement = getterBody.body[0] as estree.ReturnStatement;
-  return returnStatement.argument;
+  return statement.argument;
 }
 
 export function getIsValue(node: estree.ClassDeclaration|

--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -155,8 +155,8 @@ export class Polymer2ElementScanner implements JavaScriptScanner {
         methods: getMethods(node, document),
         superClass: this._getExtends(node, docs, warnings, document),
         mixins: jsdoc.getMixins(document, node, docs, warnings),
-        privacy: getOrInferPrivacy(className || '', docs, false),  //
-        observers,
+        privacy: getOrInferPrivacy(className || '', docs, false),
+        observers: observers,
         jsdoc: docs,
       });
 
@@ -209,7 +209,6 @@ export class Polymer2ElementScanner implements JavaScriptScanner {
         return body.argument;
       }
     }
-    return;
   }
 
   private _getObservers(

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -331,7 +331,7 @@ namespaced name.`,
     ]);
   });
 
-  test('Reads just mixin application', async() => {
+  test.skip('Reads just mixin application', async() => {
     const elements = await getElements('test-element-9.js');
     const elementData = await Promise.all(elements.map(getTestProps));
 

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -331,7 +331,7 @@ namespaced name.`,
     ]);
   });
 
-  test.skip('Reads just mixin application', async() => {
+  test('Reads just mixin application', async() => {
     const elements = await getElements('test-element-9.js');
     const elementData = await Promise.all(elements.map(getTestProps));
 

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -371,6 +371,18 @@ namespaced name.`,
         mixins: ['Mixin'],
         warningUnderlines: [],
       },
+      {
+        tagName: undefined,
+        className: 'window.MyElement',
+        superClass: 'MixedElement',
+        description: '',
+        summary: '',
+        properties: [],
+        attributes: [],
+        methods: [],
+        mixins: ['MyMixin'],
+        warningUnderlines: [],
+      }
     ]);
   });
 

--- a/src/test/static/polymer2/test-element-9.js
+++ b/src/test/static/polymer2/test-element-9.js
@@ -24,3 +24,7 @@ const SubElement = Mixin(BaseElement);
 const SubElement2 = class extends Mixin
 (BaseElement) {
 }
+
+/**
+ * @polymerElement
+ * @mixes MyMixin */ window.MyElement = class extends MixedElement { }


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

This PR subsumes https://github.com/Polymer/polymer-analyzer/pull/609 

It should otherwise be a noop change, though I'd expect it to fix some weird bugs. It's a stepping stone to #563 

Conceptually the idea is that in one pass we identify all classes and potential custom elements, and in a separate visitor we collect up all `customElements.define` calls. We then produce ScannedPolymerElements from these two lists using pretty much the same logic as before.