### PR TITLE
Added a canLoad method to Analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+* Added `canLoad` method to `Analyzer`.
 
 ## [2.0.0-alpha.36] - 2017-04-07
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -117,14 +117,18 @@ export class Analyzer {
   }
 
   /**
-   * Returns `true` if the provided resolved URL can be loaded.
+   * Returns `true` if the provided resolved URL can be loaded.  Obeys the
+   * semantics defined by `UrlLoader` and should only be used to check
+   * resolved URLs.
    */
   canLoad(resolvedUrl: string): boolean {
     return this._context.canLoad(resolvedUrl);
   }
 
   /**
-   * Loads the content at the provided resolved URL.
+   * Loads the content at the provided resolved URL.  Obeys the semantics
+   * defined by UrlLoader and should only be used to attempt to load resolved
+   * URLs.
    */
   async load(resolvedUrl: string): Promise<string> {
     return this._context.load(resolvedUrl);

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -127,7 +127,7 @@ export class Analyzer {
 
   /**
    * Loads the content at the provided resolved URL.  Obeys the semantics
-   * defined by UrlLoader and should only be used to attempt to load resolved
+   * defined by `UrlLoader` and should only be used to attempt to load resolved
    * URLs.
    */
   async load(resolvedUrl: string): Promise<string> {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -117,16 +117,29 @@ export class Analyzer {
   }
 
   /**
+   * Returns `true` if the provided resolved URL can be loaded.
+   */
+  canLoad(resolvedUrl: string): boolean {
+    return this._context.canLoad(resolvedUrl);
+  }
+
+  /**
    * Loads the content at the provided resolved URL.
    */
-  async load(resolvedUrl: string) {
+  async load(resolvedUrl: string): Promise<string> {
     return this._context.load(resolvedUrl);
   }
 
+  /**
+   * Returns `true` if the given `url` can be resolved.
+   */
   canResolveUrl(url: string): boolean {
     return this._context.canResolveUrl(url);
   }
 
+  /**
+   * Resoves `url` to a new location.
+   */
   resolveUrl(url: string): string {
     return this._context.resolveUrl(url);
   }

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -398,14 +398,18 @@ export class AnalysisContext {
   }
 
   /**
-   * Returns `true` if the provided resolved URL can be loaded.
+   * Returns `true` if the provided resolved URL can be loaded.  Obeys the
+   * semantics defined by `UrlLoader` and should only be used to check
+   * resolved URLs.
    */
   canLoad(resolvedUrl: string): boolean {
     return this._loader.canLoad(resolvedUrl);
   }
 
   /**
-   * Loads the content at the provided resolved URL.
+   * Loads the content at the provided resolved URL.  Obeys the semantics
+   * defined by `UrlLoader` and should only be used to attempt to load resolved
+   * URLs.
    *
    * Currently does no caching. If the provided contents are given then they
    * are used instead of hitting the UrlLoader (e.g. when you have in-memory

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -398,14 +398,21 @@ export class AnalysisContext {
   }
 
   /**
+   * Returns `true` if the provided resolved URL can be loaded.
+   */
+  canLoad(resolvedUrl: string): boolean {
+    return this._loader.canLoad(resolvedUrl);
+  }
+
+  /**
    * Loads the content at the provided resolved URL.
    *
    * Currently does no caching. If the provided contents are given then they
    * are used instead of hitting the UrlLoader (e.g. when you have in-memory
    * contents that should override disk).
    */
-  async load(resolvedUrl: string) {
-    if (!this._loader.canLoad(resolvedUrl)) {
+  async load(resolvedUrl: string): Promise<string> {
+    if (!this.canLoad(resolvedUrl)) {
       throw new Error(`Can't load URL: ${resolvedUrl}`);
     }
     return await this._loader.load(resolvedUrl);

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -53,6 +53,14 @@ suite('Analyzer', () => {
     underliner = new CodeUnderliner(inMemoryOverlay);
   });
 
+  test('canLoad delegates to the urlLoader canLoad method', () => {
+    assert.isTrue(analyzer.canLoad('/'), '/');
+    assert.isTrue(analyzer.canLoad('/path'), '/path');
+    assert.isFalse(analyzer.canLoad('../path'), '../path');
+    assert.isFalse(analyzer.canLoad('http://host/'), 'http://host/');
+    assert.isFalse(analyzer.canLoad('http://host/path'), 'http://host/path');
+  });
+
   test('canResolveUrl defaults to not resolving external urls', () => {
     assert.isTrue(analyzer.canResolveUrl('/path'), '/path');
     assert.isTrue(analyzer.canResolveUrl('../path'), '../path');


### PR DESCRIPTION
- [x] CHANGELOG.md has been updated
- `Analyzer` and `AnalysisContext` have public `canLoad` methods now.
- `AnalysisContext` uses its own `canLoad` method now.
- Opportunistically added missing comments and type annotations.
- Fixes https://github.com/Polymer/polymer-analyzer/issues/612
