### PR TITLE
Emit warnings from scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Add a Class feature kind for describing all kinds of classes. This is a superclass of the existing elements and mixins.
-
-## [2.0.0-alpha.38] - 2017-04-13
-
-* [minor breaking change] Revert of a change from alpha.37. The experimental `_fork` method on Analyzer returns an Analyzer again, not a Promise of an Analyzer.
 * Mix mixins into mixins. A PolymerElementMixin now has all of the members it inherits other mixins it mixes.
 * Improved our modeling of inheritance:
   * overriding inherited members now works correctly
   * overriding a private member produces a Warning
 * Documented many fields as being readonly/immutable. This isn't complete, in fact all features and scanned features should be treated as immutable once they're created and initialized.
 * Treat behaviors more like mixins, and treat using behaviors more like inheriting from mixins. This means that a Behavior object knows about all of the properties, methods, etc that it has inherited from other Behaviors that it builds upon.
+* Emit more warnings when recognizing mixins, elements, and classes.
+
+## [2.0.0-alpha.38] - 2017-04-13
+
+* [minor breaking change] Revert of a change from alpha.37. The experimental `_fork` method on Analyzer returns an Analyzer again, not a Promise of an Analyzer.
 
 ## [2.0.0-alpha.37] - 2017-04-12
 

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -27,7 +27,7 @@ import {FunctionScanner} from '../javascript/function-scanner';
 import {JavaScriptParser} from '../javascript/javascript-parser';
 import {NamespaceScanner} from '../javascript/namespace-scanner';
 import {JsonParser} from '../json/json-parser';
-import {Document, InlineDocInfo, LocationOffset, ScannedDocument, ScannedElement, ScannedFeature, ScannedImport, ScannedInlineDocument, Warning, WarningCarryingException} from '../model/model';
+import {Document, InlineDocInfo, LocationOffset, ScannedDocument, ScannedElement, ScannedImport, ScannedInlineDocument, Warning, WarningCarryingException} from '../model/model';
 import {ParsedDocument} from '../parser/document';
 import {Parser} from '../parser/parser';
 import {BehaviorScanner} from '../polymer/behavior-scanner';
@@ -358,8 +358,8 @@ export class AnalysisContext {
   private async _scanDocument(
       document: ParsedDocument<any, any>,
       maybeAttachedComment?: string): Promise<ScannedDocument> {
-    const warnings: Warning[] = [];
-    const scannedFeatures = await this._getScannedFeatures(document);
+    const {features: scannedFeatures, warnings} =
+        await this._getScannedFeatures(document);
     // If there's an HTML comment that applies to this document then we assume
     // that it applies to the first feature.
     const firstScannedFeature = scannedFeatures[0];
@@ -381,13 +381,12 @@ export class AnalysisContext {
     return scannedDocument;
   }
 
-  private async _getScannedFeatures(document: ParsedDocument<any, any>):
-      Promise<ScannedFeature[]> {
+  private async _getScannedFeatures(document: ParsedDocument<any, any>) {
     const scanners = this._scanners.get(document.type);
     if (scanners) {
       return scan(document, scanners);
     }
-    return [];
+    return {features: [], warnings: []};
   }
 
   private async _scanInlineDocuments(containingDocument: ScannedDocument) {

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -33,8 +33,7 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
 
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedElementReference[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const elements: ScannedElementReference[] = [];
 
     const visitor = (node: ASTNode) => {
@@ -73,7 +72,7 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
 
     await visit(visitor);
 
-    return elements;
+    return {features: elements, warnings: []};
   }
 }
 

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -72,7 +72,7 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
 
     await visit(visitor);
 
-    return {features: elements, warnings: []};
+    return {features: elements};
   }
 }
 

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -82,6 +82,6 @@ export class HtmlImportScanner implements HtmlScanner {
         }
       }
     }
