### PR TITLE
Improve privacy inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!--## Unreleased-->
+## Unreleased
+
+* [BREAKING] Improve rules for infering method privacy. Specifically, undocumented methods without an underscore pre- or postfix are now considered public (were considered private before) 
 
 ## [2.0.0-alpha.38] - 2017-04-13
 

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -159,7 +159,7 @@ class BehaviorVisitor implements Visitor {
       description: comment,
       events: esutil.getEventComments(node),
       sourceRange: this.document.sourceRangeForNode(node),
-      privacy: getOrInferPrivacy(symbol, parsedJsdocs, false),
+      privacy: getOrInferPrivacy(symbol, parsedJsdocs, true, 'public'),
     }));
     const behavior = this.currentBehavior!;
 
@@ -176,7 +176,7 @@ class BehaviorVisitor implements Visitor {
     }
 
     behavior.privacy =
-        getOrInferPrivacy(behavior.className, behavior.jsdoc, false);
+        getOrInferPrivacy(behavior.className, behavior.jsdoc, true, 'public');
     this._parseChainedBehaviors(node);
 
     this.currentBehavior = this.mergeBehavior(behavior);

--- a/src/polymer/js-utils.ts
+++ b/src/polymer/js-utils.ts
@@ -59,7 +59,7 @@ export function toScannedPolymerProperty(
     astNode: node,
     isConfiguration: configurationProperties.has(name),
     jsdoc: parsedJsdoc,
-    privacy: getOrInferPrivacy(name, parsedJsdoc, false)
+    privacy: getOrInferPrivacy(name, parsedJsdoc, true)
   };
 
   return result;
@@ -146,30 +146,26 @@ export function toScannedMethod(
 export function getOrInferPrivacy(
     name: string,
     annotation: jsdoc.Annotation|undefined,
-    privateUnlessDocumented: boolean): Privacy {
+    inferFromName = true,
+    defaultPrivacy: Privacy = 'private'): Privacy {
   const explicitPrivacy = jsdoc.getPrivacy(annotation);
   const specificName = name.slice(name.lastIndexOf('.') + 1);
 
   if (explicitPrivacy) {
     return explicitPrivacy;
-  } else if (specificName.startsWith('__')) {
-    return 'private';
-  } else if (specificName.startsWith('_')) {
-    return 'protected';
-  } else if (specificName.endsWith('_')) {
-    return 'private';
-  } else if (configurationProperties.has(specificName)) {
-    return 'protected';
-  } else {
-    if (privateUnlessDocumented) {
-      // Some members, like methods or properties on classes are private by
-      // default unless they have documentation.
-      const hasDocs = !!annotation && !jsdoc.isAnnotationEmpty(annotation);
-      return hasDocs ? 'public' : 'private';
+  } else if (inferFromName) {
+    if (specificName.startsWith('__')) {
+      return 'private';
+    } else if (specificName.startsWith('_')) {
+      return 'protected';
+    } else if (specificName.endsWith('_')) {
+      return 'private';
+    } else if (configurationProperties.has(specificName)) {
+      return 'protected';
     } else {
-      // Other members, like entries in the Polymer `properties` block are
-      // public unless there are clear signals otherwise.
       return 'public';
     }
+  } else {
+    return defaultPrivacy;
   }
 }

--- a/src/polymer/polymer-element-mixin.ts
+++ b/src/polymer/polymer-element-mixin.ts
@@ -67,7 +67,7 @@ export class ScannedPolymerElementMixin extends ScannedElementMixin implements
     Object.assign(element, this);
 
     for (const method of element.methods) {
-      // methods are only public by default if they're documented.
+      // Method privacy is infered from function names unless specifically defined in jsdoc
       method.privacy = getOrInferPrivacy(method.name, method.jsdoc, true);
     }
     element.mixins = [];

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -64,7 +64,7 @@ class ElementVisitor implements Visitor {
       description: docs.description,
       events: getEventComments(node),
       sourceRange: this.document.sourceRangeForNode(node), className,
-      privacy: getOrInferPrivacy(className, docs, false)
+      privacy: getOrInferPrivacy(className, docs, false, 'public')
     });
     this.propertyHandlers =
         declarationPropertyHandlers(this.element, this.document);
@@ -188,7 +188,7 @@ class ElementVisitor implements Visitor {
           description: rawDescription,
           events: getEventComments(parent),
           sourceRange: this.document.sourceRangeForNode(node.arguments[0]),
-          privacy: getOrInferPrivacy('', jsDoc, false)
+          privacy: getOrInferPrivacy('', jsDoc, false, 'public')
         });
         docs.annotate(this.element);
         this.element.description = (this.element.description || '').trim();

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -320,7 +320,7 @@ function resolveElement(
   }
 
   for (const method of element.methods) {
-    // methods are only public by default if they're documented.
+    // Method privacy is infered from function names unless specifically defined in jsdoc
     method.privacy = getOrInferPrivacy(method.name, method.jsdoc, true);
   }
 

