### PR TITLE
Resolve window references in extends clause

### DIFF
--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -468,8 +468,11 @@ class ClassFinder implements Visitor {
       // If no @extends tag, look for a superclass.
       const superClass = node.superClass;
       if (superClass != null) {
-        const extendsId = getIdentifierName(superClass);
+        let extendsId = getIdentifierName(superClass);
         if (extendsId != null) {
+          if (extendsId.startsWith('window.')) {
+            extendsId = extendsId.substring('window.'.length);
+          }
           const sourceRange = document.sourceRangeForNode(superClass)!;
           return new ScannedReference(extendsId, sourceRange);
         }

--- a/src/test/polymer/polymer-element_test.ts
+++ b/src/test/polymer/polymer-element_test.ts
@@ -102,6 +102,24 @@ suite('PolymerElement', () => {
         ],
         methods: [],
       },
+      {
+        tagName: undefined,
+        className: 'WindowBaseElement',
+        superClass: 'Polymer.Element',
+        description: '',
+        properties: [],
+        attributes: [],
+        methods: [],
+      },
+      {
+        tagName: undefined,
+        className: 'WindowSubElement',
+        superClass: 'Polymer.WindowBaseElement',
+        description: '',
+        properties: [],
+        attributes: [],
+        methods: [],
+      },
     ]);
   });
 

--- a/src/test/static/polymer2/test-element-3.js
+++ b/src/test/static/polymer2/test-element-3.js
@@ -32,3 +32,17 @@ class SubElement extends BaseElement {
     };
   }
 }
+
+/**
+ * @customElement
+ * @polymer
+ */
+class WindowBaseElement extends window.Polymer.Element {}
+
+window.Polymer.WindowBaseElement = WindowBaseElement;
+
+/**
+ * @customElement
+ * @polymer
+ */
+class WindowSubElement extends Polymer.WindowBaseElement {}

--- a/src/test/static/polymer2/test-element-3.js
+++ b/src/test/static/polymer2/test-element-3.js
@@ -36,6 +36,7 @@ class SubElement extends BaseElement {
 /**
  * @customElement
  * @polymer
+ * @memberOf Polymer
  */
 class WindowBaseElement extends window.Polymer.Element {}
 


### PR DESCRIPTION
While browsing through the http://wpt.fyi source, I found https://github.com/GoogleChrome/wptdashboard/blob/d769c47c245b5e68ba36b925c4950908f0a0d965/components/test-file-results.html#L79 which was showing warnings in my editor. It seems that `window.` parent classes were incorrectly referenced.

I am not 100% convinced this is the correct fix, as it could be that it introduces false positives when defining an object like `Polymer = { Element: ... }`, but that seems a rare edgecase. I also tried to modify https://github.com/Polymer/polymer-analyzer/blob/1d803aceced80c92501fb6144d530139778c66b6/src/javascript/class-scanner.ts#L381 to add it automatically on `window`, but that seemed to break a lot of existing tests.
 - [ ] CHANGELOG.md has been updated
