### PR TITLE
Make warning a class rather than an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * [BREAKING] `attributes`, `properties`, `methods`, and `events` are now Maps from the name to the value rather than arrays. This better models what's actually going on (you can't have two different properties with the same name in javascript) and it makes our inheritance modeling more efficient.
   * Note that the serialized output format `analysis.json` is not changed, it still uses arrays.
+* Warning is now a class, not just an interface. It also now keeps track of the
+  parsed document that it came from. This fixes a race condition and API wart
+  where to print a warning you needed to load the source of the document
+  that was seen when the warning was generated.
+  * Also, thanks to using the ParsedDocument interface, printing a warning is
+    now O(size of underlined text) rather than O(size of document).
 
 ## [2.0.0-alpha.42] -2017-05-09
 

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -357,15 +357,17 @@ export class AnalysisContext {
    * Scans a ParsedDocument.
    */
   private async _scanDocument(
-      document: ParsedDocument<any, any>,
-      maybeAttachedComment?: string): Promise<ScannedDocument> {
+      document: ParsedDocument<any, any>, maybeAttachedComment?: string,
+      maybeContainingDocument?: ParsedDocument<any, any>):
+      Promise<ScannedDocument> {
     const {features: scannedFeatures, warnings} =
         await this._getScannedFeatures(document);
     // If there's an HTML comment that applies to this document then we assume
     // that it applies to the first feature.
     const firstScannedFeature = scannedFeatures[0];
     if (firstScannedFeature && firstScannedFeature instanceof ScannedElement) {
-      firstScannedFeature.applyHtmlComment(maybeAttachedComment);
+      firstScannedFeature.applyHtmlComment(
+          maybeAttachedComment, maybeContainingDocument);
     }
 
     const scannedDocument =
@@ -406,8 +408,8 @@ export class AnalysisContext {
             feature.contents,
             containingDocument.url,
             {locationOffset, astNode: feature.astNode});
-        const scannedDoc =
-            await this._scanDocument(parsedDoc, feature.attachedComment);
+        const scannedDoc = await this._scanDocument(
+            parsedDoc, feature.attachedComment, containingDocument.document);
 
         feature.scannedDocument = scannedDoc;
       } catch (err) {

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -24,7 +24,7 @@ async function main() {
     urlResolver: new PackageUrlResolver()
   });
   const warnings = await getWarnings(analyzer, process.argv[2]);
-  const warningPrinter = new WarningPrinter(process.stderr, {analyzer});
+  const warningPrinter = new WarningPrinter(process.stderr);
   await warningPrinter.printWarnings(warnings);
   const worstSeverity = Math.min.apply(Math, warnings.map((w) => w.severity));
   if (worstSeverity === Severity.ERROR) {

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -64,7 +64,8 @@ export class ScannedScriptTagImport extends ScannedImport {
         code: 'could-not-load',
         message: `Unable to load import: ${error}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
-        severity: Severity.ERROR
+        severity: Severity.ERROR,
+        parsedDocument: document.parsedDocument
       }));
       return undefined;
     }

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document, Import, ScannedImport, Severity} from '../model/model';
+import {Document, Import, ScannedImport, Severity, Warning} from '../model/model';
 
 /**
  * <script> tags are represented in two different ways: as inline documents,
@@ -60,12 +60,12 @@ export class ScannedScriptTagImport extends ScannedImport {
     } else {
       // not found or syntax error
       const error = (this.error ? (this.error.message || this.error) : '');
-      document.warnings.push({
+      document.warnings.push(new Warning({
         code: 'could-not-load',
         message: `Unable to load import: ${error}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
-      });
+      }));
       return undefined;
     }
   }

--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -443,6 +443,7 @@ class ClassFinder implements Visitor {
           code: 'class-extends-annotation-no-id',
           message: '@extends annotation with no identifier',
           severity: Severity.WARNING, sourceRange,
+          parsedDocument: this._document
         }));
       } else {
         return new ScannedReference(extendsId, sourceRange);
@@ -537,7 +538,8 @@ class CustomElementsDefineCallFinder implements Visitor {
           `Unable to evaluate this expression down to a definitive string ` +
           `tagname.`,
       severity: Severity.WARNING,
-      sourceRange: this._document.sourceRangeForNode(expression)!
+      sourceRange: this._document.sourceRangeForNode(expression)!,
+      parsedDocument: this._document
     }));
     return undefined;
   }
@@ -562,7 +564,8 @@ class CustomElementsDefineCallFinder implements Visitor {
       code: 'cant-determine-element-class',
       message: `Unable to evaluate this expression down to a class reference.`,
       severity: Severity.WARNING,
-      sourceRange: this._document.sourceRangeForNode(elementDefn)!
+      sourceRange: this._document.sourceRangeForNode(elementDefn)!,
+      parsedDocument: this._document,
     }));
     return null;
   }

--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -439,11 +439,11 @@ class ClassFinder implements Visitor {
       // TODO(justinfagnani): we need source ranges for jsdoc annotations
       const sourceRange = document.sourceRangeForNode(node)!;
       if (extendsId == null) {
-        warnings.push({
+        warnings.push(new Warning({
           code: 'class-extends-annotation-no-id',
           message: '@extends annotation with no identifier',
           severity: Severity.WARNING, sourceRange,
-        });
+        }));
       } else {
         return new ScannedReference(extendsId, sourceRange);
       }
@@ -531,14 +531,14 @@ class CustomElementsDefineCallFinder implements Visitor {
         };
       }
     }
-    this.warnings.push({
+    this.warnings.push(new Warning({
       code: 'cant-determine-element-tagname',
       message:
           `Unable to evaluate this expression down to a definitive string ` +
           `tagname.`,
       severity: Severity.WARNING,
       sourceRange: this._document.sourceRangeForNode(expression)!
-    });
+    }));
     return undefined;
   }
 
@@ -558,12 +558,12 @@ class CustomElementsDefineCallFinder implements Visitor {
     if (elementDefn.type === 'ClassExpression') {
       return elementDefn;
     }
-    this.warnings.push({
+    this.warnings.push(new Warning({
       code: 'cant-determine-element-class',
       message: `Unable to evaluate this expression down to a class reference.`,
       severity: Severity.WARNING,
       sourceRange: this._document.sourceRangeForNode(elementDefn)!
-    });
+    }));
     return null;
   }
 }

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -15,8 +15,8 @@
 import * as estraverse from 'estraverse';
 import * as estree from 'estree';
 
-import {ParsedDocument} from '../index';
 import {ScannedEvent, Severity, SourceRange, Warning, WarningCarryingException} from '../model/model';
+import {ParsedDocument} from '../parser/document';
 import {annotateEvent} from '../polymer/docs';
 
 import * as jsdoc from './jsdoc';

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -15,6 +15,7 @@
 import * as estraverse from 'estraverse';
 import * as estree from 'estree';
 
+import {ParsedDocument} from '../index';
 import {ScannedEvent, Severity, SourceRange, Warning, WarningCarryingException} from '../model/model';
 import {annotateEvent} from '../polymer/docs';
 
