### PR TITLE
Fix compile to work with better chai typings.

### DIFF
--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -380,7 +380,7 @@ class ClassFinder implements Visitor {
       return;
     }
 
-    const name = node.id && astValue.getIdentifierName(node.id);
+    const name = (node.id && astValue.getIdentifierName(node.id)) || undefined;
     const comment = esutil.getAttachedComment(node) ||
         esutil.getAttachedComment(parent) || '';
     this._classFound(name, jsdoc.parseJsdoc(comment), node);

--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -380,7 +380,7 @@ class ClassFinder implements Visitor {
       return;
     }
 
-    const name = (node.id && astValue.getIdentifierName(node.id)) || undefined;
+    const name = node.id ? astValue.getIdentifierName(node.id) : undefined;
     const comment = esutil.getAttachedComment(node) ||
         esutil.getAttachedComment(parent) || '';
     this._classFound(name, jsdoc.parseJsdoc(comment), node);

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -40,7 +40,8 @@ export class PseudoElementScanner implements HtmlScanner {
       if (dom5.isCommentNode(node) && node.data &&
           node.data.includes('@pseudoElement')) {
         const parsedJsdoc = jsdoc.parseJsdoc(node.data);
-        const pseudoTag = jsdoc.getTag(parsedJsdoc, 'pseudoElement', 'name');
+        const pseudoTag =
+            jsdoc.getTag(parsedJsdoc, 'pseudoElement', 'name') || undefined;
         if (pseudoTag) {
           const element = new ScannedPolymerElement({
             astNode: node,

--- a/src/test/core/analysis-cache_test.ts
+++ b/src/test/core/analysis-cache_test.ts
@@ -33,14 +33,16 @@ suite('AnalysisCache', () => {
 
   async function assertHasDocument(cache: AnalysisCache, path: string) {
     assert.equal(
-        await cache.parsedDocumentPromises.getOrCompute(path, null as any),
+        await cache.parsedDocumentPromises.getOrCompute(
+            path, null as any) as any,
         `parsed ${path} promise`);
     assert.equal(
-        await cache.scannedDocumentPromises.getOrCompute(path, null as any),
+        await cache.scannedDocumentPromises.getOrCompute(
+            path, null as any) as any,
         `scanned ${path} promise`);
     // caller must assert on cache.analyzedDocumentPromises themselves
-    assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
-    assert.equal(cache.analyzedDocuments.get(path), `analyzed ${path}`);
+    assert.equal(cache.scannedDocuments.get(path) as any, `scanned ${path}`);
+    assert.equal(cache.analyzedDocuments.get(path) as any, `analyzed ${path}`);
   }
 
   function assertNotHasDocument(cache: AnalysisCache, path: string) {
@@ -54,13 +56,15 @@ suite('AnalysisCache', () => {
   async function assertDocumentScannedButNotResolved(
       cache: AnalysisCache, path: string) {
     assert.equal(
-        await cache.parsedDocumentPromises.getOrCompute(path, null as any),
+        await cache.parsedDocumentPromises.getOrCompute(
+            path, null as any) as any,
         `parsed ${path} promise`);
 
     assert.equal(
-        await cache.scannedDocumentPromises.getOrCompute(path, null as any),
+        await cache.scannedDocumentPromises.getOrCompute(
+            path, null as any) as any,
         `scanned ${path} promise`);
-    assert.equal(cache.scannedDocuments.get(path), `scanned ${path}`);
+    assert.equal(cache.scannedDocuments.get(path) as any, `scanned ${path}`);
     assert.isFalse(cache.analyzedDocuments.has(path));
     assert.isFalse(cache.analyzedDocumentPromises.has(path));
   }
@@ -82,7 +86,7 @@ suite('AnalysisCache', () => {
     // a Promise.resolve() of its non-promise cache.
     assert.equal(
         await forkedCache.analyzedDocumentPromises.getOrCompute(
-            'unrelated.html', null as any),
+            'unrelated.html', null as any) as any,
         `analyzed unrelated.html`);
   });
 

--- a/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -70,7 +70,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
       'register-before-expression'
     ].sort());
     assert.deepEqual(elementsList.map((e) => e.className).sort(), [
-      null,
+      undefined,
       'ClassDeclaration',
       'ClassExpression',
       'WithObservedAttributes',

--- a/src/test/scanning/scan_test.ts
+++ b/src/test/scanning/scan_test.ts
@@ -23,7 +23,7 @@ import {invertPromise} from '../test-utils';
 suite('scan()', () => {
 
   test('calls Scanner.scan', async() => {
-    const feature = Symbol('feature');
+    const feature = Symbol('feature') as any;
     const scanner = new ScannerStub(<any>[feature]);
     const document = makeTestDocument({});
 
@@ -62,7 +62,7 @@ suite('scan()', () => {
     });
 
     const features = await scan(document, [scanner]);
-    assert.deepEqual([`a feature`], features);
+    assert.deepEqual([`a feature` as any], features);
     assert.deepEqual(visitedVisitors, [visitor1, visitor2, visitor3]);
   });
 


### PR DESCRIPTION
Chai equality typings now verify that the type on the left hand side matches the type on the right hand side. This caught a few places in tests that we were playing fast and loose, as well as one place where we had null where our types said undefined.

 - [x] CHANGELOG.md not updated, internal change
