### PR TITLE
Prepare release of 2.2.1 version of analyzer (now with no typescript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.2.1] - 2017-07-06
+
 * Removed TypeScript from production dependencies until TypeScript analysis is fully supported.
 
 ## [2.2.0] - 2017-06-22


### PR DESCRIPTION
 - Removed TypeScript from production dependencies until TypeScript analysis is fully supported.
 - [x] CHANGELOG.md has been updated
