### PR TITLE
Moved removeFakeNodes to the html-parser so nobody gets fake nodes in their resolved document ASTs.

### DIFF
--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -197,22 +197,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
       }) + '  '.repeat(expectedIndentation - 1));
     }
 
-    removeFakeNodes(selfClone.ast);
     return parse5.serialize(selfClone.ast);
-  }
-}
-
-const injectedTagNames = new Set(['html', 'head', 'body']);
-function removeFakeNodes(ast: dom5.Node) {
-  const children = (ast.childNodes || []).slice();
-  if (ast.parentNode && !ast.__location && injectedTagNames.has(ast.nodeName)) {
-    for (const child of children) {
-      dom5.insertBefore(ast.parentNode, ast, child);
-    }
-    dom5.remove(ast);
-  }
-  for (const child of children) {
-    removeFakeNodes(child);
   }
 }
 


### PR DESCRIPTION
As a users of the `ast` property of parsed html documents, I want a tree that represents what's *really* in the document, not what parse5 is pretending is there.  I moved the removeFakeNodes code to the parser and all the tests are passing.  WDYT?