-    return {features: imports, warnings: []};
+    return {features: imports};
   }
 }

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -50,8 +50,7 @@ export class HtmlImportScanner implements HtmlScanner {
 
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedImport[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const imports: ScannedImport[] = [];
 
     const type = 'html-import';
@@ -83,6 +82,6 @@ export class HtmlImportScanner implements HtmlScanner {
         }
       }
     }
-    return imports;
+    return {features: imports, warnings: []};
   }
 }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -15,7 +15,7 @@
 import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
-import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedFeature, ScannedImport, ScannedInlineDocument} from '../model/model';
+import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedImport, ScannedInlineDocument} from '../model/model';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
@@ -34,8 +34,7 @@ const isJsScriptNode = p.AND(
 export class HtmlScriptScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedFeature[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const features: (ScannedImport|ScannedInlineDocument)[] = [];
 
     const myVisitor: HtmlVisitor = (node) => {
@@ -68,6 +67,6 @@ export class HtmlScriptScanner implements HtmlScanner {
 
     await visit(myVisitor);
 
-    return features;
+    return {features, warnings: []};
   }
 }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -67,6 +67,6 @@ export class HtmlScriptScanner implements HtmlScanner {
 
     await visit(myVisitor);
 
-    return {features, warnings: []};
+    return {features};
   }
 }

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -67,6 +67,6 @@ export class HtmlStyleScanner implements HtmlScanner {
       }
     });
 
-    return {features, warnings: []};
+    return {features};
   }
 }

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -15,7 +15,7 @@
 import * as dom5 from 'dom5';
 import {resolve as resolveUrl} from 'url';
 
-import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedFeature, ScannedImport, ScannedInlineDocument} from '../model/model';
+import {getAttachedCommentText, getLocationOffsetOfStartOfTextContent, ScannedImport, ScannedInlineDocument} from '../model/model';
 
 import {HtmlVisitor, ParsedHtmlDocument} from './html-document';
 import {HtmlScanner} from './html-scanner';
@@ -36,8 +36,7 @@ const isStyleNode = p.OR(isStyleElement, isStyleLink);
 export class HtmlStyleScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedFeature[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const features: (ScannedImport|ScannedInlineDocument)[] = [];
 
     await visit(async(node) => {
@@ -68,6 +67,6 @@ export class HtmlStyleScanner implements HtmlScanner {
       }
     });
 
-    return features;
+    return {features, warnings: []};
   }
 }