@@ -88,7 +89,9 @@ export const CLOSURE_CONSTRUCTOR_MAP = new Map(
  * @return {string} The type of that expression, in Closure terms.
  */
 export function closureType(
-    node: estree.Node, sourceRange: SourceRange): string {
+    node: estree.Node,
+    sourceRange: SourceRange,
+    document: ParsedDocument<any, any>): string {
   if (node.type.match(/Expression$/)) {
     return node.type.substr(0, node.type.length - 10);
   } else if (node.type === 'Literal') {
@@ -98,11 +101,10 @@ export function closureType(
   } else {
     throw new WarningCarryingException(new Warning({
       code: 'no-closure-type',
-      message:
-          `Unable to determine closure type for expression of type ${
-                                                                     node.type
-                                                                   }`,
-      severity: Severity.WARNING, sourceRange
+      message: `Unable to determine closure type for expression of type ` +
+          `${node.type}`,
+      severity: Severity.WARNING, sourceRange,
+      parsedDocument: document,
     }));
   }
 }

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -15,7 +15,7 @@
 import * as estraverse from 'estraverse';
 import * as estree from 'estree';
 
-import {ScannedEvent, Severity, SourceRange, WarningCarryingException} from '../model/model';
+import {ScannedEvent, Severity, SourceRange, Warning, WarningCarryingException} from '../model/model';
 import {annotateEvent} from '../polymer/docs';
 
 import * as jsdoc from './jsdoc';
@@ -96,14 +96,14 @@ export function closureType(
   } else if (node.type === 'Identifier') {
     return CLOSURE_CONSTRUCTOR_MAP.get(node.name) || node.name;
   } else {
-    throw new WarningCarryingException({
+    throw new WarningCarryingException(new Warning({
       code: 'no-closure-type',
       message:
           `Unable to determine closure type for expression of type ${
                                                                      node.type
                                                                    }`,
       severity: Severity.WARNING, sourceRange
-    });
+    }));
   }
 }
 

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -97,7 +97,7 @@ export function parseJs(
       if (err instanceof SyntaxError) {
         return {
           type: 'failure',
-          warning: {
+          warning: new Warning({
             message: err.message.split('\n')[0],
             severity: Severity.ERROR,
             code: warningCode,
@@ -108,7 +108,7 @@ export function parseJs(
                   end: {line: err.lineNumber - 1, column: err.column - 1}
                 },
                 locationOffset)!
-          }
+          })
         };
       }
       throw err;

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -151,12 +151,12 @@ export function getMixinApplications(
         // TODO(justinfagnani): we need source ranges for jsdoc annotations
         const sourceRange = document.sourceRangeForNode(node)!;
         if (mixinId === undefined) {
-          warnings.push({
-            code: 'class-applies-mixin-annotation-no-id',
+          warnings.push(new Warning({
+            code: 'class-mixes-annotation-no-id',
             message:
                 '@appliesMixin annotation with no identifier. Usage `@appliesMixin MixinName`',
             severity: Severity.WARNING, sourceRange,
-          });
+          }));
           return;
         }
         return new ScannedReference(mixinId, sourceRange);

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -156,6 +156,7 @@ export function getMixinApplications(
             message:
                 '@appliesMixin annotation with no identifier. Usage `@appliesMixin MixinName`',
             severity: Severity.WARNING, sourceRange,
+            parsedDocument: document
           }));
           return;
         }

--- a/src/model/class.ts
+++ b/src/model/class.ts
@@ -14,9 +14,9 @@
 
 import * as estree from 'estree';
 
-import {ParsedDocument} from '../index';
 import * as jsdocLib from '../javascript/jsdoc';
-import {Document, ElementMixin, Feature, Method, Privacy, Property, Reference, Resolvable, ScannedFeature, ScannedMethod, ScannedProperty, ScannedReference, Severity, SourceRange, Warning} from '../model/model';
+import {Document, Feature, Method, Privacy, Property, Reference, Resolvable, ScannedFeature, ScannedMethod, ScannedProperty, ScannedReference, Severity, SourceRange, Warning} from '../model/model';
+import {ParsedDocument} from '../parser/document';
 import {getOrInferPrivacy} from '../polymer/js-utils';
 
 import {Demo} from './element-base';

--- a/src/model/class.ts
+++ b/src/model/class.ts
@@ -222,13 +222,13 @@ export class Class implements Feature {
           if (applyingSelf) {
             warningSourceRange = newVal.sourceRange || this.sourceRange!;
           }
-          this.warnings.push({
+          this.warnings.push(new Warning({
             code: 'overriding-private',
             message: `Overriding private member '${overridingVal.name}' ` +
                 `inherited from ${existingValue.inheritedFrom || 'parent'}`,
             sourceRange: warningSourceRange,
             severity: Severity.WARNING
-          });
+          }));
         }
       }
       existing.set(key, newVal);
@@ -274,20 +274,20 @@ export class Class implements Feature {
     });
 
     if (superElements.size < 1) {
-      this.warnings.push({
+      this.warnings.push(new Warning({
         message: `Unable to resolve superclass ${reference.identifier}`,
         severity: Severity.ERROR,
         code: 'unknown-superclass',
         sourceRange: reference.sourceRange!,
-      });
+      }));
       return undefined;
     } else if (superElements.size > 1) {
-      this.warnings.push({
+      this.warnings.push(new Warning({
         message: `Multiple superclasses found for ${reference.identifier}`,
         severity: Severity.ERROR,
         code: 'unknown-superclass',
         sourceRange: reference.sourceRange!,
-      });
+      }));
       return undefined;
     }
     return superElements.values().next().value;

--- a/src/model/class.ts
+++ b/src/model/class.ts
@@ -14,6 +14,7 @@
 
 import * as estree from 'estree';
 
+import {ParsedDocument} from '../index';
 import * as jsdocLib from '../javascript/jsdoc';
 import {Document, ElementMixin, Feature, Method, Privacy, Property, Reference, Resolvable, ScannedFeature, ScannedMethod, ScannedProperty, ScannedReference, Severity, SourceRange, Warning} from '../model/model';
 import {getOrInferPrivacy} from '../polymer/js-utils';
@@ -136,6 +137,7 @@ export class Class implements Feature {
   readonly abstract: boolean;
   readonly privacy: Privacy;
   readonly demos: Demo[];
+  private readonly _parsedDocument: ParsedDocument<any, any>;
 
   constructor(init: ClassInit, document: Document) {
     ({
@@ -147,6 +149,8 @@ export class Class implements Feature {
       astNode: this.astNode,
       sourceRange: this.sourceRange
     } = init);
+
+    this._parsedDocument = document.parsedDocument;
 
     this.warnings =
         init.warnings === undefined ? [] : Array.from(init.warnings);
@@ -227,7 +231,8 @@ export class Class implements Feature {
             message: `Overriding private member '${overridingVal.name}' ` +
                 `inherited from ${existingValue.inheritedFrom || 'parent'}`,
             sourceRange: warningSourceRange,
-            severity: Severity.WARNING
+            severity: Severity.WARNING,
+            parsedDocument: this._parsedDocument,
           }));
         }
       }
@@ -279,6 +284,7 @@ export class Class implements Feature {
         severity: Severity.ERROR,
         code: 'unknown-superclass',
         sourceRange: reference.sourceRange!,
+        parsedDocument: this._parsedDocument,
       }));
       return undefined;
     } else if (superElements.size > 1) {
@@ -287,6 +293,7 @@ export class Class implements Feature {
         severity: Severity.ERROR,
         code: 'unknown-superclass',
         sourceRange: reference.sourceRange!,
+        parsedDocument: this._parsedDocument,
       }));
       return undefined;
     }

