### PR TITLE
Change the visit() method of HTMLDocument so it always visits template content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
- ## Unreleased
+## Unreleased
 
 * Scan for CSS custom variable uses and assignments.
-* Fix value of reflectToAttribute for polymer properties
+* Fix value of reflectToAttribute for polymer properties.
+* HTML Document feature scanners now visit template children.
 
 ## [2.2.2] - 2017-07-20
 

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -37,7 +37,7 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
     dom5.nodeWalk(this.ast, (node) => {
       visitors.forEach((visitor) => visitor(node));
       return false;
-    });
+    }, dom5.childNodesIncludeTemplate);
   }
 
   // An element node with end tag information will produce a source range that

--- a/src/html/html-element-reference-scanner.ts
+++ b/src/html/html-element-reference-scanner.ts
@@ -57,17 +57,6 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
 
         elements.push(element);
       }
-
-      // Descend into templates.
-      if (node.tagName === 'template') {
-        const content = treeAdapters.default.getTemplateContent(node);
-        if (content) {
-          dom5.nodeWalk(content, (n) => {
-            visitor(n);
-            return false;
-          });
-        }
-      }
     };
 
     await visit(visitor);

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -66,16 +66,6 @@ export class HtmlStyleScanner implements HtmlScanner {
               node));
         }
       }
-      // Descend into templates.
-      if (node.tagName === 'template') {
-        const content = treeAdapters.default.getTemplateContent(node);
-        if (content) {
-          dom5.nodeWalk(content, (n) => {
-            visitor(n);
-            return false;
-          });
-        }
-      }
     };
 
     await visit(visitor);


### PR DESCRIPTION
 - The `visit` method now includes template children.
 - The feature scanners will need to decide how to handle features inside templates.
 - [x] CHANGELOG.md has been updated