--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -67,9 +67,8 @@ export interface ScannedAttribute extends ScannedFeature {
  */
 export class ClassScanner implements JavaScriptScanner {
   async scan(
-      document: JavaScriptDocument, visit: (visitor: Visitor) => Promise<void>):
-      Promise<Array<ScannedPolymerElement|ScannedClass|
-                    ScannedPolymerElementMixin>> {
+      document: JavaScriptDocument,
+      visit: (visitor: Visitor) => Promise<void>) {
     const classFinder = new ClassFinder(document);
     const mixinFinder = new MixinVisitor(document);
     const elementDefinitionFinder =
@@ -154,13 +153,14 @@ export class ClassScanner implements JavaScriptScanner {
       scannedFeatures.push(mixin);
     }
 
-    // TODO(rictic): gather up the warnings from these visitors and return them
-    // too.
-    // const warnings =
-    // elementDefinitionFinder.warnings.concat(
-    // mixinFinder.warnings).concat(classFinder.warnings);
-
-    return scannedFeatures;
+    return {
+      features: scannedFeatures,
+      warnings: [
+        ...elementDefinitionFinder.warnings,
+        ...classFinder.warnings,
+        ...mixinFinder.warnings
+      ]
+    };
   }
 
   private _makeElementFeature(
@@ -321,6 +321,7 @@ interface CustomElementDefinition {
  */
 class ClassFinder implements Visitor {
   readonly classes: ScannedClass[] = [];
+  readonly warnings: Warning[] = [];
   private readonly alreadyMatched = new Set<estree.ClassExpression>();
   private readonly _document: JavaScriptDocument;
 

--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -158,7 +158,7 @@ export class ClassScanner implements JavaScriptScanner {
       warnings: [
         ...elementDefinitionFinder.warnings,
         ...classFinder.warnings,
-        ...mixinFinder.warnings
+        ...mixinFinder.warnings,
       ]
     };
   }

--- a/src/javascript/function-scanner.ts
+++ b/src/javascript/function-scanner.ts
@@ -20,6 +20,7 @@ import {getAttachedComment, isFunctionType, objectKeyToString} from '../javascri
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
+import {Warning} from '../model/model';
 import {getOrInferPrivacy} from '../polymer/js-utils';
 
 import {ScannedFunction} from './function';
@@ -27,16 +28,17 @@ import {ScannedFunction} from './function';
 export class FunctionScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedFunction[]> {
+      visit: (visitor: Visitor) => Promise<void>) {
     const visitor = new FunctionVisitor(document);
     await visit(visitor);
-    return Array.from(visitor.functions);
+    return {features: Array.from(visitor.functions), warnings: []};
   }
 }
 
 class FunctionVisitor implements Visitor {
   functions = new Set<ScannedFunction>();
   document: JavaScriptDocument;
+  warnings: Warning[] = [];
 
   constructor(document: JavaScriptDocument) {
     this.document = document;

--- a/src/javascript/function-scanner.ts
+++ b/src/javascript/function-scanner.ts
@@ -31,7 +31,7 @@ export class FunctionScanner implements JavaScriptScanner {
       visit: (visitor: Visitor) => Promise<void>) {
     const visitor = new FunctionVisitor(document);
     await visit(visitor);
-    return {features: Array.from(visitor.functions), warnings: []};
+    return {features: Array.from(visitor.functions)};
   }
 }
 

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -23,7 +23,7 @@ import {ScannedImport} from '../model/model';
 export class JavaScriptImportScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedImport[]> {
+      visit: (visitor: Visitor) => Promise<void>) {
     const imports: ScannedImport[] = [];
 
     await visit({
@@ -43,7 +43,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
             false));
       }
     });
-    return imports;
+    return {features: imports, warnings: []};
   }
 }
 

--- a/src/javascript/namespace-scanner.ts
+++ b/src/javascript/namespace-scanner.ts
@@ -20,21 +20,26 @@ import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
+import {Warning} from '../model/model';
 import {ScannedNamespace} from './namespace';
 
 export class NamespaceScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedNamespace[]> {
+      visit: (visitor: Visitor) => Promise<void>) {
     const visitor = new NamespaceVisitor(document);
     await visit(visitor);
-    return Array.from(visitor.namespaces);
+    return {
+      features: Array.from(visitor.namespaces),
+      warnings: visitor.warnings
+    };
   }
 }
 
 class NamespaceVisitor implements Visitor {
   namespaces = new Set<ScannedNamespace>();
   document: JavaScriptDocument;
+  warnings: Warning[] = [];
 
   constructor(document: JavaScriptDocument) {
     this.document = document;

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -20,7 +20,7 @@ import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
-import {Severity} from '../model/model';
+import {Severity, Warning} from '../model/model';
 
 import {ScannedBehavior, ScannedBehaviorAssignment} from './behavior';
 import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
@@ -44,17 +44,20 @@ const templatizer = 'Polymer.Templatizer';
 export class BehaviorScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedBehavior[]> {
+      visit: (visitor: Visitor) => Promise<void>) {
     const visitor = new BehaviorVisitor(document);
     await visit(visitor);
-    return Array.from(visitor.behaviors);
+    return {
+      features: Array.from(visitor.behaviors),
+      warnings: visitor.warnings
+    };
   }
 }
 
 class BehaviorVisitor implements Visitor {
   /** The behaviors we've found. */
   behaviors = new Set<ScannedBehavior>();
-
+  warnings: Warning[] = [];
   currentBehavior: ScannedBehavior|null = null;
   propertyHandlers: PropertyHandlers|null = null;
 

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -31,8 +31,7 @@ const isCssImportNode = p.AND(
 export class CssImportScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedImport[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const imports: ScannedImport[] = [];
 
     await visit((node) => {
@@ -48,6 +47,6 @@ export class CssImportScanner implements HtmlScanner {
             false));
       }
     });
-    return imports;
+    return {features: imports, warnings: []};
   }
 }

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -112,8 +112,7 @@ export class DomModule implements Feature {
 export class DomModuleScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedDomModule[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const domModules: ScannedDomModule[] = [];
 
     await visit((node) => {
@@ -157,6 +156,6 @@ export class DomModuleScanner implements HtmlScanner {
             databindings));
       }
     });
