### PR TITLE
Updated CHANGELOG for 2.0.0-alpha.42 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.0.0-alpha.42] -2017-05-09
 
 * [minor breaking change] The paths in `@demo` annotations are no longer resolved.
+* Added `MultiUrlLoader` and `PrefixedUrlLoader` to support analysis of more complicated project layouts.
 
 ## [2.0.0-alpha.41] - 2017-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [2.0.0-alpha.42] -2017-05-09
 
 * [minor breaking change] The paths in `@demo` annotations are no longer resolved.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export {PackageUrlResolver} from './url-loader/package-url-resolver';
 export {RedirectResolver} from './url-loader/redirect-resolver';
 export {UrlLoader} from './url-loader/url-loader';
 export {UrlResolver} from './url-loader/url-resolver';
+export {MultiUrlLoader} from './url-loader/multi-url-loader';
+export {PrefixedUrlLoader} from './url-loader/prefixed-url-loader';
 
 // Polymer
 export {PolymerElement} from './polymer/polymer-element';

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,13 @@ export {Analysis as AnalysisFormat} from './analysis-format';
 export {FetchUrlLoader} from './url-loader/fetch-url-loader';
 export {FSUrlLoader} from './url-loader/fs-url-loader';
 export {InMemoryOverlayUrlLoader} from './url-loader/overlay-loader';
+export {MultiUrlLoader} from './url-loader/multi-url-loader';
 export {MultiUrlResolver} from './url-loader/multi-url-resolver';
 export {PackageUrlResolver} from './url-loader/package-url-resolver';
+export {PrefixedUrlLoader} from './url-loader/prefixed-url-loader';
 export {RedirectResolver} from './url-loader/redirect-resolver';
 export {UrlLoader} from './url-loader/url-loader';
 export {UrlResolver} from './url-loader/url-resolver';
-export {MultiUrlLoader} from './url-loader/multi-url-loader';
-export {PrefixedUrlLoader} from './url-loader/prefixed-url-loader';
 
 // Polymer
 export {PolymerElement} from './polymer/polymer-element';


### PR DESCRIPTION
 - Fixed demo annotation issue, unblocking docs effort for 2.0
 - BONUS: This will also provide the PrefixedUrlLoader + MultiUrlLoader combo enabling options for polymer bundler to provide alternative to vulcanize's redirect option.
 - [x] CHANGELOG.md has been updated
