### PR TITLE
Fix typescript pruning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-analyzer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@gulp-sourcemaps/map-sources": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-analyzer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Static analysis for Web Components",
   "homepage": "https://github.com/Polymer/polymer-analyzer",
   "bugs": "https://github.com/Polymer/polymer-analyzer/issues",

--- a/src/test/typescript/typescript-analyzer_test.ts
+++ b/src/test/typescript/typescript-analyzer_test.ts
@@ -76,7 +76,8 @@ suite('TypeScriptParser', () => {
             assert.include(baseTypes, htmlElement);
             const properties = checker.getPropertiesOfType(type);
             const ownProperties = properties.filter(
-                (p) => p.getDeclarations().some((d) => d.parent === class_));
+                (p) => (<Array<any>>p.getDeclarations())
+                           .some((d) => d.parent === class_));
             assert.equal(ownProperties.length, 1);
             assert.equal(ownProperties[0].name, 'foo');
           }

--- a/src/typescript/typescript-preparser.ts
+++ b/src/typescript/typescript-preparser.ts
@@ -54,9 +54,10 @@ export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
       astNode: inlineInfo.astNode, isInline,
     });
     if (parseError) {
-      const start = sourceFile.getLineAndCharacterOfPosition(parseError.start);
+      const start =
+          sourceFile.getLineAndCharacterOfPosition(parseError.start || 0);
       const end = sourceFile.getLineAndCharacterOfPosition(
-          parseError.start + parseError.length);
+          (parseError.start || 0) + (parseError.length || 0));
       throw new WarningCarryingException(new Warning({
         code: 'parse-error',
         severity: Severity.ERROR,


### PR DESCRIPTION
 - Was trying to release analyzer but typings failed a tsc call which for some reason isn't captured by our tests.
 - [ ] CHANGELOG.md doesn't need updating