-    return domModules;
+    return {features: domModules, warnings: []};
   }
 }

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -156,6 +156,6 @@ export class DomModuleScanner implements HtmlScanner {
             databindings));
       }
     });
-    return {features: domModules, warnings: []};
+    return {features: domModules};
   }
 }

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -21,7 +21,7 @@ import {getAttachedComment, getEventComments, isFunctionType, objectKeyToString}
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
-import {Severity, WarningCarryingException} from '../model/model';
+import {Severity, Warning, WarningCarryingException} from '../model/model';
 
 import {getBehaviorAssignmentOrWarning} from './declaration-property-handlers';
 import {declarationPropertyHandlers, PropertyHandlers} from './declaration-property-handlers';
@@ -32,11 +32,11 @@ import {ScannedPolymerElement, ScannedPolymerProperty} from './polymer-element';
 
 export class PolymerElementScanner implements JavaScriptScanner {
   async scan(
-      document: JavaScriptDocument, visit: (visitor: Visitor) => Promise<void>):
-      Promise<ScannedPolymerElement[]> {
+      document: JavaScriptDocument,
+      visit: (visitor: Visitor) => Promise<void>) {
     const visitor = new ElementVisitor(document);
     await visit(visitor);
-    return visitor.features;
+    return {features: visitor.features, warnings: visitor.warnings};
   }
 }
 
@@ -49,6 +49,7 @@ class ElementVisitor implements Visitor {
   element: ScannedPolymerElement|null = null;
   propertyHandlers: PropertyHandlers|null = null;
   classDetected: boolean = false;
+  warnings: Warning[] = [];
 
   document: JavaScriptDocument;
   constructor(document: JavaScriptDocument) {

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -32,8 +32,7 @@ export class MixinVisitor implements Visitor {
   private _currentMixin: ScannedPolymerElementMixin|null = null;
   private _currentMixinNode: estree.Node|null = null;
   private _currentMixinFunction: estree.BaseFunction|null = null;
-  // TODO(rictic): do something with these warnings.
-  private _warnings: Warning[] = [];
+  readonly warnings: Warning[] = [];
 
   constructor(document: JavaScriptDocument) {
     this._document = document;
@@ -64,7 +63,7 @@ export class MixinVisitor implements Visitor {
           privacy: getOrInferPrivacy(namespacedName, parentJsDocs, false),
           jsdoc: parentJsDocs,
           mixins: jsdoc.getMixins(
-              this._document, node, parentJsDocs, this._warnings),
+              this._document, node, parentJsDocs, this.warnings),
         });
         this._currentMixinNode = node;
         this.mixins.push(this._currentMixin);
@@ -97,7 +96,7 @@ export class MixinVisitor implements Visitor {
           privacy: getOrInferPrivacy(namespacedName, nodeJsDocs, false),
           jsdoc: nodeJsDocs,
           mixins:
-              jsdoc.getMixins(this._document, node, nodeJsDocs, this._warnings),
+              jsdoc.getMixins(this._document, node, nodeJsDocs, this.warnings),
         });
         this._currentMixinNode = node;
         this.mixins.push(this._currentMixin);
@@ -139,7 +138,7 @@ export class MixinVisitor implements Visitor {
             privacy: getOrInferPrivacy(namespacedName, docs, false),
             jsdoc: docs,
             mixins: jsdoc.getMixins(
-                this._document, declaration, docs, this._warnings)
+                this._document, declaration, docs, this.warnings)
           });
         }
       }

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -70,6 +70,6 @@ export class PseudoElementScanner implements HtmlScanner {
         }
       }
     });
