### PR TITLE
Add a MultiUrlLoader for loader composition.

### DIFF
--- a/src/test/url-loader/multi-url-loader_test.ts
+++ b/src/test/url-loader/multi-url-loader_test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+
+import {MultiUrlLoader} from '../../url-loader/multi-url-loader';
+import {UrlLoader} from '../../url-loader/url-loader';
+
+class MockLoader implements UrlLoader {
+  canLoadCount: number;
+  loadCount: number;
+  constructor(private _load: string|null) {
+    this.resetCounts();
+  }
+
+  resetCounts() {
+    this.canLoadCount = 0;
+    this.loadCount = 0;
+  }
+
+  canLoad(_url: string): boolean {
+    this.canLoadCount++;
+    return this._load != null;
+  }
+
+  async load(url: string): Promise<string> {
+    if (this._load == null) {
+      throw new Error(`tried to load ${url} with loader that can\'t load`);
+    }
+    this.loadCount++;
+    return this._load;
+  }
+}
+
+const mockLoaderArray = (loads: Array<string|null>) =>
+    loads.map((load): MockLoader => new MockLoader(load));
+
+suite('MultiUrlLoader', () => {
+
+  suite('canLoad', () => {
+
+    test('canLoad is true if the first loader is true', () => {
+      const loaders = mockLoaderArray(['loader 1', null, null]);
+      console.log(loaders);
+      const loader = new MultiUrlLoader(loaders);
+      assert.isTrue(loader.canLoad('test.html'));
+      // Verify only the first loader is called
+      assert.equal(loaders[0].canLoadCount, 1);
+      assert.equal(loaders[1].canLoadCount, 0);
+      assert.equal(loaders[2].canLoadCount, 0);
+    });
+
+    test('canLoad is true if the last loader is true', () => {
+      const loaders = mockLoaderArray([null, null, 'loader 3']);
+      const loader = new MultiUrlLoader(loaders);
+      assert.isTrue(loader.canLoad('test.html'));
+      // Verify all loaders are called
+      assert.equal(loaders[0].canLoadCount, 1);
+      assert.equal(loaders[1].canLoadCount, 1);
+      assert.equal(loaders[2].canLoadCount, 1);
+    });
+
+    test('canLoad is true if all loaders are true', () => {
+      const loaders = mockLoaderArray(['loader 1', 'loader 2', 'loader 3']);
+      const loader = new MultiUrlLoader(loaders);
+      assert.isTrue(loader.canLoad('test.html'));
+      // Verify only the first loader is called
+      assert.equal(loaders[0].canLoadCount, 1);
+      assert.equal(loaders[1].canLoadCount, 0);
+      assert.equal(loaders[2].canLoadCount, 0);
+    });
+
+    test('canLoad is false if all loaders are false', () => {
+      const loaders = mockLoaderArray([null, null, null]);
+      const loader = new MultiUrlLoader(loaders);
+      assert.isFalse(loader.canLoad('test.html'));
+      // Verify only the first resolver is called
+      assert.equal(loaders[0].canLoadCount, 1);
+      assert.equal(loaders[1].canLoadCount, 1);
+      assert.equal(loaders[2].canLoadCount, 1);
+    });
+
+  });
+
+  suite('load', () => {
+    test('returns only the first loaded file', async() => {
+      const loaders = mockLoaderArray(['loader 1', 'loader 2', 'loader 3']);
+      const loader = new MultiUrlLoader(loaders);
+      assert.equal(await loader.load('test.html'), 'loader 1');
+      // Verify only the first loader is called
+      assert.equal(loaders[0].canLoadCount, 1);
+      assert.equal(loaders[1].canLoadCount, 0);
+      assert.equal(loaders[2].canLoadCount, 0);
+    });
+
+    test('returns the file from first loader that can load', async() => {
+      const loaders = mockLoaderArray([null, null, 'loader 3']);
+      const loader = new MultiUrlLoader(loaders);
+      assert.equal(await loader.load('test.html'), 'loader 3');
+      // Verify only the last load is called
+      assert.equal(loaders[0].loadCount, 0);
+      assert.equal(loaders[1].loadCount, 0);
+      assert.equal(loaders[2].loadCount, 1);
+    });
+
+    test('throws an error if no loader can be found to load', async() => {
+      const loaders = mockLoaderArray([null, null, null]);
+      const loader = new MultiUrlLoader(loaders);
+      let error;
+      try {
+        await loader.load('test.html');
+      } catch (e) {
+        error = e;
+      }
+      assert.instanceOf(error, Error);
+      assert.include(error.message, 'Unable to load test.html');
+      // Verify load is not called on any loader
+      assert.equal(loaders[0].loadCount, 0);
+      assert.equal(loaders[1].loadCount, 0);
+      assert.equal(loaders[2].loadCount, 0);
+    });
+  });
+});

