### PR TITLE
Clarify our cache invariants.

### DIFF
--- a/src/core/async-work-cache.ts
+++ b/src/core/async-work-cache.ts
@@ -24,6 +24,8 @@
  * remove it from the cache that future requests will use, but existing requests
  * should be unaffected.
  */
+import {SetOnlyMap} from '../model/immutable';
+
 export class AsyncWorkCache<K, V> {
   private _keyToResultMap: SetOnlyMap<K, Promise<V>>;
 
@@ -65,20 +67,12 @@ export class AsyncWorkCache<K, V> {
   }
 
   /**
-   * Returns a copy of the underlying map which can be mutated as necessary
-   * and then used to create another cache.
+   * Yields entries from the underlying map which can be filtered as necessary
+   * to use in creating another cache.
+   *
+   * Not valid for reading a particular value from the cache.
    */
-  fork(): Map<K, Promise<V>> {
-    return new Map(this._keyToResultMap);
+  * [Symbol.iterator]() {
+    yield* this._keyToResultMap;
   }
-}
-
-/**
- * A map whose entries may not be deleted.
- */
-export interface SetOnlyMap<K, V> extends ReadonlyMap<K, V> {
-  [Symbol.iterator](): IterableIterator<[K, V]>;
-  keys(): IterableIterator<K>;
-  values(): IterableIterator<V>;
-  set(key: K, value: V): void;
 }

--- a/src/model/immutable.ts
+++ b/src/model/immutable.ts
@@ -52,6 +52,13 @@ export declare interface ImmutableMap<K, V> {
   [Symbol.iterator](): Iterator<[K, V]>;
 }
 
+/**
+ * A map whose entries may not be deleted.
+ */
+export interface SetOnlyMap<K, V> extends ImmutableMap<K, V> {
+  set(key: K, value: V): void;
+}
+
 export function asImmutable<V>(array: Array<V>): ImmutableArray<V>;
 export function asImmutable<V>(set: Set<V>): ImmutableSet<V>;
 export function asImmutable<K, V>(map: Map<K, V>): ImmutableMap<K, V>;
@@ -59,6 +66,8 @@ export function asImmutable<O extends object>(object: O): Readonly<O>;
 export function asImmutable(x: any) {
   return x;
 }
+
+
 
 /**
  * Take care, this function is inherently unsafe.

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -1001,13 +1001,15 @@ var DuplicateNamespace = {};
         assert.deepEqual(document.url, 'base.html');
         const localFeatures = document.getFeatures({imported: false});
         const kinds = Array.from(localFeatures).map((f) => Array.from(f.kinds));
-        const message = `localFeatures: ${
-        JSON.stringify(
-            Array.from(localFeatures).map((f) => ({
-                                            kinds: Array.from(f.kinds),
-                                            ids: Array.from(f.identifiers)
-                                          })))
-        }`;
+        const message =
+            `localFeatures: ${
+                              JSON.stringify(
+                                  Array.from(localFeatures)
+                                      .map((f) => ({
+                                             kinds: Array.from(f.kinds),
+                                             ids: Array.from(f.identifiers)
+                                           })))
+                            }`;
         assert.deepEqual(
             kinds,
             [

--- a/src/test/core/analysis-cache_test.ts
+++ b/src/test/core/analysis-cache_test.ts
@@ -23,9 +23,12 @@ suite('AnalysisCache', () => {
 
   function addFakeDocumentToCache(
       cache: AnalysisCache, path: string, dependencies: string[]) {
-    cache.parsedDocumentPromises.set(path, `parsed ${path} promise` as any);
-    cache.scannedDocumentPromises.set(path, `scanned ${path} promise` as any);
-    cache.analyzedDocumentPromises.set(path, `analyzed ${path} promise` as any);
+    cache.parsedDocumentPromises['_keyToResultMap'].set(
+        path, `parsed ${path} promise` as any);
+    cache.scannedDocumentPromises['_keyToResultMap'].set(
+        path, `scanned ${path} promise` as any);
+    cache.analyzedDocumentPromises['_keyToResultMap'].set(
+        path, `analyzed ${path} promise` as any);
     cache.scannedDocuments.set(path, `scanned ${path}` as any);
     cache.analyzedDocuments.set(path, `analyzed ${path}` as any);
     cache.dependencyGraph.addDocument(path, dependencies);
@@ -46,8 +49,8 @@ suite('AnalysisCache', () => {
   }
 
   function assertNotHasDocument(cache: AnalysisCache, path: string) {
-    assert.isFalse(cache.parsedDocumentPromises.has(path));
-    assert.isFalse(cache.scannedDocumentPromises.has(path));
+    assert.isFalse(cache.parsedDocumentPromises['_keyToResultMap'].has(path));
+    assert.isFalse(cache.scannedDocumentPromises['_keyToResultMap'].has(path));
     // caller must assert on cache.analyzedDocumentPromises themselves
     assert.isFalse(cache.scannedDocuments.has(path));
     assert.isFalse(cache.analyzedDocuments.has(path));
@@ -66,7 +69,7 @@ suite('AnalysisCache', () => {
         `scanned ${path} promise`);
     assert.equal(cache.scannedDocuments.get(path) as any, `scanned ${path}`);
     assert.isFalse(cache.analyzedDocuments.has(path));
-    assert.isFalse(cache.analyzedDocumentPromises.has(path));
+    assert.isFalse(cache.analyzedDocumentPromises['_keyToResultMap'].has(path));
   }
 
   test('it invalidates a path when asked to', async() => {


### PR DESCRIPTION
AsyncWorkCache had several methods which were only valid to use in tests and during initialization. In the spirit of making interfaces that are easy to use correctly and difficult to use incorrectly I removed the methods and provided a cleaner  initialization path.

 - [x] internal change, CHANGELOG.md not updated