-    return {features: elements, warnings: []};
+    return {features: elements};
   }
 }

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -32,8 +32,7 @@ import {ScannedPolymerElement} from './polymer-element';
 export class PseudoElementScanner implements HtmlScanner {
   async scan(
       document: ParsedHtmlDocument,
-      visit: (visitor: HtmlVisitor) => Promise<void>):
-      Promise<ScannedPolymerElement[]> {
+      visit: (visitor: HtmlVisitor) => Promise<void>) {
     const elements: ScannedPolymerElement[] = [];
 
     await visit((node: ASTNode) => {
@@ -71,6 +70,6 @@ export class PseudoElementScanner implements HtmlScanner {
         }
       }
     });
-    return elements;
+    return {features: elements, warnings: []};
   }
 }

--- a/src/scanning/scan.ts
+++ b/src/scanning/scan.ts
@@ -91,7 +91,9 @@ scan<AstNode, Visitor, PDoc extends ParsedDocument<AstNode, Visitor>>(
   const warnings: Warning[] = [];
   for (const {features, warnings: w} of nestedResults) {
     nestedFeatures.push(features);
-    warnings.push(...w);
+    if (w !== undefined) {
+      warnings.push(...w);
+    }
   }
 
   return {features: sortFeatures(nestedFeatures), warnings};

--- a/src/scanning/scan.ts
+++ b/src/scanning/scan.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {ImmutableArray} from '../model/immutable';
 import {ScannedFeature, Warning} from '../model/model';
 import {ParsedDocument} from '../parser/document';
 
@@ -127,8 +128,12 @@ function compareFeaturesBySourceLocation(
   return position1.column - position2.column;
 }
 
-function sortFeatures(unorderedFeatures: ScannedFeature[][]): ScannedFeature[] {
-  const allFeatures: ScannedFeature[] =
-      Array.prototype.concat.apply([], unorderedFeatures);
+function sortFeatures(
+    unorderedFeatures: ImmutableArray<ImmutableArray<ScannedFeature>>):
+    ScannedFeature[] {
+  const allFeatures = [];
+  for (const subArray of unorderedFeatures) {
+    allFeatures.push(...subArray);
+  }
   return allFeatures.sort(compareFeaturesBySourceLocation);
 }

--- a/src/scanning/scanner.ts
+++ b/src/scanning/scanner.ts
@@ -26,7 +26,7 @@ import {ParsedDocument} from '../parser/document';
  */
 export interface Scanner<D extends ParsedDocument<A, V>, A, V> {
   scan(document: D, visit: (visitor: V) => Promise<void>):
-      Promise<{features: ScannedFeature[], warnings: Warning[]}>;
+      Promise<{features: ScannedFeature[], warnings?: Warning[]}>;
 }
 
 export interface ScannerConstructor {

--- a/src/scanning/scanner.ts
+++ b/src/scanning/scanner.ts
@@ -13,7 +13,7 @@
  */
 
 import {Analyzer} from '../analyzer';
-import {ScannedFeature} from '../model/model';
+import {ScannedFeature, Warning} from '../model/model';
 import {ParsedDocument} from '../parser/document';
 
 /**
@@ -26,7 +26,7 @@ import {ParsedDocument} from '../parser/document';
  */
 export interface Scanner<D extends ParsedDocument<A, V>, A, V> {
   scan(document: D, visit: (visitor: V) => Promise<void>):
-      Promise<ScannedFeature[]>;
+      Promise<{features: ScannedFeature[], warnings: Warning[]}>;
 }
 
 export interface ScannerConstructor {

--- a/src/scanning/scanner.ts
+++ b/src/scanning/scanner.ts
@@ -13,6 +13,7 @@
  */
 
 import {Analyzer} from '../analyzer';
+import {ImmutableArray} from '../model/immutable';
 import {ScannedFeature, Warning} from '../model/model';
 import {ParsedDocument} from '../parser/document';
 
@@ -25,8 +26,10 @@ import {ParsedDocument} from '../parser/document';
  * @template V the visitor type
  */
 export interface Scanner<D extends ParsedDocument<A, V>, A, V> {
-  scan(document: D, visit: (visitor: V) => Promise<void>):
-      Promise<{features: ScannedFeature[], warnings?: Warning[]}>;
+  scan(document: D, visit: (visitor: V) => Promise<void>): Promise<{
+    features: ImmutableArray<ScannedFeature>,
+    warnings?: ImmutableArray<Warning>
+  }>;
 }
 
 export interface ScannerConstructor {

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -584,8 +584,8 @@ suite('Analyzer', () => {
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
       const context = await getContext(analyzer);
-      const features =
-          (await context['_getScannedFeatures'](document)) as ScannedImport[];
+      const features = ((await context['_getScannedFeatures'](document))
+                            .features as ScannedImport[]);
       assert.deepEqual(
           features.map((e) => e.type),
           ['html-import', 'html-script', 'html-style']);
@@ -606,8 +606,9 @@ suite('Analyzer', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const context = await getContext(analyzer);
       const features =
-          <ScannedImport[]>(await context['_getScannedFeatures'](document))
-              .filter((e) => e instanceof ScannedImport);
+          (await context['_getScannedFeatures'](document))
+              .features.filter(
+                  (e) => e instanceof ScannedImport) as ScannedImport[];
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
       assert.equal(features[0].url, 'bar.css');
@@ -620,8 +621,8 @@ suite('Analyzer', () => {
         </head></html>`;
       const context = await getContext(analyzer);
       const document = new HtmlParser().parse(contents, 'test.html');
-      const features = <ScannedInlineDocument[]>(
-          await context['_getScannedFeatures'](document));
+      const features = ((await context['_getScannedFeatures'](document))
+                            .features) as ScannedInlineDocument[];
 
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedInlineDocument);

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -41,7 +41,7 @@ suite('HtmlElementReferenceScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
 
       assert.deepEqual(
           features.map((f) => f.tagName),
@@ -78,7 +78,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
 
       assert.deepEqual(
           features.map((f) => f.tagName), ['x-foo', 'x-bar', 'x-baz']);

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -37,7 +37,7 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'html-import');
       assert.equal(features[0].url, 'polymer.html');
@@ -53,7 +53,7 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'html-import');
       assert.equal(features[0].url, '/aybabtu/polymer.html');
@@ -70,7 +70,7 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 2);
       assert.equal(features[1].type, 'html-import');
       assert.equal(features[1].url, 'lazy-polymer.html');
@@ -97,7 +97,7 @@ suite('HtmlImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.deepEqual(
           features.map((f) => f.type),
           ['html-import', 'html-import', 'html-import', 'html-import']);

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -36,7 +36,7 @@ suite('HtmlScriptScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];
@@ -56,7 +56,7 @@ suite('HtmlScriptScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];

--- a/src/test/html/html-style-scanner_test.ts
+++ b/src/test/html/html-style-scanner_test.ts
@@ -36,7 +36,7 @@ suite('HtmlStyleScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];
@@ -56,7 +56,7 @@ suite('HtmlStyleScanner', () => {
       const document = new HtmlParser().parse(contents, 'test-document.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -20,7 +20,7 @@ import {Analyzer} from '../../analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {Class, Element, ElementMixin, Method, ScannedClass, ScannedFeature} from '../../model/model';
+import {Class, Element, ElementMixin, Method, ScannedClass} from '../../model/model';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {CodeUnderliner} from '../test-utils';
 
@@ -38,11 +38,12 @@ suite('Class', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    return await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
+    return features;
   };
 
   async function getScannedClasses(filename: string): Promise<ScannedClass[]> {
-    const features: ScannedFeature[] = await getScannedFeatures(filename);
+    const features = await getScannedFeatures(filename);
     return features.filter((e) => e instanceof ScannedClass) as ScannedClass[];
   };
 

--- a/src/test/javascript/function-scanner_test.ts
+++ b/src/test/javascript/function-scanner_test.ts
@@ -20,7 +20,6 @@ import {Visitor} from '../../javascript/estree-visitor';
 import {ScannedFunction} from '../../javascript/function';
 import {FunctionScanner} from '../../javascript/function-scanner';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ScannedFeature} from '../../model/model';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 
 import {CodeUnderliner} from '../test-utils';
@@ -37,7 +36,7 @@ suite('FunctionScanner', () => {
     const scanner = new FunctionScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
-    const features: ScannedFeature[] = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     return <ScannedFunction[]>features.filter(
         (e) => e instanceof ScannedFunction);
   };

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -34,7 +34,7 @@ suite('JavaScriptImportScanner', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     assert.equal(features.length, 1);
     assert.equal(features[0].type, 'js-import');
     assert.equal(features[0].url, '/static/javascript/submodule.js');
@@ -51,7 +51,7 @@ suite('JavaScriptImportScanner', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     assert.equal(features.length, 0);
   });
 

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -20,7 +20,6 @@ import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ScannedNamespace} from '../../javascript/namespace';
 import {NamespaceScanner} from '../../javascript/namespace-scanner';
-import {ScannedFeature} from '../../model/model';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {CodeUnderliner} from '../test-utils';
 
@@ -36,7 +35,7 @@ suite('NamespaceScanner', () => {
     const scanner = new NamespaceScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
-    const features: ScannedFeature[] = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     return <ScannedNamespace[]>features.filter(
         (e) => e instanceof ScannedNamespace);
   };

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -39,7 +39,7 @@ suite('BehaviorScanner', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     behaviors = new Map();
     behaviorsList =
         <ScannedBehavior[]>features.filter((e) => e instanceof ScannedBehavior);

--- a/src/test/polymer/css-import-scanner_test.ts
+++ b/src/test/polymer/css-import-scanner_test.ts
@@ -47,7 +47,7 @@ suite('CssImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
       assert.equal(features[0].url, 'polymer.css');
@@ -65,7 +65,7 @@ suite('CssImportScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
       assert.equal(features[0].url, '/aybabtu/polymer.css');

--- a/src/test/polymer/dom-module-scanner_test.ts
+++ b/src/test/polymer/dom-module-scanner_test.ts
@@ -47,7 +47,7 @@ suite('DomModuleScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const domModules = await scanner.scan(document, visit);
+      const {features: domModules} = await scanner.scan(document, visit);
       assert.equal(domModules.length, 1);
       assert.deepEqual(
           domModules[0].localIds.map((lid) => lid.name), ['foo', 'bar']);
@@ -69,7 +69,7 @@ suite('DomModuleScanner', () => {
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
       const underliner = CodeUnderliner.withMapping('test.html', contents);
 
-      const domModules = await scanner.scan(document, visit);
+      const {features: domModules} = await scanner.scan(document, visit);
       assert.equal(domModules.length, 1);
       assert.deepEqual(
           await underliner.underline(

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -104,7 +104,7 @@ suite('PolymerElementScanner', () => {
           new JavaScriptParser().parse(contents, 'test-document.html');
       const visit = async(visitor: Visitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
 
       assert.deepEqual(features.map((f) => f.tagName), ['x-foo', 'x-bar']);
 
@@ -242,7 +242,7 @@ suite('PolymerElementScanner', () => {
           new JavaScriptParser().parse(contents, 'test-document.html');
       const visit = async(visitor: Visitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.deepEqual(
           features.map((f) => f.tagName), ['my-other-element', 'my-element']);
       assert.deepEqual(
@@ -286,7 +286,7 @@ suite('PolymerElementScanner', () => {
           new JavaScriptParser().parse(contents, 'test-document.html');
       const visit = async(visitor: Visitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.deepEqual(features.length, 1);
       const element = features[0]!;
       assert.deepEqual(

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -39,7 +39,7 @@ suite('Polymer2ElementScanner', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     return features.filter(
         (e) => e instanceof ScannedPolymerElement) as ScannedPolymerElement[];
   };

--- a/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -51,7 +51,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
-    const features = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
 
     elementsList = features.filter(
         (e) => e instanceof ScannedPolymerElement) as ScannedPolymerElement[];

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -21,7 +21,6 @@ import {PolymerElementMixin} from '../../index';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ScannedFeature} from '../../model/model';
 import {ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {CodeUnderliner} from '../test-utils';
@@ -39,7 +38,7 @@ suite('Polymer2MixinScanner', () => {
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
-    const features: ScannedFeature[] = await scanner.scan(document, visit);
+    const {features} = await scanner.scan(document, visit);
     return <ScannedPolymerElementMixin[]>features.filter(
         (e) => e instanceof ScannedPolymerElementMixin);
   };

--- a/src/test/polymer/pseudo-element-scanner_test.ts
+++ b/src/test/polymer/pseudo-element-scanner_test.ts
@@ -40,7 +40,7 @@ suite('PseudoElementScanner', () => {
       const document = new HtmlParser().parse(contents, 'test.html');
       const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 1);
       assert.equal(features[0].tagName, 'x-foo');
       assert(features[0].pseudo);

--- a/src/test/typescript/typescript-import-scanner_test.ts
+++ b/src/test/typescript/typescript-import-scanner_test.ts
@@ -33,7 +33,7 @@ suite('TypeScriptImportScanner', () => {
       const parser = new TypeScriptPreparser();
       const document = parser.parse(source, 'test.ts');
       const visit = async(visitor: Visitor) => document.visit([visitor]);
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 0);
     });
 
@@ -46,7 +46,7 @@ suite('TypeScriptImportScanner', () => {
       const parser = new TypeScriptPreparser();
       const document = parser.parse(source, 'test.ts');
       const visit = async(visitor: Visitor) => document.visit([visitor]);
-      const features = await scanner.scan(document, visit);
+      const {features} = await scanner.scan(document, visit);
       assert.deepEqual(features.map((f) => [f.type, f.url]), [
         ['js-import', 'x.ts'],
         ['js-import', '/y.ts'],

--- a/src/typescript/typescript-import-scanner.ts
+++ b/src/typescript/typescript-import-scanner.ts
@@ -24,7 +24,7 @@ export class TypeScriptImportScanner implements
     Scanner<ParsedTypeScriptDocument, Node, Visitor> {
   async scan(
       document: ParsedTypeScriptDocument,
-      visit: (visitor: Visitor) => Promise<void>): Promise<ScannedImport[]> {
+      visit: (visitor: Visitor) => Promise<void>) {
     const imports: ScannedImport[] = [];
     class ImportVisitor extends Visitor {
       visitImportDeclaration(node: ImportDeclaration): void { /* */
@@ -46,6 +46,6 @@ export class TypeScriptImportScanner implements
     }
     const visitor = new ImportVisitor();
     await visit(visitor);
-    return imports;
+    return {features: imports, warnings: []};
   }
 }

--- a/src/typescript/typescript-import-scanner.ts
+++ b/src/typescript/typescript-import-scanner.ts
@@ -46,6 +46,6 @@ export class TypeScriptImportScanner implements
     }
     const visitor = new ImportVisitor();
     await visit(visitor);
-    return {features: imports, warnings: []};
+    return {features: imports};
   }
 }


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

After some thought, the IncompleteFeature route is kinda heavyweight, we can instead just emit warnings from scan() and attach them to the scanned document.

If approved this PR would supplant #541 and #542