### PR TITLE
Added an Analysis#getDocumentOrDie(url: string) method.

### DIFF
--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -65,6 +65,12 @@ export class Analysis implements Queryable {
     this._searchRoots = potentialRoots;
   }
 
+  /**
+   * Returns a `Document` for the given url, if one was analyzed.
+   * Returns a `Warning`, if one was generated when analyzing the URL.
+   * Returns `undefined` if the URL does not reference an analyzed
+   * document at all.
+   */
   getDocument(url: string): Document|Warning|undefined {
     const result = this._results.get(url);
     if (result != null) {
@@ -79,6 +85,22 @@ export class Analysis implements Queryable {
       return undefined;
     }
     return documents[0]!;
+  }
+
+  /**
+   * Simplified version of getDocument which simply throws an error when asked
+   * for a missing document.
+   */
+  getDocumentOrDie(url: string): Document {
+    const maybeDocument = this.getDocument(url);
+    if (maybeDocument instanceof Document) {
+      return maybeDocument;
+    }
+    let suffix = '';
+    if (maybeDocument) {
+      suffix = `: ${maybeDocument.message}`;
+    }
+    throw new Error(`Unable to get document ${url}${suffix}`);
   }
 
   /**

--- a/src/test/model/analysis_test.ts
+++ b/src/test/model/analysis_test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+
+import {assert} from 'chai';
+import {Analyzer} from '../../core/analyzer';
+import {Document} from '../../model/document';
+import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+
+suite('Analysis', () => {
+
+  suite('getDocumentOrDie', () => {
+
+    test('throws exception if asked for unrecognized url', async() => {
+      const analyzer =
+          new Analyzer({urlLoader: new FSUrlLoader('src/test/static/')});
+      const analysis = await analyzer.analyze(['stylesheet.css']);
+      assert.throw(() => {
+        analysis.getDocumentOrDie('not-a-thing.html');
+      });
+    });
+
+    test('throws exception if asked for url mapped to a Warning', async() => {
+      const analyzer =
+          new Analyzer({urlLoader: new FSUrlLoader('src/test/static/')});
+      const analysis = await analyzer.analyze(['js-parse-error.js']);
+      assert.throw(() => {
+        analysis.getDocumentOrDie('js-parse-error.js');
+      });
+    });
+
+    test('returns Document for url', async() => {
+      const analyzer =
+          new Analyzer({urlLoader: new FSUrlLoader('src/test/static/')});
+      const analysis = await analyzer.analyze(['stylesheet.css']);
+      assert.instanceOf(analysis.getDocumentOrDie('stylesheet.css'), Document);
+    });
+  });
+});


### PR DESCRIPTION
 - [ ] CHANGELOG.md has been updated
 - Added getDocumentOrDie() as a convenient option to just get a known analyzed document by url instead of dealing with multiple return type.