--- a/src/model/element-base.ts
+++ b/src/model/element-base.ts
@@ -53,13 +53,13 @@ export abstract class ScannedElementBase implements Resolvable {
       // element.
       if (this.sourceRange &&
           (this.description || this.jsdoc && this.jsdoc.tags.length > 0)) {
-        this.warnings.push({
+        this.warnings.push(new Warning({
           severity: Severity.WARNING,
           code: 'multiple-doc-comments',
           message:
               `${this.constructor.name} has both HTML doc and JSDoc comments.`,
           sourceRange: this.sourceRange,
-        });
+        }));
       }
       this.jsdoc =
           this.jsdoc ? jsdoc.join(commentJsdoc, this.jsdoc) : commentJsdoc;

--- a/src/model/element-base.ts
+++ b/src/model/element-base.ts
@@ -14,6 +14,7 @@
 
 import * as estree from 'estree';
 
+import {ParsedDocument} from '../index';
 import * as jsdoc from '../javascript/jsdoc';
 
 import {Class, ClassInit} from './class';
@@ -46,8 +47,10 @@ export abstract class ScannedElementBase implements Resolvable {
   abstract: boolean = false;
   superClass?: ScannedReference = undefined;
 
-  applyHtmlComment(commentText: string|undefined) {
-    if (commentText) {
+  applyHtmlComment(
+      commentText: string|undefined,
+      containingDocument: ParsedDocument<any, any>|undefined) {
+    if (commentText && containingDocument) {
       const commentJsdoc = jsdoc.parseJsdoc(commentText);
       // Add a Warning if there are already jsdoc tags or a description for this
       // element.
@@ -59,6 +62,7 @@ export abstract class ScannedElementBase implements Resolvable {
           message:
               `${this.constructor.name} has both HTML doc and JSDoc comments.`,
           sourceRange: this.sourceRange,
+          parsedDocument: containingDocument
         }));
       }
       this.jsdoc =

--- a/src/model/element-base.ts
+++ b/src/model/element-base.ts
@@ -14,8 +14,8 @@
 
 import * as estree from 'estree';
 
-import {ParsedDocument} from '../index';
 import * as jsdoc from '../javascript/jsdoc';
+import {ParsedDocument} from '../parser/document';
 
 import {Class, ClassInit} from './class';
 import {Privacy} from './feature';

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -72,12 +72,12 @@ export class ScannedImport implements Resolvable {
         document._analysisContext.getDocument(this.url);
     if (!(importedDocumentOrWarning instanceof Document)) {
       const error = this.error ? (this.error.message || this.error) : '';
-      document.warnings.push({
+      document.warnings.push(new Warning({
         code: 'could-not-load',
         message: `Unable to load import: ${error}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
         severity: Severity.ERROR
-      });
+      }));
       return undefined;
     }
     return new Import(

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -76,7 +76,8 @@ export class ScannedImport implements Resolvable {
         code: 'could-not-load',
         message: `Unable to load import: ${error}`,
         sourceRange: (this.urlSourceRange || this.sourceRange)!,
-        severity: Severity.ERROR
+        severity: Severity.ERROR,
+        parsedDocument: document.parsedDocument,
       }));
       return undefined;
     }

--- a/src/model/source-range.ts
+++ b/src/model/source-range.ts
@@ -56,6 +56,14 @@ export interface LocationOffset {
  * first line of the <script> contents.
  */
 export function correctSourceRange(
+    sourceRange: SourceRange,
+    locationOffset?: LocationOffset|null): SourceRange;
+export function correctSourceRange(
+    sourceRange: undefined, locationOffset?: LocationOffset|null): undefined;
+export function correctSourceRange(
+    sourceRange?: SourceRange,
+    locationOffset?: LocationOffset|null): SourceRange|undefined;
+export function correctSourceRange(
     sourceRange?: SourceRange,
     locationOffset?: LocationOffset|null): SourceRange|undefined {
   if (!locationOffset || !sourceRange) {
@@ -73,6 +81,28 @@ export function correctPosition(
   return {
     line: position.line + locationOffset.line,
     column: position.column + (position.line === 0 ? locationOffset.col : 0)
+  };
+}
+
+export function uncorrectSourceRange(
+    sourceRange?: SourceRange,
+    locationOffset?: LocationOffset|null): SourceRange|undefined {
+  if (locationOffset == null || sourceRange == null) {
+    return sourceRange;
+  }
+  return {
+    file: locationOffset.filename || sourceRange.file,
+    start: uncorrectPosition(sourceRange.start, locationOffset),
+    end: uncorrectPosition(sourceRange.end, locationOffset),
+  };
+}
+
+export function uncorrectPosition(
+    position: SourcePosition, locationOffset: LocationOffset): SourcePosition {
+  const line = position.line - locationOffset.line;
+  return {
+    line: line,
+    column: position.column - (line === 0 ? locationOffset.col : 0)
   };
 }
 

--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -13,11 +13,31 @@
  */
 
 import {SourceRange} from './source-range';
-export interface Warning {
+
+export interface WarningInit {
   readonly message: string;
   readonly sourceRange: SourceRange;
   readonly severity: Severity;
   readonly code: string;
+}
+export class Warning {
+  readonly code: string;
+  readonly message: string;
+  readonly sourceRange: SourceRange;
+  readonly severity: Severity;
+
+
+  // Useful while we migrate from object literal warnings to a warning class.
+  protected _warningBrand: never;
+
+  constructor(init: WarningInit) {
+    ({
+      message: this.message,
+      sourceRange: this.sourceRange,
+      severity: this.severity,
+      code: this.code
+    } = init);
+  }
 }
 
 export enum Severity {

--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {ParsedDocument} from '../index';
+
 import {SourceRange} from './source-range';
 
 export interface WarningInit {
@@ -19,6 +21,7 @@ export interface WarningInit {
   readonly sourceRange: SourceRange;
   readonly severity: Severity;
   readonly code: string;
+  readonly parsedDocument: ParsedDocument<any, any>|null;
 }
 export class Warning {
   readonly code: string;
@@ -26,6 +29,7 @@ export class Warning {
   readonly sourceRange: SourceRange;
   readonly severity: Severity;
 
+  private readonly _parsedDocument: ParsedDocument<any, any>|null;
 
   // Useful while we migrate from object literal warnings to a warning class.
   protected _warningBrand: never;
@@ -35,8 +39,33 @@ export class Warning {
       message: this.message,
       sourceRange: this.sourceRange,
       severity: this.severity,
-      code: this.code
+      code: this.code,
+      parsedDocument: this._parsedDocument,
     } = init);
+  }
+
+  getRelavantSourceCode(): string|undefined {
+    if (this._parsedDocument === null) {
+      return;
+    }
+    const startLineIndex =
+        this._parsedDocument.newlineIndexes[this.sourceRange.start.line];
+    const endLineIndex =
+        this._parsedDocument.newlineIndexes[this.sourceRange.end.line + 1] ||
+        this._parsedDocument.contents.length - 1;
+    if (startLineIndex === undefined) {
+      return;
+    }
+    return this._parsedDocument.contents.slice(startLineIndex, endLineIndex);
+  }
+
+  toJson() {
+    return {
+      code: this.code,
+      message: this.message,
+      severity: this.severity,
+      sourceRange: this.sourceRange,
+    };
   }
 }
 

--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -34,9 +34,6 @@ export class Warning {
 
   private readonly _parsedDocument: ParsedDocument<any, any>|null;
 
-  // Useful while we migrate from object literal warnings to a warning class.
-  protected _warningBrand: never;
-
   constructor(init: WarningInit) {
     ({
       message: this.message,

--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -24,7 +24,7 @@ export interface WarningInit {
   readonly sourceRange: SourceRange;
   readonly severity: Severity;
   readonly code: string;
-  readonly parsedDocument: ParsedDocument<any, any>|null;
+  readonly parsedDocument: ParsedDocument<any, any>;
 }
 export class Warning {
   readonly code: string;
@@ -32,7 +32,7 @@ export class Warning {
   readonly sourceRange: SourceRange;
   readonly severity: Severity;
 
-  private readonly _parsedDocument: ParsedDocument<any, any>|null;
+  private readonly _parsedDocument: ParsedDocument<any, any>;
 
   constructor(init: WarningInit) {
     ({
@@ -42,6 +42,17 @@ export class Warning {
       code: this.code,
       parsedDocument: this._parsedDocument,
     } = init);
+
+    if (!this.sourceRange) {
+      throw new Error(
+          `Attempted to construct a ${this.code} ` +
+          `warning without a source range.`);
+    }
+    if (!this._parsedDocument) {
+      throw new Error(
+          `Attempted to construct a ${this.code} ` +
+          `warning without a parsed document.`);
+    }
   }
 
   toString(options: Partial<WarningStringifyOptions> = {}): string {
@@ -51,14 +62,6 @@ export class Warning {
                                   (s: string) => s;
     const severity = this._severityToString(colorize);
 
-    if (!this.sourceRange || !this._parsedDocument) {
-      return `INTERNAL ERROR: Tried to print a '${this.code}' ` +
-          `warning without a source range and/or parsed document. ` +
-          `Please report this!\n` +
-          `     https://github.com/Polymer/polymer-analyzer/issues/new\n` +
-          `${this._severityToString(colorize)} ` +
-          `[${this.code}] - ${this.message}\n`;
-    }
     let result = '';
     if (options.verbosity !== 'one-line') {
       const underlined =

--- a/src/parser/document.ts
+++ b/src/parser/document.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {correctSourceRange, LocationOffset, SourcePosition, SourceRange} from '../model/source-range';
+import {correctSourceRange, LocationOffset, SourcePosition, SourceRange, uncorrectSourceRange} from '../model/source-range';
 
 /**
  * A parsed Document.
@@ -80,7 +80,7 @@ export abstract class ParsedDocument<AstNode, Visitor> {
 
   sourceRangeForNode(node: AstNode): SourceRange|undefined {
     const baseSource = this._sourceRangeForNode(node);
-    return correctSourceRange(baseSource, this._locationOffset);
+    return this.relativeToAbsoluteSourceRange(baseSource);
   };
 
   protected abstract _sourceRangeForNode(node: AstNode): SourceRange|undefined;
@@ -123,6 +123,25 @@ export abstract class ParsedDocument<AstNode, Visitor> {
     const result = position.column + lineOffset + 1;
     // Clamp within bounds.
     return Math.min(Math.max(0, result), this.contents.length);
+  }
+
+  relativeToAbsoluteSourceRange(sourceRange: SourceRange): SourceRange;
+  relativeToAbsoluteSourceRange(sourceRange: undefined): undefined;
+  relativeToAbsoluteSourceRange(sourceRange: SourceRange|undefined): SourceRange
+      |undefined;
+  relativeToAbsoluteSourceRange(sourceRange: SourceRange|undefined): SourceRange
+      |undefined {
+    return correctSourceRange(sourceRange, this._locationOffset);
+  }
+
+
+  absoluteToRelativeSourceRange(sourceRange: SourceRange): SourceRange;
+  absoluteToRelativeSourceRange(sourceRange: undefined): undefined;
+  absoluteToRelativeSourceRange(sourceRange: SourceRange|undefined): SourceRange
+      |undefined;
+  absoluteToRelativeSourceRange(sourceRange: SourceRange|undefined): SourceRange
+      |undefined {
+    return uncorrectSourceRange(sourceRange, this._locationOffset);
   }
 
   sourceRangeToOffsets(range: SourceRange): [number, number] {

--- a/src/polymer/analyze-properties.ts
+++ b/src/polymer/analyze-properties.ts
@@ -43,7 +43,7 @@ export function analyzeProperties(
 
   for (const property of node.properties) {
     const prop = toScannedPolymerProperty(
-        property, document.sourceRangeForNode(property)!);
+        property, document.sourceRangeForNode(property)!, document);
 
     // toScannedPolymerProperty does the wrong thing for us with type. We want
     // type to be undefined unless there's a positive signal for the type.
@@ -93,7 +93,8 @@ export function analyzeProperties(
                   code: 'invalid-property-type',
                   message: 'Invalid type in property object.',
                   severity: Severity.ERROR,
-                  sourceRange: document.sourceRangeForNode(propertyArg)!
+                  sourceRange: document.sourceRangeForNode(propertyArg)!,
+                  parsedDocument: document
                 }));
               }
             }
@@ -148,7 +149,9 @@ export function analyzeProperties(
         code: 'no-type-for-property',
         message: 'Unable to determine type for property.',
         severity: Severity.WARNING,
-        sourceRange: document.sourceRangeForNode(property)!
+        sourceRange: document.sourceRangeForNode(property)!,
+        parsedDocument: document
+
       }));
     }
 

--- a/src/polymer/analyze-properties.ts
+++ b/src/polymer/analyze-properties.ts
@@ -19,7 +19,7 @@ import * as astValue from '../javascript/ast-value';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import * as jsdoc from '../javascript/jsdoc';
-import {Severity} from '../model/model';
+import {Severity, Warning} from '../model/model';
 
 import {parseExpressionInJsStringLiteral} from './expression-scanner';
 import {toScannedPolymerProperty} from './js-utils';
@@ -89,12 +89,12 @@ export function analyzeProperties(
             if (!prop.type) {
               prop.type = esutil.objectKeyToString(propertyArg.value);
               if (prop.type === undefined) {
-                prop.warnings.push({
+                prop.warnings.push(new Warning({
                   code: 'invalid-property-type',
                   message: 'Invalid type in property object.',
                   severity: Severity.ERROR,
                   sourceRange: document.sourceRangeForNode(propertyArg)!
-                });
+                }));
               }
             }
             break;
@@ -144,12 +144,12 @@ export function analyzeProperties(
     prop.type = esutil.CLOSURE_CONSTRUCTOR_MAP.get(prop.type!) || prop.type;
 
     if (!prop.type) {
-      prop.warnings.push({
+      prop.warnings.push(new Warning({
         code: 'no-type-for-property',
         message: 'Unable to determine type for property.',
         severity: Severity.WARNING,
         sourceRange: document.sourceRangeForNode(property)!
-      });
+      }));
     }
 
     analyzedProps.push(prop);

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -89,14 +89,14 @@ class BehaviorVisitor implements Visitor {
       const prop = node.properties[i];
       const name = esutil.objectKeyToString(prop.key);
       if (!name) {
-        this.currentBehavior.warnings.push({
+        this.currentBehavior.warnings.push(new Warning({
           code: 'cant-determine-name',
           message:
               `Unable to determine property name from expression of type ` +
               `${node.type}`,
           severity: Severity.WARNING,
           sourceRange: this.document.sourceRangeForNode(node)!
-        });
+        }));
         continue;
       }
       if (name in this.propertyHandlers) {

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -95,7 +95,8 @@ class BehaviorVisitor implements Visitor {
               `Unable to determine property name from expression of type ` +
               `${node.type}`,
           severity: Severity.WARNING,
-          sourceRange: this.document.sourceRangeForNode(node)!
+          sourceRange: this.document.sourceRangeForNode(node)!,
+          parsedDocument: this.document
         }));
         continue;
       }
@@ -103,7 +104,7 @@ class BehaviorVisitor implements Visitor {
         this.propertyHandlers[name](prop.value);
       } else {
         this.currentBehavior.addProperty(toScannedPolymerProperty(
-            prop, this.document.sourceRangeForNode(prop)!));
+            prop, this.document.sourceRangeForNode(prop)!, this.document));
       }
     }
     this._finishBehavior();

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -40,7 +40,8 @@ export function getBehaviorAssignmentOrWarning(
         message: `Could not determine behavior name from expression of type ` +
             `${argNode.type}`,
         severity: Severity.WARNING,
-        sourceRange: document.sourceRangeForNode(argNode)!
+        sourceRange: document.sourceRangeForNode(argNode)!,
+        parsedDocument: document
       })
     };
   }
@@ -104,7 +105,8 @@ export function declarationPropertyHandlers(
           code: 'invalid-listeners-declaration',
           message: '`listeners` property should be an object expression',
           severity: Severity.ERROR,
-          sourceRange: document.sourceRangeForNode(node)!
+          sourceRange: document.sourceRangeForNode(node)!,
+          parsedDocument: document
         }));
         return;
       }

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -33,15 +33,15 @@ export function getBehaviorAssignmentOrWarning(
     document: JavaScriptDocument): BehaviorAssignmentOrWarning {
   const behaviorName = astValue.getIdentifierName(argNode);
   if (!behaviorName) {
-    return {kind: 'warning', warning: {
-              code: 'could-not-determine-behavior-name',
-              message:
-                  `Could not determine behavior name from expression of type ${
-    argNode.type
-                                                                       }`,
+    return {
+      kind: 'warning',
+      warning: new Warning({
+        code: 'could-not-determine-behavior-name',
+        message: `Could not determine behavior name from expression of type ` +
+            `${argNode.type}`,
         severity: Severity.WARNING,
         sourceRange: document.sourceRangeForNode(argNode)!
-      }
+      })
     };
   }
   return {
@@ -100,12 +100,12 @@ export function declarationPropertyHandlers(
     listeners(node: estree.Node) {
 
       if (node.type !== 'ObjectExpression') {
-        declaration.warnings.push({
+        declaration.warnings.push(new Warning({
           code: 'invalid-listeners-declaration',
           message: '`listeners` property should be an object expression',
           severity: Severity.ERROR,
           sourceRange: document.sourceRangeForNode(node)!
-        });
+        }));
         return;
       }
 

--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -17,10 +17,10 @@ import * as estree from 'estree';
 import * as parse5 from 'parse5';
 
 import {ParsedHtmlDocument} from '../html/html-document';
-import {ParsedDocument} from '../index';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {parseJs} from '../javascript/javascript-parser';
 import {correctSourceRange, LocationOffset, Severity, SourceRange, Warning} from '../model/model';
+import {ParsedDocument} from '../parser/document';
 
 
 const p = dom5.predicates;

--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -199,12 +199,12 @@ export abstract class DatabindingExpression {
   }
 
   private _validationWarning(message: string, node: estree.Node): Warning {
-    return {
+    return new Warning({
       code: 'invalid-polymer-expression',
       message,
       sourceRange: this.sourceRangeForNode(node)!,
       severity: Severity.WARNING
-    };
+    });
   }
 }
 
@@ -489,22 +489,22 @@ export function parseExpressionInJsStringLiteral(
   if (stringLiteral.type !== 'Literal') {
     // Should we warn here? It's potentially valid, just unanalyzable. Maybe
     // just an info that someone could escalate to a warning/error?
-    warnings.push({
+    warnings.push(new Warning({
       code: 'unanalyzable-polymer-expression',
       message: `Can only analyze databinding expressions in string literals.`,
       severity: Severity.INFO,
       sourceRange: sourceRangeForLiteral,
-    });
+    }));
     return result;
   }
   const expressionText = stringLiteral.value;
   if (typeof expressionText !== 'string') {
-    warnings.push({
+    warnings.push(new Warning({
       code: 'invalid-polymer-expression',
       message: `Expected a string, got a ${typeof expressionText}.`,
       sourceRange: sourceRangeForLiteral,
       severity: Severity.WARNING
-    });
+    }));
     return result;
   }
   const sourceRange: SourceRange = {

--- a/src/polymer/js-utils.ts
+++ b/src/polymer/js-utils.ts
@@ -16,10 +16,10 @@ import * as doctrine from 'doctrine';
 import * as escodegen from 'escodegen';
 import * as estree from 'estree';
 
-import {ParsedDocument} from '../index';
 import {closureType, getAttachedComment, objectKeyToString} from '../javascript/esutil';
 import * as jsdoc from '../javascript/jsdoc';
 import {Privacy, ScannedMethod, Severity, SourceRange, Warning} from '../model/model';
+import {ParsedDocument} from '../parser/document';
 
 import {ScannedPolymerProperty} from './polymer-element';
 

--- a/src/polymer/js-utils.ts
+++ b/src/polymer/js-utils.ts
@@ -16,6 +16,7 @@ import * as doctrine from 'doctrine';
 import * as escodegen from 'escodegen';
 import * as estree from 'estree';
 
+import {ParsedDocument} from '../index';
 import {closureType, getAttachedComment, objectKeyToString} from '../javascript/esutil';
 import * as jsdoc from '../javascript/jsdoc';
 import {Privacy, ScannedMethod, Severity, SourceRange, Warning} from '../model/model';
@@ -27,7 +28,8 @@ import {ScannedPolymerProperty} from './polymer-element';
  */
 export function toScannedPolymerProperty(
     node: estree.Property|estree.MethodDefinition,
-    sourceRange: SourceRange): ScannedPolymerProperty {
+    sourceRange: SourceRange,
+    document: ParsedDocument<any, any>): ScannedPolymerProperty {
   const parsedJsdoc = jsdoc.parseJsdoc(getAttachedComment(node) || '');
   const description = parsedJsdoc.description.trim();
   const maybeName = objectKeyToString(node.key);
@@ -40,10 +42,11 @@ export function toScannedPolymerProperty(
           `Could not determine name of property from expression of type: ` +
           `${node.key.type}`,
       sourceRange: sourceRange,
-      severity: Severity.WARNING
+      severity: Severity.WARNING,
+      parsedDocument: document
     }));
   }
-  let type = closureType(node.value, sourceRange);
+  let type = closureType(node.value, sourceRange, document);
   const typeTag = jsdoc.getTag(parsedJsdoc, 'type');
   if (typeTag) {
     type = doctrine.type.stringify(typeTag.type!) || type;
@@ -93,9 +96,10 @@ const configurationProperties = new Set([
  */
 export function toScannedMethod(
     node: estree.Property|estree.MethodDefinition,
-    sourceRange: SourceRange): ScannedMethod {
+    sourceRange: SourceRange,
+    document: ParsedDocument<any, any>): ScannedMethod {
   const scannedMethod: ScannedMethod =
-      toScannedPolymerProperty(node, sourceRange);
+      toScannedPolymerProperty(node, sourceRange, document);
 
   if (scannedMethod.type === 'Function' ||
       scannedMethod.type === 'ArrowFunction') {

--- a/src/polymer/js-utils.ts
+++ b/src/polymer/js-utils.ts
@@ -34,16 +34,14 @@ export function toScannedPolymerProperty(
 
   const warnings: Warning[] = [];
   if (!maybeName) {
-    warnings.push({
+    warnings.push(new Warning({
       code: 'unknown-prop-name',
       message:
-          `Could not determine name of property from expression of type: ${
-                                                                           node.key
-                                                                               .type
-                                                                         }`,
+          `Could not determine name of property from expression of type: ` +
+          `${node.key.type}`,
       sourceRange: sourceRange,
       severity: Severity.WARNING
-    });
+    }));
   }
   let type = closureType(node.value, sourceRange);
   const typeTag = jsdoc.getTag(parsedJsdoc, 'type');

--- a/src/polymer/polymer-core-feature-scanner.ts
+++ b/src/polymer/polymer-core-feature-scanner.ts
@@ -14,13 +14,12 @@
 
 import * as estree from 'estree';
 
-import {Warning} from '../index';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import {JavaScriptScanner} from '../javascript/javascript-scanner';
 import * as jsdoc from '../javascript/jsdoc';
-import {Severity} from '../model/model';
+import {Severity, Warning} from '../model/model';
 
 import {toScannedMethod, toScannedPolymerProperty} from './js-utils';
 import {ScannedPolymerCoreFeature} from './polymer-core-feature';

--- a/src/polymer/polymer-core-feature-scanner.ts
+++ b/src/polymer/polymer-core-feature-scanner.ts
@@ -78,6 +78,7 @@ class PolymerCoreFeatureVisitor implements Visitor {
         severity: Severity.ERROR,
         code: 'invalid-polymer-base-assignment',
         sourceRange: this.document.sourceRangeForNode(assignment)!,
+        parsedDocument: this.document
       }));
       return;
     }
@@ -112,6 +113,7 @@ class PolymerCoreFeatureVisitor implements Visitor {
         severity: Severity.ERROR,
         code: 'invalid-polymer-core-feature-call',
         sourceRange: this.document.sourceRangeForNode(call)!,
+        parsedDocument: this.document
       }));
       return;
     }
@@ -124,6 +126,7 @@ class PolymerCoreFeatureVisitor implements Visitor {
         severity: Severity.ERROR,
         code: 'invalid-polymer-core-feature-call',
         sourceRange: this.document.sourceRangeForNode(call)!,
+        parsedDocument: this.document
       }));
       return;
     }
@@ -143,10 +146,11 @@ class PolymerCoreFeatureVisitor implements Visitor {
         continue;
       }
       if (esutil.isFunctionType(prop.value)) {
-        const method = toScannedMethod(prop, sourceRange);
+        const method = toScannedMethod(prop, sourceRange, this.document);
         feature.methods.set(method.name, method);
       } else {
-        const property = toScannedPolymerProperty(prop, sourceRange);
+        const property =
+            toScannedPolymerProperty(prop, sourceRange, this.document);
         feature.properties.set(property.name, property);
       }
       // TODO(aomarks) Are there any getters/setters on Polymer.Base?

--- a/src/polymer/polymer-core-feature-scanner.ts
+++ b/src/polymer/polymer-core-feature-scanner.ts
@@ -14,6 +14,7 @@
 
 import * as estree from 'estree';
 
+import {Warning} from '../index';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
 import {JavaScriptDocument} from '../javascript/javascript-document';
@@ -71,13 +72,13 @@ class PolymerCoreFeatureVisitor implements Visitor {
 
     const rhs = assignment.right;
     if (rhs.type !== 'ObjectExpression') {
-      feature.warnings.push({
+      feature.warnings.push(new Warning({
         message: `Expected assignment to \`Polymer.Base\` to be an object.` +
             `Got \`${rhs.type}\` instead.`,
         severity: Severity.ERROR,
         code: 'invalid-polymer-base-assignment',
         sourceRange: this.document.sourceRangeForNode(assignment)!,
-      });
+      }));
       return;
     }
 
@@ -104,26 +105,26 @@ class PolymerCoreFeatureVisitor implements Visitor {
     this.features.push(feature);
 
     if (call.arguments.length !== 1) {
-      feature.warnings.push({
+      feature.warnings.push(new Warning({
         message:
             `Expected only one argument to \`Polymer.Base._addFeature\`. ` +
             `Got ${call.arguments.length}.`,
         severity: Severity.ERROR,
         code: 'invalid-polymer-core-feature-call',
         sourceRange: this.document.sourceRangeForNode(call)!,
-      });
+      }));
       return;
     }
 
     const arg = call.arguments[0];
     if (arg.type !== 'ObjectExpression') {
-      feature.warnings.push({
+      feature.warnings.push(new Warning({
         message: `Expected argument to \`Polymer.Base._addFeature\` to be an ` +
             `object. Got \`${arg.type}\` instead.`,
         severity: Severity.ERROR,
         code: 'invalid-polymer-core-feature-call',
         sourceRange: this.document.sourceRangeForNode(call)!,
-      });
+      }));
       return;
     }
 

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -256,7 +256,7 @@ class ElementVisitor implements Visitor {
       for (const prop of node.properties) {
         const name = objectKeyToString(prop.key);
         if (!name) {
-          element.warnings.push({
+          element.warnings.push(new Warning({
             message:
                 `Can't determine name for property key from expression with type ${
                                                                                    prop.key
@@ -265,7 +265,7 @@ class ElementVisitor implements Visitor {
             code: 'cant-determine-property-name',
             severity: Severity.WARNING,
             sourceRange: this.document.sourceRangeForNode(prop.key)!
-          });
+          }));
           continue;
         }
 

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -129,7 +129,7 @@ class ElementVisitor implements Visitor {
       const returnStatement = <estree.ReturnStatement>node.value.body.body[0];
       const argument = <estree.ArrayExpression>returnStatement.argument;
       const propDesc = toScannedPolymerProperty(
-          prop, this.document.sourceRangeForNode(node)!);
+          prop, this.document.sourceRangeForNode(node)!, this.document);
       docs.annotate(propDesc);
 
       // We only support observers and behaviors getters that return array
@@ -174,8 +174,8 @@ class ElementVisitor implements Visitor {
     }
 
     if (node.kind === 'method') {
-      const methodDesc =
-          toScannedMethod(prop, this.document.sourceRangeForNode(node)!);
+      const methodDesc = toScannedMethod(
+          prop, this.document.sourceRangeForNode(node)!, this.document);
       docs.annotate(methodDesc);
       element.addMethod(methodDesc);
     }
@@ -264,7 +264,8 @@ class ElementVisitor implements Visitor {
                                                                                  }.`,
             code: 'cant-determine-property-name',
             severity: Severity.WARNING,
-            sourceRange: this.document.sourceRangeForNode(prop.key)!
+            sourceRange: this.document.sourceRangeForNode(prop.key)!,
+            parsedDocument: this.document
           }));
           continue;
         }
@@ -280,14 +281,14 @@ class ElementVisitor implements Visitor {
 
         try {
           const scannedPolymerProperty = toScannedPolymerProperty(
-              prop, this.document.sourceRangeForNode(prop)!);
+              prop, this.document.sourceRangeForNode(prop)!, this.document);
           if (prop.kind === 'get') {
             getters[scannedPolymerProperty.name] = scannedPolymerProperty;
           } else if (prop.kind === 'set') {
             setters[scannedPolymerProperty.name] = scannedPolymerProperty;
           } else if (prop.method === true || isFunctionType(prop.value)) {
-            const scannedPolymerMethod =
-                toScannedMethod(prop, this.document.sourceRangeForNode(prop)!);
+            const scannedPolymerMethod = toScannedMethod(
+                prop, this.document.sourceRangeForNode(prop)!, this.document);
             element.addMethod(scannedPolymerMethod);
           } else {
             element.addProperty(scannedPolymerProperty);

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -321,24 +321,24 @@ export function getBehaviors(
       externalPackages: true
     });
     if (foundBehaviors.size === 0) {
-      warnings.push({
+      warnings.push(new Warning({
         message: `Unable to resolve behavior ` +
             `\`${behavior.name}\`. Did you import it? Is it annotated with ` +
             `@polymerBehavior?`,
         severity: Severity.ERROR,
         code: 'unknown-polymer-behavior',
         sourceRange: behavior.sourceRange
-      });
+      }));
       // Skip processing this behavior.
       continue;
     }
     if (foundBehaviors.size > 1) {
-      warnings.push({
+      warnings.push(new Warning({
         message: `Found more than one behavior named ${behavior.name}.`,
         severity: Severity.WARNING,
         code: 'multiple-polymer-behaviors',
         sourceRange: behavior.sourceRange
-      });
+      }));
       // Don't skip processing this behavior, just take the most recently
       // declared instance.
     }

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -327,7 +327,8 @@ export function getBehaviors(
             `@polymerBehavior?`,
         severity: Severity.ERROR,
         code: 'unknown-polymer-behavior',
-        sourceRange: behavior.sourceRange
+        sourceRange: behavior.sourceRange,
+        parsedDocument: document.parsedDocument
       }));
       // Skip processing this behavior.
       continue;
@@ -337,7 +338,8 @@ export function getBehaviors(
         message: `Found more than one behavior named ${behavior.name}.`,
         severity: Severity.WARNING,
         code: 'multiple-polymer-behaviors',
-        sourceRange: behavior.sourceRange
+        sourceRange: behavior.sourceRange,
+        parsedDocument: document.parsedDocument
       }));
       // Don't skip processing this behavior, just take the most recently
       // declared instance.

--- a/src/polymer/polymer2-config.ts
+++ b/src/polymer/polymer2-config.ts
@@ -82,8 +82,8 @@ export function getMethods(node: estree.Node, document: JavaScriptDocument):
   for (const statement of node.body.body) {
     if (statement.type === 'MethodDefinition' && statement.static === false &&
         statement.kind === 'method') {
-      const method =
-          toScannedMethod(statement, document.sourceRangeForNode(statement)!);
+      const method = toScannedMethod(
+          statement, document.sourceRangeForNode(statement)!, document);
       docs.annotate(method);
       methods.set(method.name, method);
     }

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -228,9 +228,11 @@ suite('Analyzer', () => {
           };
           assert.deepEqual(document.getWarnings({imported: false}), []);
           assert.deepEqual(
-              document.getWarnings({imported: true}), [expectedWarning]);
+              document.getWarnings({imported: true}).map((w) => w.toJson()),
+              [expectedWarning]);
           assert.deepEqual(
-              chainedDocument.getWarnings({imported: false}),
+              chainedDocument.getWarnings({imported: false})
+                  .map((w) => w.toJson()),
               [expectedWarning]);
         });
 

--- a/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -21,6 +21,7 @@ import {ClassScanner} from '../../javascript/class-scanner';
 import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
+
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {CodeUnderliner} from '../test-utils';
 

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -103,7 +103,7 @@ suite('Polymer2MixinScanner', () => {
                        underlinedWarnings: []
                      }]);
     const underlinedSource = await underliner.underline(mixins[0].sourceRange);
-    assert.equal(underlinedSource, `
+    assert.deepEqual(underlinedSource, `
 function TestMixin(superclass) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   return class extends superclass {
@@ -147,7 +147,7 @@ function TestMixin(superclass) {
                        underlinedWarnings: []
                      }]);
     const underlinedSource = await underliner.underline(mixins[0].sourceRange);
-    assert.equal(underlinedSource, `
+    assert.deepEqual(underlinedSource, `
 const TestMixin = (superclass) => class extends superclass {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   static get properties() {
@@ -187,7 +187,7 @@ const TestMixin = (superclass) => class extends superclass {
                        underlinedWarnings: [],
                      }]);
     const underlinedSource = await underliner.underline(mixins[0].sourceRange);
-    assert.equal(underlinedSource, `
+    assert.deepEqual(underlinedSource, `
 const TestMixin = function(superclass) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   return class extends superclass {
@@ -230,7 +230,7 @@ const TestMixin = function(superclass) {
                          }]);
         const underlinedSource =
             await underliner.underline(mixins[0].sourceRange);
-        assert.equal(underlinedSource, `
+        assert.deepEqual(underlinedSource, `
 let TestMixin;
 ~~~~~~~~~~~~~~`);
       });
@@ -254,7 +254,7 @@ let TestMixin;
                        underlinedWarnings: []
                      }]);
     const underlinedSource = await underliner.underline(mixins[0].sourceRange);
-    assert.equal(underlinedSource, `
+    assert.deepEqual(underlinedSource, `
 function TestMixin() {
 ~~~~~~~~~~~~~~~~~~~~~~
 }

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -85,7 +85,7 @@ export class CodeUnderliner {
       return 'No source range given.';
     }
     if (isWarning(reference)) {
-      return '\n' + reference.toString({verbosity: 'code-only'});
+      return '\n' + reference.toString({verbosity: 'code-only', color: false});
     }
     // We have a reference without its parsed document. Go get it.
     const parsedDocument = await this._parsedDocumentGetter(reference.file);

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -13,10 +13,11 @@
  */
 
 import {Analyzer} from '../core/analyzer';
+import {Document, ParsedDocument} from '../index';
 import {SourceRange, Warning} from '../model/model';
 import {InMemoryOverlayUrlLoader} from '../url-loader/overlay-loader';
 import {UrlLoader} from '../url-loader/url-loader';
-import {WarningPrinter} from '../warning/warning-printer';
+import {underlineCode} from '../warning/code-printer';
 
 
 export class UnexpectedResolutionError extends Error {
@@ -46,10 +47,18 @@ export type Reference = Warning | SourceRange | undefined;
  * Non-test code probably wants WarningPrinter instead.
  */
 export class CodeUnderliner {
-  warningPrinter: WarningPrinter;
+  private _parsedDocumentGetter:
+      (url: string) => Promise<ParsedDocument<any, any>>;
   constructor(urlLoader: UrlLoader) {
-    this.warningPrinter =
-        new WarningPrinter(null as any, {analyzer: new Analyzer({urlLoader})});
+    const analyzer = new Analyzer({urlLoader});
+    this._parsedDocumentGetter = async(url: string) => {
+      const analysis = await analyzer.analyze([url]);
+      const result = analysis.getDocument(url);
+      if (!(result instanceof Document)) {
+        throw new Error(`Unable to parse ${url}`);
+      }
+      return result.parsedDocument;
+    };
   }
 
   static withMapping(url: string, contents: string) {
@@ -67,16 +76,20 @@ export class CodeUnderliner {
    */
   async underline(reference: Reference): Promise<string>;
   async underline(references: Reference[]): Promise<string[]>;
-  async underline(references: Reference|Reference[]): Promise<string|string[]> {
-    if (!Array.isArray(references)) {
-      if (references === undefined) {
-        return 'No source range given.';
-      }
-      const sourceRange =
-          isWarning(references) ? references.sourceRange : references;
-      return '\n' + await this.warningPrinter.getUnderlinedText(sourceRange);
+  async underline(reference: Reference|Reference[]): Promise<string|string[]> {
+    if (Array.isArray(reference)) {
+      return Promise.all(reference.map((ref) => this.underline(ref)));
     }
-    return Promise.all(references.map((ref) => this.underline(ref)));
+
+    if (reference === undefined) {
+      return 'No source range given.';
+    }
+    if (isWarning(reference)) {
+      return '\n' + reference.toString({verbosity: 'code-only'});
+    }
+    // We have a reference without its parsed document. Go get it.
+    const parsedDocument = await this._parsedDocumentGetter(reference.file);
+    return '\n' + underlineCode(reference, parsedDocument);
   }
 }
 

--- a/src/test/warning/warning-printer_test.ts
+++ b/src/test/warning/warning-printer_test.ts
@@ -30,7 +30,8 @@ const dumbNameWarning = new Warning({
     file: 'vanilla-elements.js',
     start: {column: 6, line: 0},
     end: {column: 22, line: 0}
-  }
+  },
+  parsedDocument: null
 });
 
 const goodJobWarning = new Warning({
@@ -41,7 +42,8 @@ const goodJobWarning = new Warning({
     file: 'vanilla-elements.js',
     start: {line: 22, column: 2},
     end: {line: 29, column: 3}
-  }
+  },
+  parsedDocument: null
 });
 
 const staticTestDir = path.join(__dirname, '../static');

--- a/src/test/warning/warning-printer_test.ts
+++ b/src/test/warning/warning-printer_test.ts
@@ -22,7 +22,7 @@ import {Severity, Warning} from '../../model/model';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {WarningPrinter} from '../../warning/warning-printer';
 
-const dumbNameWarning: Warning = {
+const dumbNameWarning = new Warning({
   message: 'This is a dumb name for an element.',
   code: 'dumb-element-name',
   severity: Severity.WARNING,
@@ -31,9 +31,9 @@ const dumbNameWarning: Warning = {
     start: {column: 6, line: 0},
     end: {column: 22, line: 0}
   }
-};
+});
 
-const goodJobWarning: Warning = {
+const goodJobWarning = new Warning({
   message: 'Good job with this observedAttributes getter.',
   code: 'cool-observed-attributes',
   severity: Severity.INFO,
@@ -42,7 +42,7 @@ const goodJobWarning: Warning = {
     start: {line: 22, column: 2},
     end: {line: 29, column: 3}
   }
-};
+});
 
 const staticTestDir = path.join(__dirname, '../static');
 

--- a/src/test/warning/warning-printer_test.ts
+++ b/src/test/warning/warning-printer_test.ts
@@ -64,7 +64,7 @@ suite('WarningPrinter', () => {
     output = new memoryStreams.WritableStream();
     const urlLoader = new FSUrlLoader(staticTestDir);
     analyzer = new Analyzer({urlLoader});
-    printer = new WarningPrinter(output, {analyzer, color: false});
+    printer = new WarningPrinter(output, {color: false});
     originalChalkEnabled = chalk.enabled;
     (chalk as any).enabled = true;
   });
@@ -92,8 +92,7 @@ vanilla-elements.js(0,6) warning [dumb-element-name] - This is a dumb name for a
   });
 
   test('can format and print one-line warnings', async() => {
-    printer = new WarningPrinter(
-        output, {analyzer, verbosity: 'one-line', color: false});
+    printer = new WarningPrinter(output, {verbosity: 'one-line', color: false});
     await printer.printWarnings([dumbNameWarning]);
     const actual = output.toString();
     const expected =
@@ -102,7 +101,7 @@ vanilla-elements.js(0,6) warning [dumb-element-name] - This is a dumb name for a
   });
 
   test('it adds color if configured to do so', async() => {
-    printer = new WarningPrinter(output, {analyzer, color: true});
+    printer = new WarningPrinter(output, {color: true});
     await printer.printWarnings([dumbNameWarning]);
     const actual = output.toString();
     const expected = `

--- a/src/typescript/typescript-preparser.ts
+++ b/src/typescript/typescript-preparser.ts
@@ -46,6 +46,13 @@ export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
     const diagnostics = sourceFileMaybeWithDiagnostics.parseDiagnostics || [];
     const parseError =
         diagnostics.find((d) => d.category === ts.DiagnosticCategory.Error);
+    const result = new ParsedTypeScriptDocument({
+      url,
+      contents,
+      ast: sourceFile,
+      locationOffset: inlineInfo.locationOffset,
+      astNode: inlineInfo.astNode, isInline,
+    });
     if (parseError) {
       const start = sourceFile.getLineAndCharacterOfPosition(parseError.start);
       const end = sourceFile.getLineAndCharacterOfPosition(
@@ -60,15 +67,10 @@ export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
               start: {column: start.character, line: start.line},
               end: {column: end.character, line: end.line}
             },
-            inlineInfo.locationOffset)!
+            inlineInfo.locationOffset)!,
+        parsedDocument: result,
       }));
     }
-    return new ParsedTypeScriptDocument({
-      url,
-      contents,
-      ast: sourceFile,
-      locationOffset: inlineInfo.locationOffset,
-      astNode: inlineInfo.astNode, isInline,
-    });
+    return result;
   }
 }

--- a/src/typescript/typescript-preparser.ts
+++ b/src/typescript/typescript-preparser.ts
@@ -14,7 +14,7 @@
 
 import * as ts from 'typescript';
 
-import {correctSourceRange, InlineDocInfo, Severity, WarningCarryingException} from '../model/model';
+import {correctSourceRange, InlineDocInfo, Severity, Warning, WarningCarryingException} from '../model/model';
 import {Parser} from '../parser/parser';
 
 import {ParsedTypeScriptDocument} from './typescript-document';
@@ -50,7 +50,7 @@ export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
       const start = sourceFile.getLineAndCharacterOfPosition(parseError.start);
       const end = sourceFile.getLineAndCharacterOfPosition(
           parseError.start + parseError.length);
-      throw new WarningCarryingException({
+      throw new WarningCarryingException(new Warning({
         code: 'parse-error',
         severity: Severity.ERROR,
         message: ts.flattenDiagnosticMessageText(parseError.messageText, '\n'),
@@ -61,7 +61,7 @@ export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
               end: {column: end.character, line: end.line}
             },
             inlineInfo.locationOffset)!
-      });
+      }));
     }
     return new ParsedTypeScriptDocument({
       url,

--- a/src/warning/code-printer.ts
+++ b/src/warning/code-printer.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {SourceRange} from '../model/model';
+import {ParsedDocument} from '../parser/document';
+
+export function underlineCode(
+    sourceRange: SourceRange,
+    parsedDocument: ParsedDocument<any, any>,
+    colorizer = (s: string) => s): string|undefined {
+  const relativeRange =
+      parsedDocument.absoluteToRelativeSourceRange(sourceRange);
+  const code = _getRelavantSourceCode(relativeRange, parsedDocument);
+  if (!code) {
+    return undefined;
+  }
+  const outputLines: string[] = [];
+  const lines = code.split('\n');
+  let lineNum = relativeRange.start.line;
+  for (const line of lines) {
+    outputLines.push(line);
+    outputLines.push(
+        colorizer(getSquiggleUnderline(line, lineNum, relativeRange)));
+    lineNum++;
+  }
+  return outputLines.join('\n');
+}
+
+function _getRelavantSourceCode(
+    relativeRange: SourceRange,
+    parsedDocument: ParsedDocument<any, any>): string|undefined {
+  if (parsedDocument === null) {
+    return;
+  }
+  const startOffset = parsedDocument.sourcePositionToOffset(
+      {column: 0, line: relativeRange.start.line});
+  let endOffset;
+  if (parsedDocument.newlineIndexes.length === relativeRange.end.line) {
+    endOffset = parsedDocument.sourcePositionToOffset(
+        {column: 0, line: relativeRange.end.line + 1});
+  } else {
+    endOffset = parsedDocument.sourcePositionToOffset(
+        {column: -1, line: relativeRange.end.line + 1});
+  }
+
+  return parsedDocument.contents.slice(startOffset, endOffset);
+}
+
+function getSquiggleUnderline(
+    lineText: string, lineNum: number, sourceRange: SourceRange) {
+  // We're on a middle line of a multiline range. Squiggle the entire line.
+  if (lineNum !== sourceRange.start.line && lineNum !== sourceRange.end.line) {
+    return '~'.repeat(lineText.length);
+  }
+  // The tricky case. Might be the start of a multiline range, or it might just
+  // be a one-line range.
+  if (lineNum === sourceRange.start.line) {
+    const startColumn = sourceRange.start.column;
+    const endColumn = sourceRange.end.line === sourceRange.start.line ?
+        sourceRange.end.column :
+        lineText.length;
+    const prefix = lineText.slice(0, startColumn).replace(/[^\t]/g, ' ');
+    if (startColumn === endColumn) {
+      return prefix + '~';  // always draw at least one squiggle
+    }
+    return prefix + '~'.repeat(endColumn - startColumn);
+  }
+
+  // We're on the end line of a multiline range. Just squiggle up to the end
+  // column.
+  return '~'.repeat(sourceRange.end.column);
+}

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -44,7 +44,10 @@ export class WarningPrinter {
    */
   async printWarnings(warnings: Iterable<Warning>) {
     for (const warning of warnings) {
-      await this.printWarning(warning);
+      if (this._options.verbosity === 'full') {
+        this._outStream.write('\n\n');
+      }
+      this._outStream.write(warning.toString(this._options));
     }
   }
 

--- a/src/warning/warning-printer.ts
+++ b/src/warning/warning-printer.ts
@@ -14,19 +14,17 @@
 
 import * as chalk from 'chalk';
 
-import {Analyzer} from '../core/analyzer';
-import {Severity, SourceRange, Warning} from '../model/model';
+import {Warning} from '../model/model';
 
 export type Verbosity = 'one-line' | 'full';
 
 export interface Options {
-  analyzer: Analyzer;
   verbosity?: Verbosity;
   color?: boolean;
 }
 
 const defaultPrinterOptions = {
-  verbosity: 'full',
+  verbosity: 'full' as 'full',
   color: true
 };
 
@@ -34,8 +32,8 @@ export class WarningPrinter {
   _chalk: chalk.Chalk;
   private _options: Options;
 
-  constructor(private _outStream: NodeJS.WritableStream, options: Options) {
-    this._options = Object.assign({}, defaultPrinterOptions, options);
+  constructor(private _outStream: NodeJS.WritableStream, options?: Options) {
+    this._options = {...defaultPrinterOptions, ...options};
     this._chalk = new chalk.constructor({enabled: !!this._options.color});
   }
 
@@ -50,112 +48,4 @@ export class WarningPrinter {
       this._outStream.write(warning.toString(this._options));
     }
   }
-
-  async printWarning(warning: Warning) {
-    const severity = this._severityToString(warning.severity);
-    const range = warning.sourceRange;
-    if (!range) {
-      this._outStream.write(
-          `INTERNAL ERROR: Tried to print a '${warning.code}' ` +
-          `warning without a source range. Please report this!\n` +
-          `     https://github.com/Polymer/polymer-analyzer/issues/new\n`);
-      this._outStream.write(
-          `${this._severityToString(warning.severity)} ` +
-          `[${warning.code}] - ${warning.message}\n`);
-      return;
-    }
-
-    if (this._options.verbosity === 'full') {
-      this._outStream.write('\n\n');
-      this._outStream.write(
-          await this.getUnderlinedText(range, warning.severity) + '\n\n');
-    }
-
-    this._outStream.write(
-        `${range.file}` +
-        `(${range.start.line},${range.start.column}) ` +
-        `${severity} [${warning.code}] - ${warning.message}\n`);
-  }
-
-  private _severityToString(severity: Severity) {
-    const colorFunction = this._severityToColorFunction(severity);
-    switch (severity) {
-      case Severity.ERROR:
-        return colorFunction('error');
-      case Severity.WARNING:
-        return colorFunction('warning');
-      case Severity.INFO:
-        return colorFunction('info');
-      default:
-        const never: never = severity;
-        throw new Error(
-            `Unknown severity value - ${never} - ` +
-            `encountered while printing warning.`);
-    }
-  }
-
-  async getUnderlinedText(range: SourceRange, severity?: Severity) {
-    const colorFunction = severity == null ?
-        (v: string) => v :
-        this._severityToColorFunction(severity);
-
-    const lines = await this._getLinesOfText(
-        range.start.line, range.end.line, range.file);
-    const outputLines: string[] = [];
-    let lineNum = range.start.line;
-    for (const line of lines) {
-      outputLines.push(line);
-      outputLines.push(
-          colorFunction(getSquiggleUnderline(line, lineNum, range)));
-      lineNum++;
-    }
-    return outputLines.join('\n');
-  }
-
-  private _severityToColorFunction(severity: Severity) {
-    switch (severity) {
-      case Severity.ERROR:
-        return this._chalk.red;
-      case Severity.WARNING:
-        return this._chalk.yellow;
-      case Severity.INFO:
-        return this._chalk.green;
-      default:
-        const never: never = severity;
-        throw new Error(
-            `Unknown severity value - ${never}` +
-            ` - encountered while printing warning.`);
-    }
-  }
-
-  private async _getLinesOfText(
-      startLine: number, endLine: number, localPath: string) {
-    const contents = await this._options.analyzer.load(localPath);
-    return contents.split('\n').slice(startLine, endLine + 1);
-  }
-}
-
-function getSquiggleUnderline(
-    lineText: string, lineNum: number, sourceRange: SourceRange) {
-  // We're on a middle line of a multiline range. Squiggle the entire line.
-  if (lineNum !== sourceRange.start.line && lineNum !== sourceRange.end.line) {
-    return '~'.repeat(lineText.length);
-  }
-  // The tricky case. Might be the start of a multiline range, or it might just
-  // be a one-line range.
-  if (lineNum === sourceRange.start.line) {
-    const startColumn = sourceRange.start.column;
-    const endColumn = sourceRange.end.line === sourceRange.start.line ?
-        sourceRange.end.column :
-        lineText.length;
-    const prefix = lineText.slice(0, startColumn).replace(/[^\t]/g, ' ');
-    if (startColumn === endColumn) {
-      return prefix + '~';  // always draw at least one squiggle
-    }
-    return prefix + '~'.repeat(endColumn - startColumn);
-  }
-
-  // We're on the end line of a multiline range. Just squiggle up to the end
-  // column.
-  return '~'.repeat(sourceRange.end.column);
 }


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

One last thing question here. `Warning` is a bit of an awkward name for this, as warnings can have error severity or info severity, etc. If there's a better name this would be the time to change it, as we'll need to do one last pass to update all uses anyways. The Microsoft world calls them Diagnostics, which I find a touch too abstract. The atom linter calls them Messages, which I kinda like.