--- a/src/polymer/polymer2-element-scanner.ts
+++ b/src/polymer/polymer2-element-scanner.ts
@@ -162,7 +162,7 @@ export class Polymer2ElementScanner implements JavaScriptScanner {
         methods: getMethods(node, document),
         superClass: this._getExtends(node, docs, warnings, document),
         mixins: jsdoc.getMixins(document, node, docs, warnings),
-        privacy: getOrInferPrivacy(className || '', docs, false),
+        privacy: getOrInferPrivacy(className || '', docs, false, 'private'),
         observers: observers,
         jsdoc: docs,
       });
@@ -188,7 +188,7 @@ export class Polymer2ElementScanner implements JavaScriptScanner {
         description: (docs.description || '').trim(),
         superClass: this._getExtends(node, docs, warnings, document),
         mixins: jsdoc.getMixins(document, node, docs, warnings),
-        privacy: getOrInferPrivacy(className || '', docs, false),
+        privacy: getOrInferPrivacy(className || '', docs, false, 'private'),
         events: [],
         properties: [],
         methods: [],

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -72,7 +72,7 @@ class MixinVisitor implements Visitor {
           astNode: node,
           description: parentJsDocs.description,
           summary: (summaryTag && summaryTag.description) || '',
-          privacy: getOrInferPrivacy(namespacedName, parentJsDocs, false),
+          privacy: getOrInferPrivacy(namespacedName, parentJsDocs, true, 'public'),
           jsdoc: parentJsDocs,
           mixins: jsdoc.getMixins(
               this._document, node, parentJsDocs, this._warnings),
@@ -105,7 +105,7 @@ class MixinVisitor implements Visitor {
           astNode: node,
           description: nodeJsDocs.description,
           summary: (summaryTag && summaryTag.description) || '',
-          privacy: getOrInferPrivacy(namespacedName, nodeJsDocs, false),
+          privacy: getOrInferPrivacy(namespacedName, nodeJsDocs, true, 'public'),
           jsdoc: nodeJsDocs,
           mixins:
               jsdoc.getMixins(this._document, node, nodeJsDocs, this._warnings)
@@ -147,7 +147,7 @@ class MixinVisitor implements Visitor {
             astNode: node,
             description: docs.description,
             summary: (summaryTag && summaryTag.description) || '',
-            privacy: getOrInferPrivacy(namespacedName, docs, false),
+            privacy: getOrInferPrivacy(namespacedName, docs, true, 'public'),
             jsdoc: docs,
             mixins: jsdoc.getMixins(
                 this._document, declaration, docs, this._warnings)

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -50,7 +50,7 @@ export class PseudoElementScanner implements HtmlScanner {
             properties: [],
             description: parsedJsdoc.description,
             sourceRange: document.sourceRangeForNode(node),
-            privacy: getOrInferPrivacy(pseudoTag, parsedJsdoc, false)
+            privacy: getOrInferPrivacy(pseudoTag, parsedJsdoc, false, 'public')
           });
           element.pseudo = true;
           annotateElementHeader(element);

--- a/src/test/static/analysis/mixins/analysis.json
+++ b/src/test/static/analysis/mixins/analysis.json
@@ -145,7 +145,7 @@
         {
           "name": "frob",
           "description": "",
-          "privacy": "private",
+          "privacy": "public",
           "sourceRange": {
             "start": {
               "line": 42,

--- a/src/test/static/analysis/simple/analysis.json
+++ b/src/test/static/analysis/simple/analysis.json
@@ -167,7 +167,7 @@
         {
           "name": "customFunction",
           "description": "",
-          "privacy": "private",
+          "privacy": "public",
           "sourceRange": {
             "start": {
               "line": 24,


### PR DESCRIPTION
Updates the rules for inferring the privacy of javascript entities as described in https://github.com/Polymer/polymer-analyzer/issues/586. Specifically, undocumented methods without an underscore pre- or postfix are now considered public (were considered private before).

Fixes #586 
