### PR TITLE
Prefixed url loader 🔥🤘

### DIFF
--- a/src/test/url-loader/prefixed-url-loader_test.ts
+++ b/src/test/url-loader/prefixed-url-loader_test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+
+import {PrefixedUrlLoader} from '../../url-loader/prefixed-url-loader';
+import {UrlLoader} from '../../url-loader/url-loader';
+import {invertPromise} from '../test-utils';
+
+class MockLoader implements UrlLoader {
+  canLoadUrls: string[];
+  loadUrls: string[];
+  constructor(private _load: string|null) {
+    this.reset();
+  }
+
+  reset() {
+    this.canLoadUrls = [];
+    this.loadUrls = [];
+  }
+
+  canLoad(url: string): boolean {
+    this.canLoadUrls.push(url);
+    return this._load != null;
+  }
+
+  async load(url: string): Promise<string> {
+    this.loadUrls.push(url);
+    if (this._load == null) {
+      throw new Error(`Tried to load "${url}", and delegate can't load it.`);
+    }
+    return this._load;
+  }
+}
+
+suite('PrefixedUrlLoader', () => {
+
+  suite('canLoad', () => {
+
+    test('canLoad is true if the url starts with prefix', () => {
+      const delegate = new MockLoader('stuff');
+      const loader = new PrefixedUrlLoader('path/to/stuff/', delegate);
+      assert.isTrue(loader.canLoad('path/to/stuff/file.html'));
+      // Delegate receives an unprefixed url to check.
+      assert.deepEqual(delegate.canLoadUrls, ['file.html']);
+    });
+
+    test('canLoad is false if the url does not start with prefix', () => {
+      const delegate = new MockLoader('stuff');
+      const loader = new PrefixedUrlLoader('path/to/stuff/', delegate);
+      assert.isFalse(loader.canLoad('path/to/other/file.html'));
+      // Delegate is not consulted.
+      assert.deepEqual(delegate.canLoadUrls, []);
+    });
+
+    test('canLoad is false if the delgate loader says it is', () => {
+      const delegate = new MockLoader(null);
+      const loader = new PrefixedUrlLoader('path/to/stuff/', delegate);
+      assert.isFalse(loader.canLoad('path/to/stuff/file.html'));
+      // Delegate receives an unprefixed url to check.
+      assert.deepEqual(delegate.canLoadUrls, ['file.html']);
+    });
+  });
+
+  suite('load', () => {
+
+    test('load returns content if url starts with prefix', async() => {
+      const delegate = new MockLoader('stuff');
+      const loader = new PrefixedUrlLoader('path/to/stuff/', delegate);
+      assert.deepEqual(await loader.load('path/to/stuff/file.html'), 'stuff');
+      // Delegate receives an unprefixed url to load.
+      assert.deepEqual(delegate.loadUrls, ['file.html']);
+    });
+
+    test('load throws error if url does not start with prefix', async() => {
+      const delegate = new MockLoader('stuff');
+      const loader = new PrefixedUrlLoader('path/to/stuff/', delegate);
+      const error = await invertPromise(loader.load('path/to/other/file.html'));
+      assert.instanceOf(error, Error);
+      assert.deepEqual(
+          error.message,
+          'Can not load "path/to/other/file.html", does not match prefix "path/to/stuff/".');
+      // Delegate is not consulted.
+      assert.deepEqual(delegate.loadUrls, []);
+    });
+
+    test('load passes on delegate error if url starts with prefix', async() => {
+      const delegate = new MockLoader(null);
+      const loader = new PrefixedUrlLoader('path/to/stuff/', delegate);
+      const error = await invertPromise(loader.load('path/to/stuff/file.html'));
+      assert.instanceOf(error, Error);
+      assert.deepEqual(
+          error.message,
+          'Tried to load "file.html", and delegate can\'t load it.');
+      // Delegate was asked.
+      assert.deepEqual(delegate.loadUrls, ['file.html']);
+
+    });
+  });
+});

--- a/src/url-loader/prefixed-url-loader.ts
+++ b/src/url-loader/prefixed-url-loader.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {UrlLoader} from './url-loader';
+
+/**
+ * Resolves requests via a given delegate loader for URLs matching a given
+ * prefix. URLs are provided to their delegate without the prefix.
+ */
+export class PrefixedUrlLoader implements UrlLoader {
+  constructor(public prefix: string, public delegate: UrlLoader) {
+  }
+
+  canLoad(url: string): boolean {
+    return url.startsWith(this.prefix) &&
+        this.delegate.canLoad(this._unprefix(url));
+  }
+
+  async load(url: string): Promise<string> {
+    if (!url.startsWith(this.prefix)) {
+      throw new Error(
+          `Can not load "${url}", does not match prefix "${this.prefix}".`);
+    }
+    return this.delegate.load(this._unprefix(url));
+  }
+
+  private _unprefix(url: string): string {
+    return url.slice(this.prefix.length);
+  }
+}


### PR DESCRIPTION
In combination with the `MultiUrlLoader`, the `PrefixedUrlLoader` provides a mechanism to map multiple url prefixes (containing protocols, domains, paths, whatever), to different delegate loaders.  This provides developers the solve several use cases:

 - Route a specific url to a common directory outside the package root.  E.g. I want to point `/bower_components/polymer/` to `~/src/polymer-fork`.
```js
new MultiUrlLoader([
  new PrefixedUrlLoader('bower_components/polymer', 
    new FSUrlLoader('~/src/polymer-fork')), 
  new FSUrlLoader()])
```
 - Chrome can create a sequence of mappings for each chrome protocol like: (`bin/polymer-bundler` could easily construct this and implement the old vulcanize `--redirect` option.
```js
new PrefixedUrlLoader('chrome://downloads/',
  new FSUrlLoader('/tmp/polymer_bundler_test/folder2/'))
```
 - Route a specific url to a remote copy of the package in question.:
```js
new MultiUrlLoader([
  new PrefixedUrlLoader('bower_components/polymer/',
    new FetchUrlLoader('https://userx.mycdn.com/files/components/polymer/')),
  new FSUrlLoader('.')])
```