### PR TITLE
Fix value of reflectToAttribute for polymer properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  ## Unreleased
 
 * Scan for CSS custom variable uses and assignments.
+* Fix value of reflectToAttribute for polymer properties
 
 ## [2.2.2] - 2017-07-20
 

--- a/src/polymer/analyze-properties.ts
+++ b/src/polymer/analyze-properties.ts
@@ -119,7 +119,8 @@ export function analyzeProperties(
             prop.readOnly = !!astValue.expressionToValue(propertyArg.value);
             break;
           case 'reflectToAttribute':
-            prop.reflectToAttribute = !!astValue.expressionToValue(propertyArg);
+            prop.reflectToAttribute =
+                !!astValue.expressionToValue(propertyArg.value);
             break;
           case 'computed':
             isComputed = true;

--- a/src/test/static/polymer2/test-element-17.js
+++ b/src/test/static/polymer2/test-element-17.js
@@ -1,0 +1,18 @@
+/**
+ * @customElement
+ * @polymer
+ * @extends Polymer.Element
+ */
+class BaseElement extends Polymer.Element {
+  static get properties() {
+    return {
+      foo: {
+        notify: true,
+        type: String,
+        reflectToAttribute: true,
+        readOnly: true,
+        value: 'foo'
+      },
+    };
+  }
+}


### PR DESCRIPTION
By accident I discovered that this value was incorrectly `false` if it was explicitly set to `true`. Seemed like a copy-paste error, but there was no existing test for it. Thus I also added an extra test to test for the different property configurations.

 - [x] CHANGELOG.md has been updated
