### PR TITLE
Track methods on behaviors properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!--## Unreleased-->
+## Unreleased
+
+* Track methods on behaviors as such. They were being treated as properties.
 
 ## [2.0.1] - 2017-05-15
 

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -96,14 +96,19 @@ suite('BehaviorScanner', () => {
     const deepChainedBehaviors =
         behaviors.get('Really.Really.Deep.Behavior')!.behaviorAssignments;
     assert.deepEqual(
-        childBehaviors.map((b: ScannedBehaviorAssignment) => b.name), [
-          'SimpleBehavior',
-          'CustomNamedBehavior',
-          'Really.Really.Deep.Behavior'
-        ]);
+        childBehaviors.map((b: ScannedBehaviorAssignment) => b.name),
+        ['SimpleBehavior', 'AwesomeBehavior', 'Really.Really.Deep.Behavior']);
     assert.deepEqual(
         deepChainedBehaviors.map((b: ScannedBehaviorAssignment) => b.name),
         ['Do.Re.Mi.Fa']);
   });
 
+  test('Does not count methods as properties', function() {
+    const behavior = behaviors.get('Polymer.SimpleNamespacedBehavior');
+    if (!behavior) {
+      throw new Error('Could not find Polymer.SimpleNamespacedBehavior');
+    }
+    assert.deepEqual([...behavior.methods.keys()], ['method']);
+    assert.deepEqual([...behavior.properties.keys()], ['simple']);
+  });
 });

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -9,6 +9,9 @@ var SimpleBehavior = {
  * */
 var SimpleNamespacedBehavior = {
   simple: true,
+  method: function (paramA, paramB) {
+
+  },
 };
 
 
@@ -33,4 +36,4 @@ Really.Really.Deep.Behavior = [
 @polymerBehavior
 */
 CustomBehaviorList =
-    [SimpleBehavior, CustomNamedBehavior, Really.Really.Deep.Behavior];
+    [SimpleBehavior, AwesomeBehavior, Really.Really.Deep.Behavior];


### PR DESCRIPTION
We were treating them as properties, but now if they're function typed we call 'em methods.

Fixes #681

 - [x] CHANGELOG.md has been updated
