### PR TITLE
Added Document.isDocument and then used it everywhere.

### DIFF
--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -36,7 +36,7 @@ async function getWarnings(analyzer: Analyzer, localPath: string):
     Promise<Warning[]> {
       const result =
           (await analyzer.analyze([localPath])).getDocument(localPath);
-      if (result instanceof Document) {
+      if (Document.isDocument(result)) {
         return result.getWarnings({imported: false});
       } else if (result !== undefined) {
         return [result];

--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -46,7 +46,7 @@ export class Analysis implements Queryable {
 
     this._results = results;
     const documents = Array.from(results.values())
-                          .filter((r) => r instanceof Document) as Document[];
+                          .filter((r) => Document.isDocument(r)) as Document[];
     const potentialRoots = new Set(documents);
 
     // We trim down the set of documents as a performance optimization. We only
@@ -108,7 +108,7 @@ export class Analysis implements Queryable {
    */
   getWarnings(options?: Query): Warning[] {
     const warnings = Array.from(this._results.values())
-                         .filter((r) => !(r instanceof Document)) as Warning[];
+                         .filter((r) => !Document.isDocument(r)) as Warning[];
     const result = new Set(warnings);
     const docQuery = this._getDocumentQuery(options);
     for (const doc of this._searchRoots) {
@@ -152,7 +152,7 @@ function addAll<T>(set1: Set<T>, set2: Set<T>): Set<T> {
 function workAroundDuplicateJsScriptsBecauseOfHtmlScriptTags(
     results: Map<string, Document|Warning>) {
   const documents = Array.from(results.values())
-                        .filter((r) => r instanceof Document) as Document[];
+                        .filter((r) => Document.isDocument(r)) as Document[];
   // TODO(rictic): handle JS imported via script src from HTML better than
   //     this.
   const potentialDuplicates =

--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -45,8 +45,8 @@ export class Analysis implements Queryable {
     workAroundDuplicateJsScriptsBecauseOfHtmlScriptTags(results);
 
     this._results = results;
-    const documents = Array.from(results.values())
-                          .filter((r) => Document.isDocument(r)) as Document[];
+    const documents =
+        Array.from(results.values()).filter(Document.isDocument) as Document[];
     const potentialRoots = new Set(documents);
 
     // We trim down the set of documents as a performance optimization. We only
@@ -151,8 +151,8 @@ function addAll<T>(set1: Set<T>, set2: Set<T>): Set<T> {
  */
 function workAroundDuplicateJsScriptsBecauseOfHtmlScriptTags(
     results: Map<string, Document|Warning>) {
-  const documents = Array.from(results.values())
-                        .filter((r) => Document.isDocument(r)) as Document[];
+  const documents =
+      Array.from(results.values()).filter(Document.isDocument) as Document[];
   // TODO(rictic): handle JS imported via script src from HTML better than
   //     this.
   const potentialDuplicates =

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -139,7 +139,7 @@ export class Document implements Feature, Queryable {
   }
 
   static isDocument(value: any): value is Document {
-    return typeof value === 'object' && !!value.constructor.isDocument;
+    return value && value.constructor && !!value.constructor.isDocument;
   }
 
   get url(): string {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -138,6 +138,10 @@ export class Document implements Feature, Queryable {
     this.warnings = Array.from(base.warnings);
   }
 
+  static isDocument(value: any): value is Document {
+    return typeof value === 'object' && !!value.constructor.isDocument;
+  }
+
   get url(): string {
     return this._scannedDocument.url;
   }
@@ -372,19 +376,16 @@ export class Document implements Feature, Queryable {
     documentsWalked.add(this);
 
     for (const localFeature of this._localFeatures) {
-      if (localFeature instanceof Document) {
+      if (Document.isDocument(localFeature)) {
         result = result.concat(
             localFeature._toString(documentsWalked).map((line) => `  ${line}`));
       } else {
         let subResult = localFeature.toString();
         if (subResult === '[object Object]') {
-          subResult = `<${
-          localFeature.constructor.name
-          } kinds="${
-          Array.from(localFeature.kinds).join(', ')
-          }" ids="${
-          Array.from(localFeature.identifiers).join(',')
-          }">}`;
+          const name = localFeature.constructor.name;
+          const kinds = [...localFeature.kinds].join(', ');
+          const ids = [...localFeature.identifiers].join(', ');
+          subResult = `<${name} kinds="${kinds}" ids="${ids}">`;
         }
         result.push(`  ${subResult}`);
       }
@@ -396,7 +397,7 @@ export class Document implements Feature, Queryable {
   stringify(): string {
     const inlineDocuments =
         (Array.from(this._localFeatures)
-             .filter((f) => f instanceof Document && f.isInline) as Document[])
+             .filter((f) => Document.isDocument(f) && f.isInline) as Document[])
             .map((d) => d.parsedDocument);
     return this.parsedDocument.stringify({inlineDocuments: inlineDocuments});
   }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -70,7 +70,7 @@ export class ScannedImport implements Resolvable {
     }
     const importedDocumentOrWarning =
         document._analysisContext.getDocument(this.url);
-    if (!(importedDocumentOrWarning instanceof Document)) {
+    if (!Document.isDocument(importedDocumentOrWarning)) {
       const error = this.error ? (this.error.message || this.error) : '';
       document.warnings.push(new Warning({
         code: 'could-not-load',

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -221,7 +221,8 @@ suite('Analyzer', () => {
           const inlineDocuments =
               Array.from(document.getFeatures({imported: false}))
                   .filter(
-                      (d) => d instanceof Document && d.isInline) as Document[];
+                      (d) =>
+                          Document.isDocument(d) && d.isInline) as Document[];
           assert.equal(inlineDocuments.length, 1);
 
           // This is the main purpose of the test: get a feature from
@@ -292,7 +293,7 @@ suite('Analyzer', () => {
           assert.equal(documents.size, 2);
 
           const inlineDocuments = Array.from(documents).filter(
-              (d) => d instanceof Document && d.isInline) as Document[];
+              (d) => Document.isDocument(d) && d.isInline) as Document[];
           assert.equal(inlineDocuments.length, 1);
 
           // This is the main purpose of the test: get a feature
@@ -419,7 +420,7 @@ suite('Analyzer', () => {
       const url = '/static/does_not_exist';
       const result = await analyzer.analyze([url]);
       const warning = result.getDocument(url);
-      assert.isFalse(warning instanceof Document);
+      assert.isFalse(Document.isDocument(warning));
     });
 
     test('handles documents from multiple calls to analyze()', async() => {
@@ -668,7 +669,7 @@ suite('Analyzer', () => {
 
   test('analyzes a document with a namespace', async() => {
     const document = await analyzeDocument('static/namespaces/import-all.html');
-    if (!(document instanceof Document)) {
+    if (!Document.isDocument(document)) {
       throw new Error(`Expected Document, got ${document}`);
     }
 

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -54,7 +54,7 @@ export class CodeUnderliner {
     this._parsedDocumentGetter = async(url: string) => {
       const analysis = await analyzer.analyze([url]);
       const result = analysis.getDocument(url);
-      if (!(result instanceof Document)) {
+      if (!Document.isDocument(result)) {
         throw new Error(`Unable to parse ${url}`);
       }
       return result.parsedDocument;


### PR DESCRIPTION
Created a static method to replace `d instanceof Document` calls in order to support scenarios where multiple versions of `polymer-analyzer` wind up in `node_modules`.

This is mostly for consideration as a general approach to this class of problem.  Not sure if:

1.) sufficient to address problem of multiple versions of analyzer in the mix
2.) people are going to have multiple versions of analyzer now that our tools require it as "^2.x", but it *might* enable a degree of 2.x and 3.x interop?

Mixed feelings now that I went through the exercise...