--- a/src/test/url-loader/multi-url-loader_test.ts
+++ b/src/test/url-loader/multi-url-loader_test.ts
@@ -85,7 +85,7 @@ suite('MultiUrlLoader', () => {
       const loaders = mockLoaderArray([null, null, null]);
       const loader = new MultiUrlLoader(loaders);
       assert.isFalse(loader.canLoad('test.html'));
-      // Verify only the first resolver is called
+      // Verify only the first loader is called
       assert.equal(loaders[0].canLoadCount, 1);
       assert.equal(loaders[1].canLoadCount, 1);
       assert.equal(loaders[2].canLoadCount, 1);

--- a/src/test/url-loader/multi-url-loader_test.ts
+++ b/src/test/url-loader/multi-url-loader_test.ts
@@ -16,6 +16,7 @@ import {assert} from 'chai';
 
 import {MultiUrlLoader} from '../../url-loader/multi-url-loader';
 import {UrlLoader} from '../../url-loader/url-loader';
+import {invertPromise} from '../test-utils';
 
 class MockLoader implements UrlLoader {
   canLoadCount: number;
@@ -52,7 +53,6 @@ suite('MultiUrlLoader', () => {
 
     test('canLoad is true if the first loader is true', () => {
       const loaders = mockLoaderArray(['loader 1', null, null]);
-      console.log(loaders);
       const loader = new MultiUrlLoader(loaders);
       assert.isTrue(loader.canLoad('test.html'));
       // Verify only the first loader is called
@@ -117,12 +117,7 @@ suite('MultiUrlLoader', () => {
     test('throws an error if no loader can be found to load', async() => {
       const loaders = mockLoaderArray([null, null, null]);
       const loader = new MultiUrlLoader(loaders);
-      let error;
-      try {
-        await loader.load('test.html');
-      } catch (e) {
-        error = e;
-      }
+      const error = await invertPromise(loader.load('test.html'));
       assert.instanceOf(error, Error);
       assert.include(error.message, 'Unable to load test.html');
       // Verify load is not called on any loader

--- a/src/url-loader/multi-url-loader.ts
+++ b/src/url-loader/multi-url-loader.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {UrlLoader} from './url-loader';
+
+/**
+ * Resolves requests via one of a sequence of loaders.
+ */
+export class MultiUrlLoader implements UrlLoader {
+  constructor(private _loaders: UrlLoader[]) {
+  }
+
+  canLoad(url: string): boolean {
+    return this._loaders.some((loader) => loader.canLoad(url));
+  }
+
+  async load(url: string): Promise<string> {
+    for (const loader of this._loaders) {
+      if (loader.canLoad(url)) {
+        return loader.load(url);
+      }
+    }
+    return Promise.reject(new Error(`Unable to load ${url}`));
+  }
+}


### PR DESCRIPTION
This `MultiUrlLoader` is a very simple implementation.  It depends on `canLoad` to choose the loader to use, in sequence.

My intent with this loader is to support dispatching to multiple loaders to support cases such as the `redirect` option bundler use to use to deal with Chrome's special protocol paths.  To do that will require a different form of the current FSUrlLoader than we have, but because this multi-loader is such a basic compositional tool for loader assembly, I thought I'd add in its own PR.