### PR TITLE
Fix README example so it will run by passing file path to analyze in an Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ let analyzer = new Analyzer({
   urlLoader: new FSUrlLoader(pathToPackageRoot),
 });
 
-analyzer.analyze('/path-to-polymer-element.html')
+analyzer.analyze(['/path-to-polymer-element.html'])
   .then((document) => {
     for (const element of document.getFeatures({kind: 'element'})) {
       console.log(element);


### PR DESCRIPTION
The current example snippet in the README.md passes a file path to analyze as a string to `analyzer.analyze`.

```
analyzer.analyze('/path-to-polymer-element.html').then(...)
```

Running this code snippet with the correct files in place to analyze produces the following error:

```
(node:5737) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): TypeError: urls.map is not a function
(node:5737) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

It looks like the issue comes [from this bit of code in the analyzer module](https://github.com/Polymer/polymer-analyzer/blob/965c9fa8ae1ae10d2aa076ab92b2ed6fd87e7aed/src/core/analyzer.ts#L83-L94):

```
  /**
   * Loads, parses and analyzes the root document of a dependency graph and its
   * transitive dependencies.
   */
  async analyze(urls: string[]): Promise<Analysis> {
    const previousAnalysisComplete = this._analysisComplete;
    this._analysisComplete = (async() => {
      const previousContext = await previousAnalysisComplete;
      return await previousContext.analyze(urls);
    })();
    const context = await this._analysisComplete;
    const results = new Map(urls.map(
        (url) => [url, context.getDocument(url)] as
            [string, Document | Warning]));
    return new Analysis(results);
```

When the Map is created, calling `urls.map` on the string fails and throws a `TypeError`. This PR fixes the README example snippet to pass an Array, which fixes the issue:

```
analyzer.analyze(['/path-to-polymer-element.html']).then(...)
```