### PR TITLE
Mark many fields readonly/immutable. Simplify Element class construction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Improved our modeling of inheritance:
   * overriding inherited members now works correctly
   * overriding a private member produces a Warning
+* Documented many fields as being readonly/immutable. This isn't complete, in fact all features and scanned features should be treated as immutable once they're created and initialized.
+* Treat behaviors more like mixins, and treat using behaviors more like inheriting from mixins. This means that a Behavior object knows about all of the properties, methods, etc that it has inherited from other Behaviors that it builds upon.
 
 ## [2.0.0-alpha.37] - 2017-04-12
 

--- a/src/analysis-format.ts
+++ b/src/analysis-format.ts
@@ -314,7 +314,7 @@ export interface Method extends Feature {
    * undocumented JavaScript function. Argument types can only be read from
    * associated JSDoc via @param tags
    */
-  params?: {name: string, type?: string, description?: string}[];
+  params?: Parameter[];
 
   /**
    * Data describing the method return type. This data may be incomplete.
@@ -327,6 +327,12 @@ export interface Method extends Feature {
 
   /** The identifier of the class or mixin that declared this property. */
   inheritedFrom?: string;
+}
+
+export interface Parameter {
+  name: string;
+  type?: string;
+  description?: string;
 }
 
 export interface Event extends Feature {

--- a/src/generate-analysis.ts
+++ b/src/generate-analysis.ts
@@ -16,7 +16,7 @@ import * as fs from 'fs';
 import * as jsonschema from 'jsonschema';
 import * as pathLib from 'path';
 
-import {Analysis, Attribute, Element, ElementLike, ElementMixin, Event, Function, Method, Namespace, Property, SourceRange} from './analysis-format';
+import {Analysis, Attribute, Element, ElementLike, ElementMixin, Event, Function, Method, Namespace, Parameter, Property, SourceRange} from './analysis-format';
 import {Function as ResolvedFunction} from './javascript/function';
 import {Namespace as ResolvedNamespace} from './javascript/namespace';
 import {Analysis as AnalysisResult} from './model/analysis';
@@ -271,9 +271,9 @@ function serializePolymerBehaviorAsElementMixin(
 
 function serializeElementLike(
     elementOrMixin: ElementOrMixin, packagePath: string): ElementLike {
-  const path = elementOrMixin.sourceRange.file;
+  const path = elementOrMixin.sourceRange!.file;
   const packageRelativePath =
-      pathLib.relative(packagePath, elementOrMixin.sourceRange.file);
+      pathLib.relative(packagePath, elementOrMixin.sourceRange!.file);
 
   const attributes = elementOrMixin.attributes.map(
       (a) => serializeAttribute(elementOrMixin, path, a));
@@ -361,7 +361,16 @@ function serializeMethod(
     metadata: resolvedElement.emitMethodMetadata(resolvedMethod),
   };
   if (resolvedMethod.params) {
-    method.params = resolvedMethod.params;
+    method.params = resolvedMethod.params.map(({name, description, type}) => {
+      const param: Parameter = {name: name};
+      if (description) {
+        param.description = description;
+      }
+      if (type) {
+        param.type = type;
+      }
+      return param;
+    });
   }
   if (resolvedMethod.return ) {
     method.return = resolvedMethod.return;

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -98,9 +98,14 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
     }
     // The attribute name can't have any spaces, newlines, or other funny
     // business in it, so this is pretty simple.
-    range.end.line = range.start.line;
-    range.end.column = range.start.column + attrName.length;
-    return range;
+    return {
+      file: range.file,
+      start: range.start,
+      end: {
+        line: range.start.line,
+        column: range.start.column + attrName.length
+      }
+    };
   }
 
   sourceRangeForAttributeValue(

--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -14,6 +14,7 @@
 
 import {Document} from './document';
 import {Feature} from './feature';
+import {ImmutableMap, ImmutableSet} from './immutable';
 import {AnalysisQuery as Query, AnalysisQueryWithKind as QueryWithKind, DocumentQuery, FeatureKind, FeatureKindMap, Queryable} from './queryable';
 import {Warning} from './warning';
 
@@ -33,8 +34,8 @@ const MATCHES_EXTERNAL = /(^|\/)(bower_components|node_modules|build($|\/))/;
  * documents in the package.
  */
 export class Analysis implements Queryable {
-  private _results: Map<string, Document|Warning>;
-  private _searchRoots: Set<Document>;
+  private readonly _results: ImmutableMap<string, Document|Warning>;
+  private readonly _searchRoots: ImmutableSet<Document>;
 
   static isExternal(path: string) {
     return MATCHES_EXTERNAL.test(path);

--- a/src/model/attribute.ts
+++ b/src/model/attribute.ts
@@ -17,13 +17,13 @@ import {SourceRange} from '../model/model';
 export {Visitor} from '../javascript/estree-visitor';
 
 export interface ScannedAttribute {
-  name: string;
-  sourceRange: SourceRange|undefined;
-  description?: string;
-  type?: string;
-  changeEvent?: string;
+  readonly name: string;
+  readonly sourceRange: SourceRange|undefined;
+  readonly description?: string;
+  readonly type?: string;
+  readonly changeEvent?: string;
 }
 
 export interface Attribute extends ScannedAttribute {  //
-  inheritedFrom?: string;
+  readonly inheritedFrom?: string;
 }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -18,7 +18,7 @@ import {ParsedDocument} from '../parser/document';
 
 import {Analysis} from './analysis';
 import {Feature, ScannedFeature} from './feature';
-import {ImmutableSet} from './immutable';
+import {ImmutableSet, unsafeAsMutable} from './immutable';
 import {Import} from './import';
 import {DocumentQuery as Query, DocumentQueryWithKind as QueryWithKind, FeatureKind, FeatureKindMap, Queryable} from './queryable';
 import {isResolvable} from './resolvable';
@@ -131,9 +131,9 @@ export class Document implements Feature, Queryable {
     this.languageAnalysis = languageAnalysis;
 
     if (!base.isInline) {
-      (this.identifiers as Set<string>).add(this.url);
+      unsafeAsMutable(this.identifiers).add(this.url);
     }
-    (this.kinds as Set<string>).add(`${this.parsedDocument.type}-document`);
+    unsafeAsMutable(this.kinds).add(`${this.parsedDocument.type}-document`);
     this.warnings = Array.from(base.warnings);
   }
 

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -18,6 +18,7 @@ import {ParsedDocument} from '../parser/document';
 
 import {Analysis} from './analysis';
 import {Feature, ScannedFeature} from './feature';
+import {ImmutableSet} from './immutable';
 import {Import} from './import';
 import {DocumentQuery as Query, DocumentQueryWithKind as QueryWithKind, FeatureKind, FeatureKindMap, Queryable} from './queryable';
 import {isResolvable} from './resolvable';
@@ -89,8 +90,8 @@ declare module './queryable' {
   }
 }
 export class Document implements Feature, Queryable {
-  kinds: Set<string> = new Set(['document']);
-  identifiers: Set<string> = new Set();
+  readonly kinds: ImmutableSet<string> = new Set(['document']);
+  readonly identifiers: ImmutableSet<string> = new Set();
 
   /**
    * AnalysisContext is a private type. Only internal analyzer code should touch
@@ -100,8 +101,8 @@ export class Document implements Feature, Queryable {
   warnings: Warning[];
   languageAnalysis?: any;
 
-  private _localFeatures = new Set<Feature>();
-  private _scannedDocument: ScannedDocument;
+  private readonly _localFeatures = new Set<Feature>();
+  private readonly _scannedDocument: ScannedDocument;
 
 
   /**
@@ -130,9 +131,9 @@ export class Document implements Feature, Queryable {
     this.languageAnalysis = languageAnalysis;
 
     if (!base.isInline) {
-      this.identifiers.add(this.url);
+      (this.identifiers as Set<string>).add(this.url);
     }
-    this.kinds.add(`${this.parsedDocument.type}-document`);
+    (this.kinds as Set<string>).add(`${this.parsedDocument.type}-document`);
     this.warnings = Array.from(base.warnings);
   }
 
@@ -400,14 +401,6 @@ export class Document implements Feature, Queryable {
     return this.parsedDocument.stringify({inlineDocuments: inlineDocuments});
   }
 
-  private _featuresByKind: Map<string, Set<Feature>>|null = null;
-  private _featuresByKindAndId: Map<string, Map<string, Set<Feature>>>|null =
-      null;
-  private _initIndexes() {
-    this._featuresByKind = new Map<string, Set<Feature>>();
-    this._featuresByKindAndId = new Map<string, Map<string, Set<Feature>>>();
-  }
-
   private _indexFeature(feature: Feature) {
     if (!this._featuresByKind || !this._featuresByKindAndId) {
       return;
@@ -427,6 +420,9 @@ export class Document implements Feature, Queryable {
     }
   }
 
+  private _featuresByKind: Map<string, Set<Feature>>|null = null;
+  private _featuresByKindAndId: Map<string, Map<string, Set<Feature>>>|null =
+      null;
   private _buildIndexes() {
     if (this._featuresByKind) {
       throw new Error(
@@ -437,7 +433,8 @@ export class Document implements Feature, Queryable {
           `Tried to build indexes before finished resolving. ` +
           `Need to wait until afterwards or the indexes would be incomplete.`);
     }
-    this._initIndexes();
+    this._featuresByKind = new Map<string, Set<Feature>>();
+    this._featuresByKindAndId = new Map<string, Map<string, Set<Feature>>>();
     for (const feature of this.getFeatures(
              {imported: true, externalPackages: true})) {
       this._indexFeature(feature);

--- a/src/model/element-base.ts
+++ b/src/model/element-base.ts
@@ -14,9 +14,14 @@
 
 import * as estree from 'estree';
 import * as url from 'url';
-import * as jsdoc from '../javascript/jsdoc';
 
+import * as jsdoc from '../javascript/jsdoc';
+import {getOrInferPrivacy} from '../polymer/js-utils';
+
+import {Privacy} from './feature';
+import {ImmutableArray, ImmutableSet} from './immutable';
 import {Attribute, Document, Event, Feature, Method, Property, Reference, Resolvable, ScannedAttribute, ScannedEvent, ScannedProperty, ScannedReference, SourceRange, Warning} from './model';
+import {Severity} from './warning';
 
 export {Visitor} from '../javascript/estree-visitor';
 
@@ -31,11 +36,15 @@ export abstract class ScannedElementBase implements Resolvable {
   demos: {desc?: string; path: string}[] = [];
   events: ScannedEvent[] = [];
   sourceRange: SourceRange|undefined;
+  methods: Method[];
   astNode: estree.Node|null;
   warnings: Warning[] = [];
   jsdoc?: jsdoc.Annotation;
   'slots': Slot[] = [];
   mixins: ScannedReference[] = [];
+  privacy: Privacy;
+
+  superClass?: ScannedReference = undefined;
 
   applyHtmlComment(commentText: string|undefined) {
     this.description = this.description || commentText || '';
@@ -45,13 +54,13 @@ export abstract class ScannedElementBase implements Resolvable {
     if (!this.jsdoc || !this.jsdoc.tags) {
       return;
     }
-    this.jsdoc.tags.filter((tag) => tag.tag === 'demo' && tag.name)
-        .forEach((tag) => {
-          this.demos.push({
-            desc: tag.description || undefined,
-            path: url.resolve(baseUrl, tag.name!)
-          });
-        });
+    this.demos = this.jsdoc.tags.filter((tag) => tag.tag === 'demo' && tag.name)
+                     .map((tag) => {
+                       return {
+                         desc: tag.description || undefined,
+                         path: url.resolve(baseUrl, tag.name!)
+                       };
+                     });
   }
 
   resolve(_document: Document): any {
@@ -69,23 +78,50 @@ export class Slot {
   }
 }
 
+export interface Demo {
+  desc?: string;
+  path: string;
+}
+
+export interface ElementBaseInit {
+  description: string;
+  summary: string;
+  demos?: Demo[];
+  events?: Event[];
+  sourceRange: SourceRange|undefined;
+  properties?: Property[];
+  attributes?: Attribute[];
+  methods?: Method[];
+  astNode: any;
+  warnings?: Warning[];
+  slots?: Slot[];
+  privacy: Privacy;
+  jsdoc?: jsdoc.Annotation;
+  superClass?: ScannedReference;
+  mixins?: ScannedReference[];
+}
+
 /**
  * Base class for Element and ElementMixin.
  */
 export abstract class ElementBase implements Feature {
-  properties: Property[] = [];
-  attributes: Attribute[] = [];
-  methods: Method[] = [];
-  description = '';
-  summary = '';
-  demos: {desc?: string; path: string}[] = [];
-  events: Event[] = [];
-  sourceRange: SourceRange;
-  jsdoc?: jsdoc.Annotation;
-  astNode: estree.Node|null;
-  abstract kinds: Set<string>;
-  warnings: Warning[] = [];
+  readonly properties: Property[] = [];
+  readonly attributes: Attribute[] = [];
+  readonly methods: Method[] = [];
+  description: string;
+  readonly summary: string;
+  readonly demos: Demo[] = [];
+  readonly events: Event[] = [];
+  readonly sourceRange: SourceRange|undefined;
+  readonly jsdoc?: jsdoc.Annotation;
+  readonly astNode: any;
+  abstract kinds: ImmutableSet<string>;
+  readonly warnings: Warning[] = [];
   'slots': Slot[] = [];
+  readonly privacy: Privacy;
+  readonly superClass?: Reference;
+
+  abstract readonly name: string|undefined;
 
   /**
    * Mixins that this class declares with `@mixes`.
@@ -95,7 +131,180 @@ export abstract class ElementBase implements Feature {
    * single list. A mixin can be applied more than once, each time its
    * members override those before it in the prototype chain.
    */
-  mixins: Reference[] = [];
+  readonly mixins: ImmutableArray<Reference>;
+
+  constructor(init: ElementBaseInit, document: Document) {
+    const {
+      description,
+      summary,
+      demos,
+      events,
+      sourceRange,
+      properties,
+      attributes,
+      methods,
+      astNode,
+      warnings,
+      slots,
+      privacy,
+      jsdoc,
+      superClass,
+      mixins,
+    } = init;
+    this.description = description;
+    this.summary = summary;
+    this.demos = demos ? Array.from(demos) : [];
+    this.sourceRange = sourceRange;
+    this.astNode = astNode;
+    this.warnings = warnings ? Array.from(warnings) : [];
+    this.slots = slots ? Array.from(slots) : [];
+    this.privacy = privacy;
+    this.jsdoc = jsdoc;
+    this.superClass = superClass ? superClass.resolve(document) : undefined;
+    this.mixins = (mixins || []).map((m) => m.resolve(document));
+
+    const prototypeChain = this._getPrototypeChain(document, init);
+    for (const superClass of prototypeChain) {
+      this.inheritFrom(superClass);
+    }
+
+    this._overwriteInherited(
+        this.properties, properties || [], undefined, true);
+    this._overwriteInherited(
+        this.attributes, attributes || [], undefined, true);
+    this._overwriteInherited(this.methods, methods || [], undefined, true);
+    this._overwriteInherited(this.events, events || [], undefined, true);
+
+    for (const method of this.methods) {
+      // methods are only public by default if they're documented.
+      method.privacy = getOrInferPrivacy(method.name, method.jsdoc, true);
+    }
+  }
+
+  /**
+   * Returns the elementLikes that make up this class's prototype chain.
+   *
+   * Should return them in the order that they're constructed in JS
+   * engine (i.e. closest to HTMLElement first, closest to `this` last).
+   */
+  protected _getPrototypeChain(document: Document, _init: ElementBaseInit) {
+    const mixins = this.mixins.map(
+        (m) =>
+            this._resolveReferenceToSuperClass(m, document, 'element-mixin'));
+    const superClass = this._resolveReferenceToSuperClass(
+        this.superClass, document, 'element');
+
+    const prototypeChain: ElementBase[] = [];
+    if (superClass) {
+      prototypeChain.push(superClass);
+    }
+    for (const mixin of mixins) {
+      if (mixin) {
+        prototypeChain.push(mixin);
+      }
+    }
+
+    return prototypeChain;
+  }
+
+  protected _resolveReferenceToSuperClass(
+      reference: Reference|undefined, document: Document,
+      kind: 'element'|'element-mixin'): ElementBase|undefined {
+    if (!reference || reference.identifier === 'HTMLElement') {
+      return undefined;
+    }
+    const superElements = document.getFeatures({
+      kind: kind,
+      id: reference.identifier,
+      externalPackages: true,
+      imported: true,
+    });
+
+    if (superElements.size < 1) {
+      this.warnings.push({
+        message: `Unable to resolve superclass ${reference.identifier}`,
+        severity: Severity.ERROR,
+        code: 'unknown-superclass',
+        sourceRange: reference.sourceRange!,
+      });
+      return undefined;
+    } else if (superElements.size > 1) {
+      this.warnings.push({
+        message: `Multiple superclasses found for ${reference.identifier}`,
+        severity: Severity.ERROR,
+        code: 'unknown-superclass',
+        sourceRange: reference.sourceRange!,
+      });
+      return undefined;
+    }
+    return superElements.values().next().value;
+  }
+
+  protected inheritFrom(superClass: ElementBase) {
+    this._overwriteInherited(
+        this.properties, superClass.properties, superClass.name);
+    this._overwriteInherited(this.methods, superClass.methods, superClass.name);
+    this._overwriteInherited(
+        this.attributes, superClass.attributes, superClass.name);
+    this._overwriteInherited(this.events, superClass.events, superClass.name);
+
+    // TODO(justinfagnani): slots, listeners, observers, dom-module?
+    // What actually inherits?
+  }
+
+  /**
+   * This method is applied to an array of members to overwrite members lower in
+   * the prototype graph (closer to Object) with members higher up (closer to
+   * the final class we're constructing).
+   *
+   * @param . existing The array of members so far. N.B. *This param is
+   * mutated.*
+   * @param . overriding The array of members from this new, higher prototype in
+   *   the graph
+   * @param . overridingClassName The name of the prototype whose members are
+   *   being applied over the existing ones. Should be `undefined` when
+   *   applyingSelf is true
+   * @param . applyingSelf True on the last call to this method, when we're
+   *   applying the class's own local members.
+   */
+  protected _overwriteInherited<P extends PropertyLike>(
+      existing: P[], overriding: P[], overridingClassName: string|undefined,
+      applyingSelf = false) {
+    // This exists to treat the arrays as maps.
+    // TODO(rictic): convert these arrays to maps.
+    const existingIndexByName =
+        new Map(existing.map((e, idx) => [e.name, idx] as [string, number]));
+    for (const overridingVal of overriding) {
+      const newVal = Object.assign({}, overridingVal, {
+        inheritedFrom: overridingVal['inheritedFrom'] || overridingClassName
+      });
+      if (existingIndexByName.has(overridingVal.name)) {
+        /**
+         * TODO(rictic): if existingVal.privacy is protected, newVal should be
+         *    protected unless an explicit privacy was specified.
+         *    https://github.com/Polymer/polymer-analyzer/issues/631
+         */
+        const existingIndex = existingIndexByName.get(overridingVal.name)!;
+        const existingValue = existing[existingIndex]!;
+        if (existingValue.privacy === 'private') {
+          let warningSourceRange = this.sourceRange!;
+          if (applyingSelf) {
+            warningSourceRange = newVal.sourceRange || this.sourceRange!;
+          }
+          this.warnings.push({
+            code: 'overriding-private',
+            message: `Overriding private member '${overridingVal.name}' ` +
+                `inherited from ${existingValue.inheritedFrom || 'parent'}`,
+            sourceRange: warningSourceRange,
+            severity: Severity.WARNING
+          });
+        }
+        existing[existingIndex] = newVal;
+        continue;
+      }
+      existing.push(newVal);
+    }
+  }
 
   get identifiers(): Set<string> {
     throw new Error('abstract');
@@ -120,4 +329,11 @@ export abstract class ElementBase implements Feature {
   emitEventMetadata(_event: Event): Object {
     return {};
   }
+}
+
+export interface PropertyLike {
+  name: string;
+  sourceRange?: SourceRange;
+  inheritedFrom?: string;
+  privacy?: Privacy;
 }

--- a/src/model/element-mixin.ts
+++ b/src/model/element-mixin.ts
@@ -12,21 +12,26 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document, ElementBase, Feature, Privacy, ScannedElementBase} from './model';
+import {ElementBaseInit} from './element-base';
+import {ImmutableSet} from './immutable';
+import {Document, ElementBase, Feature, ScannedElementBase} from './model';
 
 export {Visitor} from '../javascript/estree-visitor';
 
 export class ScannedElementMixin extends ScannedElementBase {
-  name: string;
-  privacy: Privacy;
+  readonly name: string;
+  constructor({name}: {name: string}) {
+    super();
+    this.name = name;
+  }
 
   resolve(document: Document): ElementMixin {
-    const element = new ElementMixin();
-    Object.assign(element, this);
     this.applyJsdocDemoTags(document.url);
-    return element;
+    return new ElementMixin(this, document);
   }
 }
+
+export interface ElementMixinInit extends ElementBaseInit { name: string; }
 
 declare module './queryable' {
   interface FeatureKindMap {
@@ -34,9 +39,18 @@ declare module './queryable' {
   }
 }
 export class ElementMixin extends ElementBase implements Feature {
-  name: string;
-  privacy: Privacy;
-  kinds = new Set(['element-mixin']);
+  readonly name: string;
+  readonly kinds: ImmutableSet<string> = new Set(['element-mixin']);
+
+  constructor(init: ElementMixinInit, document: Document) {
+    super(init, document);
+    console.log(`element mixin ${this.name} created. ${
+                                                       this.attributes.length
+                                                     } attributes`);
+
+    this.name = init.name;
+    this.identifiers.add(this.name);
+  }
 
   get identifiers(): Set<string> {
     return new Set([this.name]);

--- a/src/model/element-reference.ts
+++ b/src/model/element-reference.ts
@@ -16,12 +16,15 @@ import * as dom5 from 'dom5';
 
 import {Feature, Resolvable, SourceRange, Warning} from '../model/model';
 
+import {Document} from './document';
+import {ImmutableArray, ImmutableSet} from './immutable';
+
 export interface Attribute {
-  name: string;
-  sourceRange: SourceRange;
-  nameSourceRange: SourceRange;
-  valueSourceRange: SourceRange|undefined;
-  value?: string;
+  readonly name: string;
+  readonly sourceRange: SourceRange;
+  readonly nameSourceRange: SourceRange;
+  readonly valueSourceRange: SourceRange|undefined;
+  readonly value?: string;
 }
 
 declare module '../model/queryable' {
@@ -31,24 +34,32 @@ declare module '../model/queryable' {
 }
 
 export class ElementReference implements Feature {
-  tagName: string;
-  attributes: Attribute[] = [];
-  sourceRange: SourceRange;
-  astNode: dom5.Node;
-  warnings: Warning[] = [];
-  kinds: Set<string> = new Set(['element-reference']);
+  readonly tagName: string;
+  readonly attributes: ImmutableArray<Attribute>;
+  readonly sourceRange: SourceRange;
+  readonly astNode: dom5.Node;
+  readonly warnings: ImmutableArray<Warning>;
+  readonly kinds: ImmutableSet<string> = new Set(['element-reference']);
 
-  get identifiers(): Set<string> {
+  constructor(scannedRef: ScannedElementReference, _document: Document) {
+    this.tagName = scannedRef.tagName;
+    this.attributes = scannedRef.attributes;
+    this.sourceRange = scannedRef.sourceRange;
+    this.astNode = scannedRef.astNode;
+    this.warnings = scannedRef.warnings;
+  }
+
+  get identifiers(): ImmutableSet<string> {
     return new Set([this.tagName]);
   }
 }
 
 export class ScannedElementReference implements Resolvable {
-  tagName: string;
-  attributes: Attribute[] = [];
-  sourceRange: SourceRange;
-  astNode: dom5.Node;
-  warnings: Warning[] = [];
+  readonly tagName: string;
+  readonly attributes: Attribute[] = [];
+  readonly sourceRange: SourceRange;
+  readonly astNode: dom5.Node;
+  readonly warnings: ImmutableArray<Warning> = [];
 
   constructor(tagName: string, sourceRange: SourceRange, ast: dom5.Node) {
     this.tagName = tagName;
@@ -56,9 +67,7 @@ export class ScannedElementReference implements Resolvable {
     this.astNode = ast;
   }
 
-  resolve(): ElementReference {
-    const ref = new ElementReference();
-    Object.assign(ref, this);
-    return ref;
+  resolve(document: Document): ElementReference {
+    return new ElementReference(this, document);
   }
 }

--- a/src/model/element.ts
+++ b/src/model/element.ts
@@ -13,7 +13,7 @@
  */
 
 import {Document} from './document';
-import {ElementBase, ScannedElementBase} from './element-base';
+import {ElementBase, ElementBaseInit, ScannedElementBase} from './element-base';
 import {Feature, Privacy} from './feature';
 import {Reference, ScannedReference} from './reference';
 
@@ -39,11 +39,17 @@ export class ScannedElement extends ScannedElementBase {
   }
 
   resolve(document: Document): Element {
-    const element = new Element();
-    Object.assign(element, this);
     this.applyJsdocDemoTags(document.url);
-    return element;
+
+    return new Element(this, document);
   }
+}
+
+export interface ElementInit extends ElementBaseInit {
+  tagName?: string;
+  className?: string;
+  superClass?: ScannedReference;
+  extends?: string;
 }
 
 declare module './queryable' {
@@ -52,16 +58,25 @@ declare module './queryable' {
   }
 }
 export class Element extends ElementBase implements Feature {
-  tagName?: string;
-  className?: string;
-  superClass?: Reference;
-  privacy: Privacy;
+  readonly tagName?: string;
+  readonly className?: string;
+  readonly superClass?: Reference;
+  get name() {
+    return this.className;
+  }
 
   /**
    * For customized built-in elements, the tagname of the superClass.
    */
   extends?: string;
   kinds = new Set(['element']);
+
+  constructor(init: ElementInit, document: Document) {
+    super(init, document);
+    this.tagName = init.tagName;
+    this.className = init.className;
+    this.extends = init.extends;
+  }
 
   get identifiers(): Set<string> {
     const result: Set<string> = new Set();

--- a/src/model/event.ts
+++ b/src/model/event.ts
@@ -16,18 +16,18 @@ import * as estree from 'estree';
 import {ScannedFeature} from './feature';
 
 export interface ScannedEvent extends ScannedFeature {
-  name: string;
-  type?: string;
-  description?: string;
-  params?: {type: string, desc: string, name: string}[];
-  astNode: estree.Node|null;
+  readonly name: string;
+  readonly type?: string;
+  readonly description?: string;
+  readonly params: {type: string, desc: string, name: string}[];
+  readonly astNode: estree.Node|null;
 }
 
 export interface Event {
-  name: string;
-  type?: string;
+  readonly name: string;
+  readonly type?: string;
   // TODO: represent detail object properly
-  description?: string;
-  inheritedFrom?: string;
-  astNode: estree.Node|null;
+  readonly description?: string;
+  readonly astNode: estree.Node|null;
+  readonly inheritedFrom?: string;
 }

--- a/src/model/feature.ts
+++ b/src/model/feature.ts
@@ -14,26 +14,29 @@
 
 import * as jsdoc from '../javascript/jsdoc';
 
+import {ImmutableArray, ImmutableSet} from './immutable';
 import {SourceRange} from './source-range';
 import {Warning} from './warning';
 
 export abstract class Feature {
-  kinds = new Set<string>();
-  identifiers = new Set<string>();
+  readonly kinds: Set<string>|ImmutableSet<string> = new Set<string>();
+  readonly identifiers: Set<string>|ImmutableSet<string> = new Set<string>();
 
   /** Tracks the source that this feature came from. */
-  sourceRange?: SourceRange;
+  readonly sourceRange?: SourceRange;
 
   /**
    * The AST Node, if any, that corresponds to this feature in its containing
    * document.
    */
-  astNode?: any;
+  readonly astNode?: any;
 
   /** Warnings that were encountered while processing this feature. */
-  warnings: Warning[];
+  readonly warnings: Array<Warning>|ImmutableArray<Warning>;
 
-  constructor(sourceRange?: SourceRange, astNode?: any, warnings?: Warning[]) {
+  constructor(
+      sourceRange?: SourceRange, astNode?: any,
+      warnings?: Array<Warning>|ImmutableArray<Warning>) {
     this.sourceRange = sourceRange;
     this.astNode = astNode;
     this.warnings = warnings || [];
@@ -42,22 +45,22 @@ export abstract class Feature {
 
 export abstract class ScannedFeature {
   // TODO(justinfagnani): why is this here and not on Feature?
-  description?: string;
+  readonly description?: string;
 
   // TODO(rictic): this is the wrong place to put a jsdoc annotation.
-  jsdoc?: jsdoc.Annotation;
+  readonly jsdoc?: jsdoc.Annotation;
 
   /** Tracks the source that this feature came from. */
-  sourceRange: SourceRange|undefined;
+  readonly sourceRange: SourceRange|undefined;
 
   /**
    * The AST Node, if any, that corresponds to this feature in its containing
    * document.
    */
-  astNode?: any;
+  readonly astNode?: any;
 
   /** Warnings that were encountered while processing this feature. */
-  warnings: Warning[];
+  readonly warnings: Array<Warning>|ImmutableArray<Warning>;
 
   constructor(
       sourceRange?: SourceRange, astNode?: any, description?: string,

--- a/src/model/immutable.ts
+++ b/src/model/immutable.ts
@@ -59,3 +59,17 @@ export function asImmutable<O extends object>(object: O): Readonly<O>;
 export function asImmutable(x: any) {
   return x;
 }
+
+/**
+ * Take care, this function is inherently unsafe.
+ *
+ * You're taking a data structure that has been declare as immutable and getting
+ * a mutable reference to it.
+ */
+export function unsafeAsMutable<V>(array: ImmutableArray<V>): Array<V>;
+export function unsafeAsMutable<V>(set: ImmutableSet<V>): Set<V>;
+export function unsafeAsMutable<K, V>(map: ImmutableMap<K, V>): Map<K, V>;
+export function unsafeAsMutable<O extends object>(object: Readonly<O>): O;
+export function unsafeAsMutable(x: any) {
+  return x;
+}

--- a/src/model/immutable.ts
+++ b/src/model/immutable.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This is a simple pattern to provide a readonly view of a normal javascript
+ * collection. Note that this trades performance for protection. There's nothing
+ * stoping a user from mutating one of these data structures, save a warning
+ * that the typescript compiler may give them.
+ *
+ * Other options to consider are facebook's Immutable.js which provides a
+ * variety of truely immutable data structures.
+ */
+
+
+/** A zero-overhead immutable view of an array. */
+export declare interface ImmutableArray<V> {
+  readonly [index: number]: V|undefined;
+  readonly length: number;
+  slice(left?: number, right?: number): Array<V>;
+  map<U>(f: (v: V, idx: number) => U): Array<U>;
+  forEach(f: (v: V, idx: number) => void): void;
+  [Symbol.iterator](): Iterator<V>;
+}
+
+/** A zero-overhead immutable view of a set. */
+export declare interface ImmutableSet<V> {
+  readonly size: number;
+  has(candidate: V): boolean;
+  values(): Iterable<V>;
+  [Symbol.iterator](): Iterator<V>;
+}
+
+/** A zero-overhead immutable view of a map. */
+export declare interface ImmutableMap<K, V> {
+  readonly size: number;
+  has(candidate: K): boolean;
+  get(key: K): V|undefined;
+  keys(): Iterable<K>;
+  values(): Iterable<V>;
+  entries(): Iterable<[K, V]>;
+  [Symbol.iterator](): Iterator<[K, V]>;
+}
+
+export function asImmutable<V>(array: Array<V>): ImmutableArray<V>;
+export function asImmutable<V>(set: Set<V>): ImmutableSet<V>;
+export function asImmutable<K, V>(map: Map<K, V>): ImmutableMap<K, V>;
+export function asImmutable<O extends object>(object: O): Readonly<O>;
+export function asImmutable(x: any) {
+  return x;
+}

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -107,16 +107,16 @@ declare module './queryable' {
 }
 
 export class Import implements Feature {
-  type: 'html-import'|'html-script'|'html-style'|string;
-  url: string;
-  document: Document;
-  identifiers = new Set();
-  kinds = new Set(['import']);
-  sourceRange: SourceRange|undefined;
-  urlSourceRange: SourceRange|undefined;
-  astNode: any|null;
-  warnings: Warning[];
-  lazy: boolean;
+  readonly type: 'html-import'|'html-script'|'html-style'|string;
+  readonly url: string;
+  readonly document: Document;
+  readonly identifiers = new Set();
+  readonly kinds = new Set(['import']);
+  readonly sourceRange: SourceRange|undefined;
+  readonly urlSourceRange: SourceRange|undefined;
+  readonly astNode: any|null;
+  readonly warnings: Warning[];
+  readonly lazy: boolean;
 
   constructor(
       url: string, type: string, document: Document,

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -21,6 +21,7 @@ import * as jsdoc from '../javascript/jsdoc';
 
 import {Document, ScannedDocument} from './document';
 import {ScannedFeature} from './feature';
+import {unsafeAsMutable} from './immutable';
 import {Resolvable} from './resolvable';
 import {LocationOffset, SourceRange} from './source-range';
 import {Warning} from './warning';
@@ -82,7 +83,7 @@ declare module './queryable' {
 export class InlineDocument extends Document {
   constructor(base: ScannedDocument, containerDocument: Document) {
     super(base, containerDocument._analysisContext);
-    (this.kinds as Set<string>).add('inline-document');
+    unsafeAsMutable(this.kinds).add('inline-document');
     this._addFeature(containerDocument);
   }
 }

--- a/src/model/inline-document.ts
+++ b/src/model/inline-document.ts
@@ -82,7 +82,7 @@ declare module './queryable' {
 export class InlineDocument extends Document {
   constructor(base: ScannedDocument, containerDocument: Document) {
     super(base, containerDocument._analysisContext);
-    this.kinds.add('inline-document');
+    (this.kinds as Set<string>).add('inline-document');
     this._addFeature(containerDocument);
   }
 }

--- a/src/model/method.ts
+++ b/src/model/method.ts
@@ -20,12 +20,12 @@ export interface ScannedMethod extends ScannedProperty {
 }
 
 export interface Method extends Property {
-  params?: MethodParam[];
-  return?: {type?: string, desc?: string};
+  readonly params?: MethodParam[];
+  readonly return?: {type?: string, desc?: string};
 }
 
 export interface MethodParam {
-  name: string;
-  type?: string;
-  description?: string;
+  readonly name: string;
+  readonly type?: string;
+  readonly description?: string;
 }

--- a/src/model/property.ts
+++ b/src/model/property.ts
@@ -16,6 +16,7 @@ import * as jsdoc from '../javascript/jsdoc';
 import {SourceRange} from '../model/model';
 
 import {Privacy, ScannedFeature} from './model';
+import {Warning} from './warning';
 
 export interface ScannedProperty extends ScannedFeature {
   name: string;
@@ -24,17 +25,18 @@ export interface ScannedProperty extends ScannedFeature {
   'default'?: string;
   readOnly?: boolean;
   changeEvent?: string;
+  warnings: Warning[];
 }
 
 export interface Property {
-  name: string;
-  type?: string;
-  description?: string;
-  jsdoc?: jsdoc.Annotation;
+  readonly name: string;
+  readonly type?: string;
+  readonly description?: string;
+  readonly jsdoc?: jsdoc.Annotation;
   privacy: Privacy;
-  'default'?: string;
-  readOnly?: boolean;
-  sourceRange?: SourceRange;
-  inheritedFrom?: string;
-  changeEvent?: string;
+  readonly 'default'?: string;
+  readonly readOnly?: boolean;
+  readonly sourceRange?: SourceRange;
+  readonly inheritedFrom?: string;
+  readonly changeEvent?: string;
 }

--- a/src/model/reference.ts
+++ b/src/model/reference.ts
@@ -16,22 +16,20 @@ import {Annotation} from '../javascript/jsdoc';
 
 import {Document} from './document';
 import {Feature, ScannedFeature} from './feature';
+import {ImmutableArray} from './immutable';
 import {Resolvable} from './resolvable';
 import {SourceRange} from './source-range';
 import {Warning} from './warning';
-
-export interface ScannedReferenceInit extends Partial<Reference> {
-  identifier: string;
-}
 
 /**
  * A reference to another feature by identifier.
  */
 export class ScannedReference extends ScannedFeature implements Resolvable {
-  identifier: string;
+  readonly identifier: string;
+  readonly sourceRange: SourceRange;
 
   constructor(
-      identifier: string, sourceRange?: SourceRange, astNode?: any,
+      identifier: string, sourceRange: SourceRange, astNode?: any,
       description?: string, jsdoc?: Annotation, warnings?: Warning[]) {
     super(sourceRange, astNode, description, jsdoc, warnings);
     this.identifier = identifier;
@@ -46,10 +44,6 @@ export class ScannedReference extends ScannedFeature implements Resolvable {
   }
 }
 
-export interface ReferenceInit extends Partial<Reference> {
-  identifier: string;
-}
-
 declare module './queryable' {
   interface FeatureKindMap {
     'reference': Reference;
@@ -62,10 +56,10 @@ export class Reference extends Feature {
   identifier: string;
 
   constructor(
-      identifier: string, sourceRange?: SourceRange, astNode?: any,
-      warnings?: Warning[]) {
+      identifier: string, sourceRange: SourceRange, astNode: any,
+      warnings: ImmutableArray<Warning>) {
     super(sourceRange, astNode, warnings);
-    this.kinds.add('reference');
+    (this.kinds as Set<string>).add('reference');
     this.identifier = identifier;
   }
 }

--- a/src/model/reference.ts
+++ b/src/model/reference.ts
@@ -16,7 +16,7 @@ import {Annotation} from '../javascript/jsdoc';
 
 import {Document} from './document';
 import {Feature, ScannedFeature} from './feature';
-import {ImmutableArray} from './immutable';
+import {ImmutableArray, unsafeAsMutable} from './immutable';
 import {Resolvable} from './resolvable';
 import {SourceRange} from './source-range';
 import {Warning} from './warning';
@@ -59,7 +59,7 @@ export class Reference extends Feature {
       identifier: string, sourceRange: SourceRange, astNode: any,
       warnings: ImmutableArray<Warning>) {
     super(sourceRange, astNode, warnings);
-    (this.kinds as Set<string>).add('reference');
+    unsafeAsMutable(this.kinds).add('reference');
     this.identifier = identifier;
   }
 }

--- a/src/model/source-range.ts
+++ b/src/model/source-range.ts
@@ -21,27 +21,27 @@
  */
 export interface SourceRange {
   /* The resolved path to the file. */
-  file: string;
-  start: SourcePosition;
-  end: SourcePosition;
+  readonly file: string;
+  readonly start: SourcePosition;
+  readonly end: SourcePosition;
 }
 
 export interface SourcePosition {
   /** The line number, starting from zero. */
-  line: number;
+  readonly line: number;
   /** The column offset within the line, starting from zero. */
-  column: number;
+  readonly column: number;
 }
 
 export interface LocationOffset {
   /** Zero based line index. */
-  line: number;
+  readonly line: number;
   /** Zero based column index. */
-  col: number;
+  readonly col: number;
   /**
    * The url of the source file.
    */
-  filename?: string;
+  readonly filename?: string;
 }
 
 /**

--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -14,10 +14,10 @@
 
 import {SourceRange} from './source-range';
 export interface Warning {
-  message: string;
-  sourceRange: SourceRange;
-  severity: Severity;
-  code: string;
+  readonly message: string;
+  readonly sourceRange: SourceRange;
+  readonly severity: Severity;
+  readonly code: string;
 }
 
 export enum Severity {
@@ -28,7 +28,7 @@ export enum Severity {
 
 // TODO(rictic): can we get rid of this class entirely?
 export class WarningCarryingException extends Error {
-  warning: Warning;
+  readonly warning: Warning;
   constructor(warning: Warning) {
     super(warning.message);
     this.warning = warning;

--- a/src/polymer/analyze-properties.ts
+++ b/src/polymer/analyze-properties.ts
@@ -104,7 +104,7 @@ export function analyzeProperties(
             prop.observerNode = propertyArg.value;
             const parseResult = parseExpressionInJsStringLiteral(
                 document, propertyArg.value, 'identifierOnly');
-            prop.warnings = prop.warnings.concat(parseResult.warnings);
+            prop.warnings.push(...parseResult.warnings);
             prop.observerExpression = parseResult.databinding;
             if (val === undefined) {
               prop.observer = astValue.CANT_CONVERT;
@@ -122,7 +122,7 @@ export function analyzeProperties(
             isComputed = true;
             const computedParseResult = parseExpressionInJsStringLiteral(
                 document, propertyArg.value, 'callExpression');
-            prop.warnings = prop.warnings.concat(computedParseResult.warnings);
+            prop.warnings.push(...computedParseResult.warnings);
             prop.computedExpression = computedParseResult.databinding;
             break;
           case 'value':

--- a/src/polymer/behavior.ts
+++ b/src/polymer/behavior.ts
@@ -13,7 +13,7 @@
  */
 
 import {Document, SourceRange} from '../model/model';
-import {getBehaviors, Options as ElementOptions, PolymerElement, ScannedPolymerElement} from '../polymer/polymer-element';
+import {Options as ElementOptions, PolymerElement, ScannedPolymerElement} from '../polymer/polymer-element';
 
 /**
  * A scanned behavior assignment of a Polymer element. This is only a
@@ -47,12 +47,8 @@ export class ScannedBehavior extends ScannedPolymerElement {
   }
 
   resolve(document: Document) {
-    const behaviorsAndWarnings =
-        getBehaviors(this.behaviorAssignments, document);
-    const behavior = Object.assign(new Behavior(), this);
-    behavior.warnings = behavior.warnings.concat(behaviorsAndWarnings.warnings);
     this.applyJsdocDemoTags(document.url);
-    return behavior;
+    return new Behavior(this, document);
   }
 }
 
@@ -65,8 +61,8 @@ declare module '../model/queryable' {
 export class Behavior extends PolymerElement {
   tagName: undefined;
   className: string;
-  constructor() {
-    super();
+  constructor(scannedBehavior: ScannedBehavior, document: Document) {
+    super(scannedBehavior, document);
     this.kinds = new Set(['behavior']);
   }
 

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -99,18 +99,19 @@ export function annotateEvent(annotation: jsdoc.Annotation): ScannedEvent {
     sourceRange: undefined,
     astNode: null,
     warnings: [],
+    params: []
   };
 
   const tags = (annotation && annotation.tags || []);
   // process @params
-  scannedEvent.params =
-      tags.filter((tag) => tag.tag === 'param').map(function(param) {
+  scannedEvent.params.push(
+      ...tags.filter((tag) => tag.tag === 'param').map(function(param) {
         return {
           type: param.type || 'N/A',
           desc: param.description || '',
           name: param.name || 'N/A'
         };
-      });
+      }));
   // process @params
   return scannedEvent;
 }

--- a/src/polymer/js-utils.ts
+++ b/src/polymer/js-utils.ts
@@ -17,7 +17,7 @@ import * as estree from 'estree';
 
 import {closureType, getAttachedComment, objectKeyToString} from '../javascript/esutil';
 import * as jsdoc from '../javascript/jsdoc';
-import {MethodParam, Privacy, ScannedMethod, Severity, SourceRange, Warning} from '../model/model';
+import {Privacy, ScannedMethod, Severity, SourceRange, Warning} from '../model/model';
 
 import {ScannedPolymerProperty} from './polymer-element';
 
@@ -121,21 +121,21 @@ export function toScannedMethod(
     }
 
     scannedMethod.params = (value.params || []).map((nodeParam) => {
-      const param: MethodParam = {
-        // With ES6 we can have a lot of param patterns. Best to leave the
-        // formatting to escodegen.
-        name: escodegen.generate(nodeParam),
-      };
-      const tag = paramTags[param.name];
+      let type = undefined;
+      let description = undefined;
+      // With ES6 we can have a lot of param patterns. Best to leave the
+      // formatting to escodegen.
+      const name = escodegen.generate(nodeParam);
+      const tag = paramTags[name];
       if (tag) {
         if (tag.type) {
-          param.type = tag.type;
+          type = tag.type;
         }
         if (tag.description) {
-          param.description = tag.description;
+          description = tag.description;
         }
       }
-      return param;
+      return {name, type, description};
     });
   }
 

--- a/src/polymer/polymer-element-mixin.ts
+++ b/src/polymer/polymer-element-mixin.ts
@@ -134,9 +134,9 @@ export class PolymerElementMixin extends ElementMixin implements
     return {polymer: polymerMetadata};
   }
 
-  protected _getPrototypeChain(
+  protected _getSuperclassAndMixins(
       document: Document, init: ScannedPolymerElementMixin): ElementBase[] {
-    const prototypeChain = super._getPrototypeChain(document, init);
+    const prototypeChain = super._getSuperclassAndMixins(document, init);
 
     const {warnings, behaviors} =
         getBehaviors(init.behaviorAssignments, document);

--- a/src/polymer/polymer-element-mixin.ts
+++ b/src/polymer/polymer-element-mixin.ts
@@ -14,13 +14,14 @@
 import * as dom5 from 'dom5';
 import * as estree from 'estree';
 
-import {Attribute, Event} from '../index';
+import {ElementBase} from '../index';
 import {Annotation as JsDocAnnotation} from '../javascript/jsdoc';
+import {ImmutableSet} from '../model/immutable';
 import {Document, ElementMixin, Method, Privacy, ScannedElementMixin, ScannedMethod, ScannedReference, SourceRange} from '../model/model';
 
 import {ScannedBehaviorAssignment} from './behavior';
 import {getOrInferPrivacy} from './js-utils';
-import {_overwriteInherited, addMethod, addProperty, applyMixins, LocalId, Observer, PolymerExtension, PolymerProperty, ScannedPolymerExtension, ScannedPolymerProperty} from './polymer-element';
+import {addMethod, addProperty, getBehaviors, LocalId, Observer, PolymerExtension, PolymerProperty, ScannedPolymerExtension, ScannedPolymerProperty} from './polymer-element';
 
 export interface Options {
   name: string;
@@ -58,8 +59,7 @@ export class ScannedPolymerElementMixin extends ScannedElementMixin implements
     mixins,
     astNode
   }: Options) {
-    super();
-    this.name = name;
+    super({name});
     this.jsdoc = jsdoc;
     this.description = description;
     this.summary = summary;
@@ -101,68 +101,26 @@ export class PolymerElementMixin extends ElementMixin implements
   readonly scriptElement?: dom5.Node;
   readonly localIds: LocalId[] = [];
 
-  readonly kinds = new Set(['element-mixin', 'polymer-element-mixin']);
+  readonly kinds: ImmutableSet<string> =
+      new Set(['element-mixin', 'polymer-element-mixin']);
   readonly pseudo: boolean;
   readonly abstract: boolean;
 
   constructor(scannedMixin: ScannedPolymerElementMixin, document: Document) {
-    super();
+    super(scannedMixin, document);
+    console.log(
+        `polymer element mixin ${this.name} created. ${
+                                                       this.attributes.length
+                                                     } attributes`);
     this.abstract = scannedMixin.abstract;
-    this.astNode = scannedMixin.astNode;
-    this.demos = scannedMixin.demos;
     this.description = scannedMixin.description;
     this.domModule = scannedMixin.domModule;
-    this.jsdoc = scannedMixin.jsdoc;
-    this.name = scannedMixin.name;
-    this.privacy = scannedMixin.privacy;
     this.pseudo = scannedMixin.pseudo;
     this.scriptElement = scannedMixin.scriptElement;
     this.slots = scannedMixin.slots;
-    this.sourceRange = scannedMixin.sourceRange;
-    this.summary = scannedMixin.summary;
-    this.warnings = scannedMixin.warnings;
-
-    this.identifiers.add(this.name);
 
     this.behaviorAssignments = Array.from(scannedMixin.behaviorAssignments);
     this.observers = Array.from(scannedMixin.observers);
-    this.properties = [];
-    this.attributes = [];
-    this.methods = [];
-    this.events = [];
-
-    applyMixins(this, scannedMixin, document);
-
-    // TODO(rictic): do this in a more sane place, ideally somewhere in a parent
-    // constructor.
-    _overwriteInherited(
-        this.properties,
-        scannedMixin.properties as PolymerProperty[],
-        undefined,
-        this.warnings,
-        this.sourceRange,
-        true);
-    _overwriteInherited(
-        this.attributes,
-        scannedMixin.attributes as Attribute[],
-        undefined,
-        this.warnings,
-        this.sourceRange,
-        true);
-    _overwriteInherited(
-        this.events,
-        scannedMixin.events as Event[],
-        undefined,
-        this.warnings,
-        this.sourceRange,
-        true);
-    _overwriteInherited(
-        this.methods,
-        scannedMixin.methods as Method[],
-        undefined,
-        this.warnings,
-        this.sourceRange,
-        true);
   }
 
   emitPropertyMetadata(property: PolymerProperty) {
@@ -174,5 +132,16 @@ export class PolymerElementMixin extends ElementMixin implements
       }
     }
     return {polymer: polymerMetadata};
+  }
+
+  protected _getPrototypeChain(
+      document: Document, init: ScannedPolymerElementMixin): ElementBase[] {
+    const prototypeChain = super._getPrototypeChain(document, init);
+
+    const {warnings, behaviors} =
+        getBehaviors(init.behaviorAssignments, document);
+    this.warnings.push(...warnings);
+    prototypeChain.push(...behaviors);
+    return prototypeChain;
   }
 }

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -15,17 +15,15 @@
 import * as dom5 from 'dom5';
 import * as estree from 'estree';
 
-import {Attribute, Event} from '../index';
 import * as jsdoc from '../javascript/jsdoc';
 import {Annotation as JsDocAnnotation} from '../javascript/jsdoc';
-import {Document, Element, ElementBase, LiteralValue, Method, Privacy, Property, ScannedAttribute, ScannedElement, ScannedElementBase, ScannedEvent, ScannedMethod, ScannedProperty, Severity, SourceRange, Warning} from '../model/model';
+import {ImmutableArray} from '../model/immutable';
+import {Document, Element, ElementBase, LiteralValue, Privacy, Property, ScannedAttribute, ScannedElement, ScannedElementBase, ScannedEvent, ScannedMethod, ScannedProperty, Severity, SourceRange, Warning} from '../model/model';
 import {ScannedReference} from '../model/reference';
 
 import {Behavior, ScannedBehaviorAssignment} from './behavior';
 import {DomModule} from './dom-module-scanner';
 import {JavascriptDatabindingExpression} from './expression-scanner';
-import {getOrInferPrivacy} from './js-utils';
-import {PolymerElementMixin} from './polymer-element-mixin';
 
 export interface BasePolymerProperty {
   published?: boolean;
@@ -129,7 +127,8 @@ export function addProperty(
       description: `Fired when the \`${prop.name}\` property changes.`,
       sourceRange: prop.sourceRange,
       astNode: prop.astNode,
-      warnings: []
+      warnings: [],
+      params: []
     });
   }
 }
@@ -187,24 +186,23 @@ export class ScannedPolymerElement extends ScannedElement implements
 
   resolve(document: Document): PolymerElement {
     this.applyJsdocDemoTags(document.url);
-    return resolveElement(this, document);
+    return new PolymerElement(this, document);
   }
 }
 
 export interface PolymerExtension extends ElementBase {
   properties: PolymerProperty[];
-  methods: Method[];
 
-  observers: {
-    javascriptNode: estree.Expression | estree.SpreadElement,
-    expression: LiteralValue,
-    parsedExpression: JavascriptDatabindingExpression|undefined;
-  }[];
-  listeners: {event: string, handler: string}[];
-  behaviorAssignments: ScannedBehaviorAssignment[];
-  domModule?: dom5.Node;
+  observers: ImmutableArray < {
+    javascriptNode: estree.Expression|estree.SpreadElement,
+        expression: LiteralValue,
+        parsedExpression: JavascriptDatabindingExpression|undefined;
+  }
+  > ;
+  listeners: ImmutableArray<{event: string, handler: string}>;
+  behaviorAssignments: ImmutableArray<ScannedBehaviorAssignment>;
   scriptElement?: dom5.Node;
-  localIds: LocalId[];
+  localIds: ImmutableArray<LocalId>;
 
   abstract?: boolean;
 
@@ -219,22 +217,56 @@ declare module '../model/queryable' {
 }
 
 export class PolymerElement extends Element implements PolymerExtension {
-  properties: PolymerProperty[] = [];
-  methods: Method[] = [];
+  readonly properties: PolymerProperty[];
+  readonly observers: ImmutableArray<Observer> = [];
+  readonly listeners: ImmutableArray<{event: string, handler: string}> = [];
+  readonly behaviorAssignments: ImmutableArray<ScannedBehaviorAssignment> = [];
+  readonly domModule?: dom5.Node;
+  readonly scriptElement?: dom5.Node;
+  readonly localIds: ImmutableArray<LocalId> = [];
 
-  observers: Observer[] = [];
-  listeners: {event: string, handler: string}[] = [];
-  behaviorAssignments: ScannedBehaviorAssignment[] = [];
-  domModule?: dom5.Node;
-  scriptElement?: dom5.Node;
-  localIds: LocalId[] = [];
-
-  abstract?: boolean;
+  readonly abstract?: boolean;
 
   kinds = new Set(['element', 'polymer-element']);
 
+  constructor(scannedElement: ScannedPolymerElement, document: Document) {
+    super(scannedElement, document);
+
+    this.abstract = scannedElement.abstract;
+    this.observers = Array.from(scannedElement.observers);
+    this.listeners = Array.from(scannedElement.listeners);
+    this.behaviorAssignments = Array.from(scannedElement.behaviorAssignments);
+    this.scriptElement = scannedElement.scriptElement;
+
+    const domModules = scannedElement.tagName == null ?
+        new Set<DomModule>() :
+        document.getFeatures({
+          kind: 'dom-module',
+          id: scannedElement.tagName,
+          imported: true,
+          externalPackages: true
+        });
+    let domModule = undefined;
+    if (domModules.size === 1) {
+      // TODO(rictic): warn if this isn't true.
+      domModule = domModules.values().next().value;
+    }
+
+
+    if (domModule) {
+      this.description = this.description || domModule.comment || '';
+      this.domModule = domModule.node;
+      this.slots = domModule.slots.slice();
+      this.localIds = domModule.localIds.slice();
+    }
+
+    if (scannedElement.pseudo) {
+      this.kinds.add('pseudo-element');
+    }
+  }
+
   emitPropertyMetadata(property: PolymerProperty) {
-    const polymerMetadata: any = {};
+    const polymerMetadata = {};
     const polymerMetadataFields = ['notify', 'observer', 'readOnly'];
     for (const field of polymerMetadataFields) {
       if (field in property) {
@@ -242,6 +274,18 @@ export class PolymerElement extends Element implements PolymerExtension {
       }
     }
     return {polymer: polymerMetadata};
+  }
+
+  protected _getPrototypeChain(
+      document: Document, init: ScannedPolymerElement) {
+    const prototypeChain = super._getPrototypeChain(document, init);
+
+    const {warnings, behaviors} =
+        getBehaviors(init.behaviorAssignments, document);
+
+    this.warnings.push(...warnings);
+    prototypeChain.push(...behaviors);
+    return prototypeChain;
   }
 }
 
@@ -260,101 +304,6 @@ function propertyToAttributeName(propertyName: string): string|null {
       /([A-Z])/g, (_: string, c1: string) => `-${c1.toLowerCase()}`);
 }
 
-function resolveElement(
-    scannedElement: ScannedPolymerElement, document: Document): PolymerElement {
-  const element = new PolymerElement();
-  element.privacy = scannedElement.privacy;
-  applySuperClass(element, scannedElement, document);
-  applyMixins(element, scannedElement, document);
-
-  //
-  // Behaviors
-  //
-  // TODO(justinfagnani): Refactor behaviors to work like superclasses and
-  // mixins and be applied before own members
-  const {warnings, behaviors} =
-      getBehaviors(scannedElement.behaviorAssignments, document);
-
-  // This has the combined effects of copying the array of warnings from the
-  // ScannedElement, and adding in any new ones found when resolving behaviors.
-  element.warnings = element.warnings.concat(warnings);
-
-  for (const behavior of behaviors) {
-    inheritFrom(element, behavior);
-  }
-
-  applySelf(element, scannedElement, document);
-
-  const domModules = scannedElement.tagName == null ?
-      new Set<DomModule>() :
-      document.getFeatures({
-        kind: 'dom-module',
-        id: scannedElement.tagName,
-        imported: true,
-        externalPackages: true
-      });
-  let domModule = undefined;
-  if (domModules.size === 1) {
-    // TODO(rictic): warn if this isn't true.
-    domModule = domModules.values().next().value;
-  }
-
-
-  if (domModule) {
-    element.description = element.description || domModule.comment || '';
-    element.domModule = domModule.node;
-    element.slots = domModule.slots.slice();
-    element.localIds = domModule.localIds.slice();
-  }
-
-  if (scannedElement.pseudo) {
-    element.kinds.add('pseudo-element');
-  }
-
-  for (const method of element.methods) {
-    // methods are only public by default if they're documented.
-    method.privacy = getOrInferPrivacy(method.name, method.jsdoc, true);
-  }
-
-  return element;
-}
-
-/**
- * Note: mutates `element`.
- */
-function inheritFrom(element: PolymerElement, superElement: PolymerExtension) {
-  // TODO(rictic): we don't inherit private members, but we should check for
-  //     clashes between them, as that can cause issues at runtime.
-
-  const superName = getSuperName(superElement);
-  _overwriteInherited(
-      element.properties,
-      superElement.properties,
-      superName,
-      element.warnings,
-      element.sourceRange);
-  _overwriteInherited(
-      element.methods,
-      superElement.methods,
-      superName,
-      element.warnings,
-      element.sourceRange);
-  _overwriteInherited(
-      element.attributes,
-      superElement.attributes,
-      superName,
-      element.warnings,
-      element.sourceRange);
-  _overwriteInherited(
-      element.events,
-      superElement.events,
-      superName,
-      element.warnings,
-      element.sourceRange);
-
-  // TODO(justinfagnani): slots, listeners, observers, dom-module?
-  // What actually inherits?
-}
 
 export interface PropertyLike {
   name: string;
@@ -363,236 +312,11 @@ export interface PropertyLike {
   privacy?: Privacy;
 }
 
-/**
- * This method is applied to an array of members to overwrite members lower in
- * the prototype graph (closer to Object) with members higher up (closer to the
- * final class we're constructing).
- *
- * @param . existing The array of members so far. N.B. *This param is mutated.*
- * @param . overriding The array of members from this new, higher prototype in
- *   the graph
- * @param . overridingClassName The name of the prototype whose members are
- *   being applied over the existing ones. Should be `undefined` when
- *   applyingSelf is true
- * @param . warnings Place to put generated warnings.
- * @param . sourceRange A source range to use for warnings when the inheritance
- *   goes wrong but there's no more specific source range.
- * @param . applyingSelf True on the last call to this method, when we're
- *   applying the class's own local members.
- */
-export function _overwriteInherited<P extends PropertyLike>(
-    existing: P[],
-    overriding: P[],
-    overridingClassName: string | undefined,
-    warnings: Warning[],
-    sourceRange: SourceRange,
-    applyingSelf = false) {
-  // This exists to treat the arrays as maps.
-  // TODO(rictic): convert these arrays to maps.
-  const existingIndexByName =
-      new Map(existing.map((e, idx) => [e.name, idx] as [string, number]));
-  for (const overridingVal of overriding) {
-    const newVal = Object.assign({}, overridingVal, {
-      inheritedFrom: overridingVal['inheritedFrom'] || overridingClassName
-    });
-    if (existingIndexByName.has(overridingVal.name)) {
-      /**
-       * TODO(rictic): if existingVal.privacy is protected, newVal should be
-       *    protected unless an explicit privacy was specified.
-       *    https://github.com/Polymer/polymer-analyzer/issues/631
-       */
-      const existingIndex = existingIndexByName.get(overridingVal.name)!;
-      const existingValue = existing[existingIndex]!;
-      if (existingValue.privacy === 'private') {
-        let warningSourceRange = sourceRange;
-        if (applyingSelf) {
-          warningSourceRange = newVal.sourceRange || sourceRange;
-        }
-        warnings.push({
-          code: 'overriding-private',
-          message: `Overriding private member '${overridingVal.name}' ` +
-              `inherited from ${existingValue.inheritedFrom || 'parent'}`,
-          sourceRange: warningSourceRange,
-          severity: Severity.WARNING
-        });
-      }
-      existing[existingIndex] = newVal;
-      continue;
-    }
-    existing.push(newVal);
-  }
-}
-
-function applySelf(
-    element: PolymerElement,
-    scannedElement: ScannedPolymerElement,
-    document: Document) {
-  // TODO(justinfagnani): Copy over all properties better, or have
-  // PolymerElement wrap ScannedPolymerElement.
-  element.abstract = scannedElement.abstract;
-  element.astNode = scannedElement.astNode;
-  scannedElement.behaviorAssignments.forEach(
-      (o) => element.behaviorAssignments.push(o));
-  element.className = scannedElement.className;
-  scannedElement.demos.forEach((o) => element.demos.push(o));
-  element.description = scannedElement.description;
-  element.domModule = scannedElement.domModule;
-  scannedElement.events.forEach((o) => element.events.push(o));
-  element.extends = scannedElement.extends;
-  element.jsdoc = scannedElement.jsdoc;
-  scannedElement.listeners.forEach((o) => element.listeners.push(o));
-  scannedElement.observers.forEach((o) => element.observers.push(o));
-  element.scriptElement = scannedElement.scriptElement;
-  scannedElement.slots.forEach((o) => element.slots.push(o));
-  element.sourceRange = scannedElement.sourceRange!;
-  element.summary = scannedElement.summary;
-  element.superClass =
-      scannedElement.superClass && scannedElement.superClass.resolve(document);
-  element.tagName = scannedElement.tagName;
-  scannedElement.warnings.forEach((o) => element.warnings.push(o));
-
-  _overwriteInherited(
-      element.properties,
-      scannedElement.properties as PolymerProperty[],
-      undefined,
-      element.warnings,
-      element.sourceRange,
-      true);
-  _overwriteInherited(
-      element.attributes,
-      scannedElement.attributes as Attribute[],
-      undefined,
-      element.warnings,
-      element.sourceRange,
-      true);
-  _overwriteInherited(
-      element.methods,
-      scannedElement.methods as Method[],
-      undefined,
-      element.warnings,
-      element.sourceRange,
-      true);
-  _overwriteInherited(
-      element.events,
-      scannedElement.events as Event[],
-      undefined,
-      element.warnings,
-      element.sourceRange,
-      true);
-}
-
-function applySuperClass(
-    element: PolymerElement,
-    scannedElement: ScannedElement,
-    document: Document) {
-  if (scannedElement.superClass &&
-      scannedElement.superClass.identifier !== 'HTMLElement') {
-    const superElements = document.getFeatures({
-      kind: 'element',
-      id: scannedElement.superClass.identifier,
-      externalPackages: true,
-      imported: true,
-    });
-    if (superElements.size === 1) {
-      const superElement = superElements.values().next().value;
-      if (!superElement.kinds.has('polymer-element')) {
-        element.warnings.push({
-          message:
-              `A Polymer element can\'t extend from a non-Polymer element: ` +
-              `${scannedElement.superClass.identifier}`,
-          severity: Severity.ERROR,
-          code: 'unknown-superclass',
-          sourceRange: scannedElement.superClass.sourceRange!,
-        });
-      } else {
-        inheritFrom(element, superElement as PolymerElement);
-      }
-    } else {
-      if (superElements.size === 0) {
-        element.warnings.push({
-          message: `Unable to resolve superclass ${
-                                                   scannedElement.superClass
-                                                       .identifier
-                                                 }`,
-          severity: Severity.ERROR,
-          code: 'unknown-superclass',
-          sourceRange: scannedElement.superClass.sourceRange!,
-        });
-      } else {
-        element.warnings.push({
-          message: `Multiple superclasses found for ${
-                                                      scannedElement.superClass
-                                                          .identifier
-                                                    }`,
-          severity: Severity.ERROR,
-          code: 'unknown-superclass',
-          sourceRange: scannedElement.superClass.sourceRange!,
-        });
-      }
-    }
-  }
-}
-
-export function applyMixins(
-    element: PolymerElement,
-    scannedElement: ScannedElement,
-    document: Document) {
-  for (const scannedMixinReference of scannedElement.mixins) {
-    const mixinReference = scannedMixinReference.resolve(document);
-    const mixinId = mixinReference.identifier;
-    element.mixins.push(mixinReference);
-    const mixins = document.getFeatures({
-      kind: 'element-mixin',
-      id: mixinId,
-      externalPackages: true,
-      imported: true,
-    });
-    if (mixins.size === 0) {
-      element.warnings.push({
-        message: `@mixes reference not found: ${mixinId}.` +
-            `Did you import it? Is it annotated with @polymerMixin?`,
-        severity: Severity.ERROR,
-        code: 'mixes-reference-not-found',
-        sourceRange: scannedMixinReference.sourceRange!,
-      });
-      continue;
-    } else if (mixins.size > 1) {
-      element.warnings.push({
-        message: `@mixes reference, multiple mixins found ${mixinId}`,
-        severity: Severity.ERROR,
-        code: 'mixes-reference-multiple-found',
-        sourceRange: scannedMixinReference.sourceRange!,
-      });
-      continue;
-    }
-    const mixin = mixins.values().next().value;
-    if (!(mixin instanceof PolymerElementMixin)) {
-      element.warnings.push({
-        message: `@mixes reference to a non-Mixin ${mixinId}`,
-        severity: Severity.ERROR,
-        code: 'mixes-reference-non-mixin',
-        sourceRange: scannedMixinReference.sourceRange!,
-      });
-      continue;
-    }
-    inheritFrom(element, mixin as PolymerElementMixin);
-  }
-}
-
-// TODO(justinfagnani): move to Behavior
 export function getBehaviors(
-    behaviorAssignments: ScannedBehaviorAssignment[], document: Document) {
-  const resolvedBehaviors = new Set<Behavior>();
-  const warnings = _getFlattenedAndResolvedBehaviors(
-      behaviorAssignments, document, resolvedBehaviors);
-  return {behaviors: resolvedBehaviors, warnings};
-}
-
-function _getFlattenedAndResolvedBehaviors(
-    behaviorAssignments: ScannedBehaviorAssignment[],
-    document: Document,
-    resolvedBehaviors: Set<Behavior>) {
+    behaviorAssignments: ImmutableArray<ScannedBehaviorAssignment>,
+    document: Document) {
   const warnings: Warning[] = [];
+  const behaviors: Behavior[] = [];
   for (const behavior of behaviorAssignments) {
     const foundBehaviors = document.getFeatures({
       kind: 'behavior',
@@ -623,26 +347,7 @@ function _getFlattenedAndResolvedBehaviors(
       // declared instance.
     }
     const foundBehavior = Array.from(foundBehaviors)[foundBehaviors.size - 1];
-    if (resolvedBehaviors.has(foundBehavior)) {
-      continue;
-    }
-    resolvedBehaviors.add(foundBehavior);
-    // Note that we don't care about warnings from transitively resolved
-    // behaviors. Those should become warnings on those behaviors themselves.
-    _getFlattenedAndResolvedBehaviors(
-        foundBehavior.behaviorAssignments, document, resolvedBehaviors);
+    behaviors.push(foundBehavior);
   }
-  return warnings;
-}
-
-function getSuperName(superElement: PolymerExtension|
-                      ScannedPolymerElement): string|undefined {
-  // TODO(justinfagnani): Mixins, elements and functions should all have a
-  // name property.
-  if (superElement instanceof PolymerElement ||
-      superElement instanceof ScannedPolymerElement) {
-    return superElement.className;
-  } else if (superElement instanceof PolymerElementMixin) {
-    return superElement.name;
-  }
+  return {warnings, behaviors};
 }

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -276,9 +276,9 @@ export class PolymerElement extends Element implements PolymerExtension {
     return {polymer: polymerMetadata};
   }
 
-  protected _getPrototypeChain(
+  protected _getSuperclassAndMixins(
       document: Document, init: ScannedPolymerElement) {
-    const prototypeChain = super._getPrototypeChain(document, init);
+    const prototypeChain = super._getSuperclassAndMixins(document, init);
 
     const {warnings, behaviors} =
         getBehaviors(init.behaviorAssignments, document);

--- a/src/test/editor-service/editor-service_test.ts
+++ b/src/test/editor-service/editor-service_test.ts
@@ -81,18 +81,18 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
     kind: 'attributes',
     attributes: [
       {
-        name: 'inherit-please',
-        description: 'A property provided by SimpleBehavior.',
-        type: 'number',
-        sortKey: 'ddd-inherit-please',
-        inheritedFrom: 'MyNamespace.SimpleBehavior',
-      },
-      {
         name: 'deeply-inherited-property',
         description: 'This is a deeply inherited property.',
         type: 'Array',
         sortKey: 'ddd-deeply-inherited-property',
         inheritedFrom: 'MyNamespace.SubBehavior',
+      },
+      {
+        name: 'inherit-please',
+        description: 'A property provided by SimpleBehavior.',
+        type: 'number',
+        sortKey: 'ddd-inherit-please',
+        inheritedFrom: 'MyNamespace.SimpleBehavior',
       },
       {
         name: 'local-property',
@@ -102,19 +102,19 @@ function editorTests(editorFactory: (basedir: string) => EditorService) {
         inheritedFrom: undefined,
       },
       {
-        name: 'on-inherit-please-changed',
-        description: 'Fired when the `inheritPlease` property changes.',
-        type: 'CustomEvent',
-        sortKey: 'eee-ddd-on-inherit-please-changed',
-        inheritedFrom: 'MyNamespace.SimpleBehavior',
-      },
-      {
         name: 'on-deeply-inherited-property-changed',
         description:
             'Fired when the `deeplyInheritedProperty` property changes.',
         type: 'CustomEvent',
         sortKey: 'eee-ddd-on-deeply-inherited-property-changed',
         inheritedFrom: 'MyNamespace.SubBehavior',
+      },
+      {
+        name: 'on-inherit-please-changed',
+        description: 'Fired when the `inheritPlease` property changes.',
+        type: 'CustomEvent',
+        sortKey: 'eee-ddd-on-inherit-please-changed',
+        inheritedFrom: 'MyNamespace.SimpleBehavior',
       },
       {
         name: 'on-local-property-changed',

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -424,7 +424,11 @@ namespaced name.`,
               {
                 name: 'customInstanceFunctionWithParams',
                 description: '',
-                params: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
+                params: [
+                  {name: 'a', type: undefined, description: undefined},
+                  {name: 'b', type: undefined, description: undefined},
+                  {name: 'c', type: undefined, description: undefined}
+                ],
                 return: undefined,
               },
               {
@@ -437,10 +441,7 @@ namespaced name.`,
                     type: 'Number',
                     description: 'The first argument',
                   },
-                  {
-                    name: 'b',
-                    type: 'Number',
-                  },
+                  {name: 'b', type: 'Number', description: undefined},
                   {
                     name: 'c',
                     type: 'Number',

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -62,7 +62,20 @@ suite('Polymer2MixinScanner', () => {
     }
     const methods = [];
     for (const {name, params, return: r} of mixin.methods) {
-      methods.push({name, params, return: r});
+      let processedParams = undefined;
+      if (params) {
+        processedParams = params.map(({name, type, description}) => {
+          const result: any = {name};
+          if (type != null) {
+            result.type = type;
+          }
+          if (description != null) {
+            result.description = description;
+          }
+          return result;
+        });
+      }
+      methods.push({name, return: r, params: processedParams});
     }
     const {name, description, summary} = mixin;
     return {

--- a/src/test/static/analysis/behaviors/analysis.json
+++ b/src/test/static/analysis/behaviors/analysis.json
@@ -2,35 +2,13 @@
   "schema_version": "1.0.0",
   "elements": [
     {
-      "tagname": "behavior-test-elem",
       "description": "An element to test out behavior inheritance.",
       "summary": "",
-      "superclass": "HTMLElement",
       "path": "elementdir/element.html",
-      "privacy": "public",
       "attributes": [
-        {
-          "name": "inherit-please",
-          "description": "A property provided by SimpleBehavior.",
-          "inheritedFrom": "MyNamespace.SimpleBehavior",
-          "sourceRange": {
-            "file": "../behavior.html",
-            "start": {
-              "line": 11,
-              "column": 6
-            },
-            "end": {
-              "line": 15,
-              "column": 7
-            }
-          },
-          "type": "number",
-          "metadata": {}
-        },
         {
           "name": "deeply-inherited-property",
           "description": "This is a deeply inherited property.",
-          "inheritedFrom": "MyNamespace.SubBehavior",
           "sourceRange": {
             "file": "../subdir/subbehavior.html",
             "start": {
@@ -42,8 +20,27 @@
               "column": 7
             }
           },
+          "metadata": {},
           "type": "Array",
-          "metadata": {}
+          "inheritedFrom": "MyNamespace.SubBehavior"
+        },
+        {
+          "name": "inherit-please",
+          "description": "A property provided by SimpleBehavior.",
+          "sourceRange": {
+            "file": "../behavior.html",
+            "start": {
+              "line": 11,
+              "column": 6
+            },
+            "end": {
+              "line": 15,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "number",
+          "inheritedFrom": "MyNamespace.SimpleBehavior"
         },
         {
           "name": "local-property",
@@ -58,41 +55,16 @@
               "column": 7
             }
           },
-          "type": "boolean",
-          "metadata": {}
+          "metadata": {},
+          "type": "boolean"
         }
       ],
       "properties": [
-        {
-          "name": "inheritPlease",
-          "type": "number",
-          "description": "A property provided by SimpleBehavior.",
-          "privacy": "public",
-          "inheritedFrom": "MyNamespace.SimpleBehavior",
-          "sourceRange": {
-            "file": "../behavior.html",
-            "start": {
-              "line": 11,
-              "column": 6
-            },
-            "end": {
-              "line": 15,
-              "column": 7
-            }
-          },
-          "defaultValue": "10",
-          "metadata": {
-            "polymer": {
-              "notify": true
-            }
-          }
-        },
         {
           "name": "deeplyInheritedProperty",
           "type": "Array",
           "description": "This is a deeply inherited property.",
           "privacy": "public",
-          "inheritedFrom": "MyNamespace.SubBehavior",
           "sourceRange": {
             "file": "../subdir/subbehavior.html",
             "start": {
@@ -104,12 +76,37 @@
               "column": 7
             }
           },
-          "defaultValue": "[]",
           "metadata": {
             "polymer": {
               "notify": true
             }
-          }
+          },
+          "defaultValue": "[]",
+          "inheritedFrom": "MyNamespace.SubBehavior"
+        },
+        {
+          "name": "inheritPlease",
+          "type": "number",
+          "description": "A property provided by SimpleBehavior.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../behavior.html",
+            "start": {
+              "line": 11,
+              "column": 6
+            },
+            "end": {
+              "line": 15,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "10",
+          "inheritedFrom": "MyNamespace.SimpleBehavior"
         },
         {
           "name": "localProperty",
@@ -126,12 +123,12 @@
               "column": 7
             }
           },
-          "defaultValue": "true",
           "metadata": {
             "polymer": {
               "notify": true
             }
-          }
+          },
+          "defaultValue": "true"
         },
         {
           "name": "_protectedProperty",
@@ -148,10 +145,10 @@
               "column": 7
             }
           },
-          "defaultValue": "\"do cool stuff with me!\"",
           "metadata": {
             "polymer": {}
-          }
+          },
+          "defaultValue": "\"do cool stuff with me!\""
         },
         {
           "name": "__privateProperty",
@@ -168,10 +165,10 @@
               "column": 7
             }
           },
-          "defaultValue": "\"don't look!\"",
           "metadata": {
             "polymer": {}
-          }
+          },
+          "defaultValue": "\"don't look!\""
         }
       ],
       "methods": [
@@ -189,8 +186,8 @@
               "column": 5
             }
           },
-          "params": [],
-          "metadata": {}
+          "metadata": {},
+          "params": []
         }
       ],
       "styling": {
@@ -201,23 +198,23 @@
       "slots": [],
       "events": [
         {
-          "name": "inherit-please-changed",
-          "description": "Fired when the `inheritPlease` property changes.",
-          "inheritedFrom": "MyNamespace.SimpleBehavior",
           "type": "CustomEvent",
-          "metadata": {}
-        },
-        {
           "name": "deeply-inherited-property-changed",
           "description": "Fired when the `deeplyInheritedProperty` property changes.",
-          "inheritedFrom": "MyNamespace.SubBehavior",
-          "type": "CustomEvent",
-          "metadata": {}
+          "metadata": {},
+          "inheritedFrom": "MyNamespace.SubBehavior"
         },
         {
+          "type": "CustomEvent",
+          "name": "inherit-please-changed",
+          "description": "Fired when the `inheritPlease` property changes.",
+          "metadata": {},
+          "inheritedFrom": "MyNamespace.SimpleBehavior"
+        },
+        {
+          "type": "CustomEvent",
           "name": "local-property-changed",
           "description": "Fired when the `localProperty` property changes.",
-          "type": "CustomEvent",
           "metadata": {}
         }
       ],
@@ -231,14 +228,16 @@
           "line": 29,
           "column": 3
         }
-      }
+      },
+      "privacy": "public",
+      "tagname": "behavior-test-elem",
+      "superclass": "HTMLElement"
     }
   ],
   "metadata": {
     "polymer": {
       "behaviors": [
         {
-          "name": "MyNamespace.SubBehavior",
           "description": "A simple sub-behavior description.",
           "summary": "",
           "path": "subdir/subbehavior.html",
@@ -310,14 +309,32 @@
               "column": 3
             }
           },
-          "privacy": "public"
+          "privacy": "public",
+          "name": "MyNamespace.SubBehavior"
         },
         {
-          "name": "MyNamespace.SimpleBehavior",
           "description": "A simple behavior description.",
           "summary": "",
           "path": "behavior.html",
           "attributes": [
+            {
+              "name": "deeply-inherited-property",
+              "description": "This is a deeply inherited property.",
+              "sourceRange": {
+                "file": "subdir/subbehavior.html",
+                "start": {
+                  "line": 8,
+                  "column": 6
+                },
+                "end": {
+                  "line": 14,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "type": "Array",
+              "inheritedFrom": "MyNamespace.SubBehavior"
+            },
             {
               "name": "inherit-please",
               "description": "A property provided by SimpleBehavior.",
@@ -336,6 +353,30 @@
             }
           ],
           "properties": [
+            {
+              "name": "deeplyInheritedProperty",
+              "type": "Array",
+              "description": "This is a deeply inherited property.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "subdir/subbehavior.html",
+                "start": {
+                  "line": 8,
+                  "column": 6
+                },
+                "end": {
+                  "line": 14,
+                  "column": 7
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true
+                }
+              },
+              "defaultValue": "[]",
+              "inheritedFrom": "MyNamespace.SubBehavior"
+            },
             {
               "name": "inheritPlease",
               "type": "number",
@@ -369,6 +410,13 @@
           "events": [
             {
               "type": "CustomEvent",
+              "name": "deeply-inherited-property-changed",
+              "description": "Fired when the `deeplyInheritedProperty` property changes.",
+              "metadata": {},
+              "inheritedFrom": "MyNamespace.SubBehavior"
+            },
+            {
+              "type": "CustomEvent",
               "name": "inherit-please-changed",
               "description": "Fired when the `inheritPlease` property changes.",
               "metadata": {}
@@ -385,7 +433,8 @@
               "column": 4
             }
           },
-          "privacy": "public"
+          "privacy": "public",
+          "name": "MyNamespace.SimpleBehavior"
         }
       ]
     }

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -34,9 +34,8 @@ export class WarningPrinter {
   _chalk: chalk.Chalk;
   private _options: Options;
 
-  constructor(private _outStream: NodeJS.WritableStream, _options?: Options) {
-    this._options =
-        Object.assign({}, defaultPrinterOptions, _options) as Options;
+  constructor(private _outStream: NodeJS.WritableStream, options: Options) {
+    this._options = Object.assign({}, defaultPrinterOptions, options);
     this._chalk = new chalk.constructor({enabled: !!this._options.color});
   }
 


### PR DESCRIPTION
Builds on top of #628 

Mark many fields readonly/immutable. Simplify element construction.

This is merely a descriptive change of how we already think of these fields.

More fields are still logically readonly/immutable, but we've got code that
initializes them in various places in a gradual way.

There is one functionality change in this PR, and that's that we treat behaviors
more like elements and more like mixins. We now mix behaviors into behaviors
and apply the same inheritance logic as mixins to behaviors.

This also makes element construction much more sane, by centralizing and documenting
how we deal with inheritance.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
