### PR TITLE
Update Javascript parser to recast + esprima

### DIFF
--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -2,3 +2,4 @@
 /// <reference path="./espree.d.ts" />
 /// <reference path="./estree.d.ts" />
 /// <reference path="./strip-indent.d.ts" />
+/// <reference path="./recast.d.ts" />

--- a/custom_typings/recast.d.ts
+++ b/custom_typings/recast.d.ts
@@ -1,0 +1,19 @@
+declare module 'recast' {
+    
+  import * as estree from 'estree';
+
+  export interface File {
+    name: string;
+    program: estree.Program;
+  }
+
+  export interface Options {
+    quote?: 'single' | 'double' | 'auto';
+    wrapColumn?: number;
+    tabWidth?: number;
+  }
+
+  export function parse(source: string): File;
+
+  export function print(node: estree.Node, options?: Options): {code: string};
+}

--- a/custom_typings/recast.d.ts
+++ b/custom_typings/recast.d.ts
@@ -1,5 +1,4 @@
 declare module 'recast' {
-    
   import * as estree from 'estree';
 
   export interface File {
@@ -8,12 +7,26 @@ declare module 'recast' {
   }
 
   export interface Options {
-    quote?: 'single' | 'double' | 'auto';
+    quote?: 'single'|'double'|'auto';
     wrapColumn?: number;
     tabWidth?: number;
   }
 
-  export function parse(source: string): File;
+  export interface ParseOptions {
+    parser?: {parse(code: string): any}, tabWidth?: number, useTabs?: boolean,
+        reuseWhitespace?: boolean, lineTerminator?: string, wrapColumn?: number,
+        sourceFileName?: string, sourceMapName?: string, sourceRoot?: string,
+        inputSourceMap?: string, range?: boolean, tolerant?: boolean,
+        quote?: 'single'|'double'|'auto', trailingComma?: boolean|{
+          objects?: boolean,
+          arrays?: boolean,
+          parameters?: boolean,
+        },
+        arrayBracketSpacing?: boolean, objectCurlySpacing?: boolean,
+        arrowParensAlways?: boolean, flowObjectCommas?: boolean,
+  }
+
+  export function parse(source: string, options?: ParseOptions): File;
 
   export function print(node: estree.Node, options?: Options): {code: string};
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,17 +31,17 @@
       }
     },
     "@types/chai-subset": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.0.tgz",
-      "integrity": "sha1-dM7M7zsvwtpzkbcT3rcv6afl94I=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
       "requires": {
-        "@types/chai": "4.0.1"
+        "@types/chai": "4.0.4"
       },
       "dependencies": {
         "@types/chai": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
-          "integrity": "sha512-DWrdkraJO+KvBB7+Jc6AuDd2+fwV6Z9iK8cqEEoYpcurYrH7GiUZmwjFuQIIWj5HhFz6NsSxdN72YMIHT7Fy2Q=="
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
+          "integrity": "sha512-cvU0HomQ7/aGDQJZsbtJXqBQ7w4J4TqLB0Z/h8mKrpRjfeZEvTbygkfJEb7fWdmwpIeDeFmIVwAEqS0OYuUv3Q=="
         }
       }
     },
@@ -76,22 +76,22 @@
       "integrity": "sha1-qnr2mjqRkiFx7kEbPJ2Pa+tK8yE="
     },
     "@types/mocha": {
-      "version": "2.2.41",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
-      "integrity": "sha1-4nzwgXFT658nE7LT9saPHhw8pgg=",
+      "version": "2.2.42",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.42.tgz",
+      "integrity": "sha512-b6gVDoxEbAQGwbV7gSzeFw/hy3/eEAokztktdzl4bHvGgb9K5zW4mVQDlVYch2w31m8t/J7L2iqhQvz3r5edCQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.79",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
-      "integrity": "sha512-7F3/P6MkTPA0QxOstRqfcnoReCUy5V/QG92cyBoZSPnqdX44L8TtNELSVfN56gAttm3YWj9cEi8FRIPVq0WmeQ=="
+      "version": "6.0.88",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+      "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ=="
     },
     "@types/parse5": {
       "version": "2.2.34",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
-        "@types/node": "6.0.79"
+        "@types/node": "6.0.88"
       }
     },
     "@types/promises-a-plus": {
@@ -99,13 +99,6 @@
       "resolved": "https://registry.npmjs.org/@types/promises-a-plus/-/promises-a-plus-0.0.27.tgz",
       "integrity": "sha1-xkZRE0YUyEuPXXEUzokB02pgl4A=",
       "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-      "dev": true,
-      "optional": true
     },
     "acorn": {
       "version": "5.1.1",
@@ -154,7 +147,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -170,9 +163,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -216,13 +209,13 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "app-usage-stats": {
@@ -232,64 +225,18 @@
       "dev": true,
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "feature-detect-es6": "1.3.1",
         "home-path": "1.0.5",
         "test-value": "2.1.0",
         "usage-stats": "0.8.6"
       }
     },
-    "aproba": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
-      "dev": true,
-      "optional": true
-    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "argparse": {
       "version": "1.0.9",
@@ -392,30 +339,21 @@
       "dev": true
     },
     "asap": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true,
-      "optional": true
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true,
-      "optional": true
     },
     "assertion-error": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
       "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
       "dev": true
+    },
+    "ast-types": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.11.tgz",
+      "integrity": "sha1-NxF3u1kjL/XOqh0J7lytcFsaWqk="
     },
     "async": {
       "version": "1.5.2",
@@ -429,37 +367,16 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true,
-      "optional": true
-    },
     "atob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
       "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
       "dev": true
     },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true,
-      "optional": true
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true,
-      "optional": true
-    },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -473,41 +390,49 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
       }
     },
     "babel-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
+        "core-js": "2.5.0",
+        "regenerator-runtime": "0.11.0"
       }
     },
     "babel-traverse": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
+        "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
         "debug": "2.6.8",
         "globals": "9.18.0",
         "invariant": "2.2.2",
@@ -515,21 +440,21 @@
       }
     },
     "babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
-      "version": "6.17.4",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-      "integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -538,16 +463,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
     "beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
@@ -555,34 +470,16 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "bluebird": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
       "dev": true
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
     },
     "bower": {
       "version": "1.8.0",
@@ -591,17 +488,17 @@
       "dev": true
     },
     "boxen": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
-      "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+      "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "1.1.3",
+        "chalk": "2.1.0",
         "cli-boxes": "1.0.0",
-        "string-width": "2.1.0",
-        "term-size": "0.1.1",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
         "widest-line": "1.0.0"
       },
       "dependencies": {
@@ -611,10 +508,36 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -624,9 +547,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -640,6 +563,15 @@
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -719,7 +651,7 @@
       "dev": true,
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "feature-detect-es6": "1.3.1",
         "fs-then-native": "1.0.2",
         "mkdirp": "0.5.1"
@@ -752,17 +684,10 @@
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true,
-      "optional": true
-    },
     "catharsis": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz",
-      "integrity": "sha1-aTR59DqsVJ2Aa9c+kkzQ2USVGgY=",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
         "underscore-contrib": "0.3.0"
@@ -817,7 +742,7 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
         "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
@@ -829,9 +754,9 @@
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clang-format": {
@@ -842,7 +767,7 @@
       "requires": {
         "async": "1.5.2",
         "glob": "7.1.2",
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "cli-boxes": {
@@ -873,9 +798,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -952,6 +877,21 @@
         }
       }
     },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -968,7 +908,7 @@
         "array-back": "1.0.4",
         "collect-json": "1.0.8",
         "command-line-args": "2.1.6",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "deep-extend": "0.4.2",
         "feature-detect-es6": "1.3.1",
         "object-tools": "2.0.6",
@@ -994,7 +934,7 @@
           "requires": {
             "array-back": "1.0.4",
             "command-line-usage": "2.0.5",
-            "core-js": "2.4.1",
+            "core-js": "2.5.0",
             "feature-detect-es6": "1.3.1",
             "find-replace": "1.0.3",
             "typical": "2.6.1"
@@ -1166,30 +1106,24 @@
       "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.23.0",
+        "babel-polyfill": "6.26.0",
         "feature-detect-es6": "1.3.1",
         "walk-back": "2.0.1"
       }
     },
     "configstore": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
-      "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.1.1",
+        "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
         "make-dir": "1.0.0",
         "unique-string": "1.0.0",
-        "write-file-atomic": "2.1.0",
+        "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
       }
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -1204,10 +1138,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-      "dev": true
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1232,7 +1165,7 @@
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
-        "which": "1.2.14"
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -1245,38 +1178,6 @@
             "yallist": "2.1.2"
           }
         }
-      }
-    },
-    "cross-spawn-async": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.2.14"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        }
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "2.10.1"
       }
     },
     "crypto-random-string": {
@@ -1319,7 +1220,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.23"
+        "es5-ext": "0.10.30"
       }
     },
     "dargs": {
@@ -1327,25 +1228,6 @@
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
       "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
       "dev": true
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "dateformat": {
       "version": "2.0.0",
@@ -1360,7 +1242,7 @@
       "dev": true,
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "handlebars": "3.0.3",
         "marked": "0.3.6",
         "object-get": "2.1.0",
@@ -1475,25 +1357,18 @@
       "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
       "dev": true
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
-    },
     "depcheck": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.6.7.tgz",
       "integrity": "sha1-az0emTkx4J7mc9NQfTF123NII+Y=",
       "dev": true,
       "requires": {
-        "babel-traverse": "6.25.0",
-        "babylon": "6.17.4",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
         "builtin-modules": "1.1.1",
         "deprecate": "1.0.0",
         "deps-regex": "0.1.4",
-        "js-yaml": "3.8.4",
+        "js-yaml": "3.9.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "require-package-name": "2.0.1",
@@ -1579,16 +1454,16 @@
       "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
       "requires": {
         "@types/clone": "0.1.30",
-        "@types/node": "6.0.79",
+        "@types/node": "6.0.88",
         "@types/parse5": "2.2.34",
         "clone": "2.1.1",
         "parse5": "2.2.3"
       }
     },
     "dot-prop": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
-      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
@@ -1610,33 +1485,24 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-      "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.0.0",
+        "end-of-stream": "1.4.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-          "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
           "dev": true,
           "requires": {
-            "once": "1.3.3"
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
+            "once": "1.4.0"
           }
         },
         "readable-stream": {
@@ -1663,16 +1529,6 @@
             "safe-buffer": "5.1.1"
           }
         }
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
       }
     },
     "end-of-stream": {
@@ -1705,9 +1561,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -1721,7 +1577,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.30",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1732,7 +1588,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1746,7 +1602,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1759,7 +1615,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23"
+        "es5-ext": "0.10.30"
       }
     },
     "es6-weak-map": {
@@ -1769,7 +1625,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -1822,18 +1678,18 @@
         "doctrine": "1.5.0",
         "es6-map": "0.1.5",
         "escope": "3.6.0",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "1.3.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
+        "is-my-json-valid": "2.16.1",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
+        "js-yaml": "3.9.1",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -1873,9 +1729,9 @@
       }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "requires": {
         "acorn": "5.1.1",
         "acorn-jsx": "3.0.1"
@@ -1921,7 +1777,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.23"
+        "es5-ext": "0.10.30"
       }
     },
     "execa": {
@@ -1995,12 +1851,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-      "dev": true
     },
     "fancy-log": {
       "version": "1.3.0",
@@ -2157,9 +2007,9 @@
       "dev": true,
       "requires": {
         "expand-tilde": "2.0.2",
-        "is-plain-object": "2.0.3",
+        "is-plain-object": "2.0.4",
         "object.defaults": "1.1.0",
-        "object.pick": "1.2.0",
+        "object.pick": "1.3.0",
         "parse-filepath": "1.0.1"
       },
       "dependencies": {
@@ -2192,7 +2042,7 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
@@ -2212,13 +2062,6 @@
       "requires": {
         "for-in": "1.0.2"
       }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true,
-      "optional": true
     },
     "form-data": {
       "version": "0.2.0",
@@ -2295,52 +2138,534 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
+        "nan": "2.7.0",
         "node-pre-gyp": "0.6.36"
       },
       "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
           }
         },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "jsonify": "0.0.0"
           }
         },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
-            "npmlog": "4.1.2",
+            "npmlog": "4.1.0",
             "rc": "1.2.1",
             "request": "2.81.0",
             "rimraf": "2.6.1",
@@ -2349,84 +2674,359 @@
             "tar-pack": "3.4.0"
           }
         },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
           }
         },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-        }
-      }
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "aproba": "1.1.2",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
           "dev": true,
           "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -2465,25 +3065,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -2620,7 +3201,7 @@
         "homedir-polyfill": "1.0.1",
         "ini": "1.3.4",
         "is-windows": "0.2.0",
-        "which": "1.2.14"
+        "which": "1.3.0"
       }
     },
     "globals": {
@@ -2807,7 +3388,7 @@
         "dargs": "5.1.0",
         "execa": "0.6.3",
         "gulp-util": "3.0.8",
-        "mocha": "3.4.2",
+        "mocha": "3.5.0",
         "npm-run-path": "2.0.2",
         "through2": "2.0.3"
       }
@@ -2897,7 +3478,7 @@
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "through2": "2.0.3",
         "typescript": "1.8.10",
         "vinyl-fs": "2.4.4"
@@ -3044,9 +3625,9 @@
           }
         },
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "string_decoder": {
@@ -3091,7 +3672,7 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "3.5.0",
+            "duplexify": "3.5.1",
             "glob-stream": "5.3.5",
             "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
@@ -3217,24 +3798,6 @@
         }
       }
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-      "dev": true,
-      "optional": true
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3258,36 +3821,10 @@
         "sparkles": "1.0.0"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
-    },
     "herit": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/herit/-/herit-2.2.2.tgz",
       "integrity": "sha1-DhGb3K6AfKLqbV2VwWt1x7Bj6Yc=",
-      "dev": true
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "home-path": {
@@ -3311,22 +3848,10 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
-      }
-    },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "import-lazy": {
@@ -3373,7 +3898,7 @@
         "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "figures": "1.7.0",
         "lodash": "4.17.4",
         "readline2": "1.0.1",
@@ -3427,7 +3952,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -3491,9 +4016,9 @@
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -3548,9 +4073,9 @@
       }
     },
     "is-plain-object": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz",
-      "integrity": "sha1-wVvz5LZrYtcu+vKSWEhmPsvGGbY=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
@@ -3618,13 +4143,6 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true,
-      "optional": true
-    },
     "is-unc-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
@@ -3672,13 +4190,6 @@
         "isarray": "1.0.0"
       }
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true,
-      "optional": true
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3686,19 +4197,19 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "esprima": "4.0.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         }
       }
@@ -3709,13 +4220,6 @@
       "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
       "dev": true
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
     "jsdoc-75lb": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
@@ -3723,7 +4227,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.4.7",
-        "catharsis": "0.8.8",
+        "catharsis": "0.8.9",
         "escape-string-regexp": "1.0.5",
         "espree": "3.1.7",
         "js2xmlparser": "1.0.0",
@@ -3769,7 +4273,7 @@
         "array-back": "1.0.4",
         "cache-point": "0.3.4",
         "collect-all": "1.0.3",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "feature-detect-es6": "1.3.1",
         "file-set": "1.1.1",
         "jsdoc-75lb": "3.6.0",
@@ -3809,7 +4313,7 @@
         "collect-json": "1.0.8",
         "command-line-args": "2.1.6",
         "command-line-tool": "0.1.0",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "feature-detect-es6": "1.3.1",
         "file-set": "0.2.8",
         "jsdoc-api": "1.2.4",
@@ -3855,7 +4359,7 @@
           "requires": {
             "array-back": "1.0.4",
             "command-line-usage": "2.0.5",
-            "core-js": "2.4.1",
+            "core-js": "2.5.0",
             "feature-detect-es6": "1.3.1",
             "find-replace": "1.0.3",
             "typical": "2.6.1"
@@ -3965,13 +4469,6 @@
         "feature-detect-es6": "1.3.1"
       }
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true,
-      "optional": true
-    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -3980,13 +4477,6 @@
       "requires": {
         "jsonify": "0.0.0"
       }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true,
-      "optional": true
     },
     "json3": {
       "version": "3.3.2",
@@ -4016,31 +4506,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.1.tgz",
-      "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk="
-    },
-    "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true,
-          "optional": true
-        }
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
+      "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg=="
     },
     "kew": {
       "version": "0.7.0",
@@ -4148,7 +4616,7 @@
         "lodash.isstring": "4.0.1",
         "lodash.mapvalues": "4.6.0",
         "rechoir": "0.6.2",
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "load-json-file": {
@@ -4551,14 +5019,14 @@
       "dev": true
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
@@ -4569,15 +5037,6 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -4591,12 +5050,6 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
@@ -4631,9 +5084,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
       "dev": true,
       "optional": true
     },
@@ -4643,17 +5096,6 @@
       "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
       "dev": true
     },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "abbrev": "1.1.0",
-        "osenv": "0.1.4"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -4662,7 +5104,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
+        "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -4672,7 +5114,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
@@ -4684,31 +5126,11 @@
         "path-key": "2.0.1"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true,
-      "optional": true
     },
     "object-assign": {
       "version": "3.0.0",
@@ -4793,12 +5215,20 @@
       }
     },
     "object.pick": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
-      "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "once": {
@@ -4918,17 +5348,6 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -4944,7 +5363,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       }
     },
     "parse-filepath": {
@@ -5111,6 +5530,11 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
+    "private": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -5129,7 +5553,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.5"
+        "asap": "2.0.6"
       }
     },
     "promise.prototype.finally": {
@@ -5143,13 +5567,6 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true,
-      "optional": true
     },
     "qs": {
       "version": "2.3.3",
@@ -5308,13 +5725,37 @@
         "mute-stream": "0.0.5"
       }
     },
+    "recast": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.6.tgz",
+      "integrity": "sha1-Sw+4L+sdELO9YtNJQ0Jtmz7TDUw=",
+      "requires": {
+        "ast-types": "0.9.11",
+        "core-js": "2.5.0",
+        "esprima": "4.0.0",
+        "private": "0.1.7",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "reduce-component": {
@@ -5366,9 +5807,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
       "dev": true
     },
     "regex-cache": {
@@ -5401,9 +5842,9 @@
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -5435,95 +5876,6 @@
         "feature-detect-es6": "1.3.1",
         "lodash.pick": "4.4.0",
         "typical": "2.6.1"
-      }
-    },
-    "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "require-directory": {
@@ -5572,9 +5924,9 @@
       }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -5659,9 +6011,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "semver-diff": {
@@ -5670,7 +6022,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       }
     },
     "sequencify": {
@@ -5747,22 +6099,6 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "sort-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
@@ -5795,18 +6131,18 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
+      "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -5849,32 +6185,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "statsd-client": {
       "version": "0.2.1",
@@ -5953,13 +6263,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true,
-      "optional": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -6066,7 +6369,7 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6082,9 +6385,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6109,7 +6412,7 @@
       "dev": true,
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "deep-extend": "0.4.2",
         "feature-detect-es6": "1.3.1",
         "typical": "2.6.1",
@@ -6121,62 +6424,6 @@
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
-    },
-    "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
-    },
-    "tar-pack": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "debug": "2.6.8",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.1",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "temp": {
       "version": "0.8.3",
@@ -6203,48 +6450,28 @@
       "dev": true
     },
     "term-size": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
-      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.4.0"
+        "execa": "0.7.0"
       },
       "dependencies": {
         "execa": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "2.2.5",
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
             "is-stream": "1.1.0",
-            "npm-run-path": "1.0.0",
-            "object-assign": "4.1.1",
-            "path-key": "1.0.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
           }
-        },
-        "npm-run-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-          "dev": true,
-          "requires": {
-            "path-key": "1.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "path-key": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-          "dev": true
         }
       }
     },
@@ -6361,16 +6588,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
@@ -6383,13 +6600,13 @@
       "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
+        "babel-code-frame": "6.26.0",
         "colors": "1.1.2",
         "diff": "3.2.0",
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.3.3",
+        "resolve": "1.4.0",
         "tsutils": "1.9.1",
         "update-notifier": "2.2.0"
       },
@@ -6426,23 +6643,6 @@
       "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
       "dev": true
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -6464,9 +6664,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
     "typescript-json-schema": {
@@ -6543,13 +6743,6 @@
         }
       }
     },
-    "uid-number": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-      "dev": true,
-      "optional": true
-    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -6606,9 +6799,9 @@
       "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
       "dev": true,
       "requires": {
-        "boxen": "1.1.0",
+        "boxen": "1.2.1",
         "chalk": "1.1.3",
-        "configstore": "3.1.0",
+        "configstore": "3.1.1",
         "import-lazy": "2.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
@@ -6639,7 +6832,7 @@
       "requires": {
         "array-back": "1.0.4",
         "cli-commands": "0.1.0",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "feature-detect-es6": "1.3.1",
         "home-path": "1.0.5",
         "mkdirp2": "1.0.3",
@@ -6706,16 +6899,6 @@
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
-      }
-    },
-    "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "extsprintf": "1.0.2"
       }
     },
     "vinyl": {
@@ -6844,9 +7027,9 @@
       }
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -6857,16 +7040,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "string-width": "1.0.2"
-      }
     },
     "widest-line": {
       "version": "1.0.0",
@@ -6920,14 +7093,14 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "signal-exit": "3.0.2"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "estraverse": "^4.2.0",
     "jsonschema": "^1.1.0",
     "parse5": "^2.2.1",
+    "recast": "^0.12.6",
     "shady-css-parser": "^0.1.0",
     "strip-indent": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "doctrine": "^2.0.0",
     "dom5": "^2.1.0",
     "escodegen": "^1.7.0",
-    "espree": "^3.1.7",
     "estraverse": "^4.2.0",
     "jsonschema": "^1.1.0",
     "parse5": "^2.2.1",

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -149,7 +149,9 @@ function getLeadingComments(node: estree.Node): string[]|undefined {
     return;
   }
   const comments = [];
-  for (const comment of node.leadingComments || []) {
+  const leadingComments =
+      (((node as any).comments) || []).filter((c: any) => c.leading);
+  for (const comment of leadingComments) {
     // Espree says any comment that immediately precedes a node is "leading",
     // but we want to be stricter and require them to be touching. If we don't
     // have locations for some reason, err on the side of including the

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -12,9 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as escodegen from 'escodegen';
 import {traverse, VisitorOption} from 'estraverse';
 import {Node, Program} from 'estree';
+import * as recast from 'recast';
 
 import {SourceRange} from '../model/model';
 import {Options as ParsedDocumentOptions, ParsedDocument, StringifyOptions} from '../parser/document';
@@ -166,6 +166,6 @@ export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
       formatOptions.format.indent.base = options.indent;
     }
 
-    return escodegen.generate(this.ast, formatOptions) + '\n';
+    return recast.print(this.ast, {tabWidth: options.indent}).code + '\n';
   }
 }

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as espree from 'espree';
 import * as estree from 'estree';
+import * as recast from 'recast';
 
 import {correctSourceRange, InlineDocInfo, LocationOffset, Severity, SourceRange, Warning, WarningCarryingException} from '../model/model';
 import {Parser} from '../parser/parser';
@@ -100,7 +100,7 @@ export function parseJs(
     return {
       type: 'success',
       sourceType: 'script',
-      program: espree.parse(contents, options)
+      program: recast.parse(contents).program
     };
   } catch (_ignored) {
     try {
@@ -108,7 +108,7 @@ export function parseJs(
       return {
         type: 'success',
         sourceType: 'module',
-        program: espree.parse(contents, options)
+        program: recast.parse(contents).program
       };
     } catch (err) {
       if (err instanceof SyntaxError) {

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -92,7 +92,7 @@ suite('Analyzer', () => {
 
     test(
         'analyzes a document with an inline Polymer element feature',
-        async() => {
+        async () => {
           const document = await analyzeDocument(
               'static/analysis/simple/simple-element.html');
           const elements = Array.from(
@@ -102,7 +102,7 @@ suite('Analyzer', () => {
 
     test(
         'analyzes a document with an external Polymer element feature',
-        async() => {
+        async () => {
           const document =
               await analyzeDocument('static/analysis/separate-js/element.html');
           const elements = Array.from(
@@ -110,7 +110,7 @@ suite('Analyzer', () => {
           assert.deepEqual(elements.map((e) => e.tagName), ['my-element']);
         });
 
-    test('gets source ranges of documents correct', async() => {
+    test('gets source ranges of documents correct', async () => {
       const document = await analyzeDocument('static/dependencies/root.html');
       assert.deepEqual(await underliner.underline(document.sourceRange), `
 <link rel="import" href="inline-only.html">
@@ -127,7 +127,7 @@ suite('Analyzer', () => {
 `);
     });
 
-    test('analyzes inline scripts correctly', async() => {
+    test('analyzes inline scripts correctly', async () => {
       const document = await analyzeDocument(
           'static/inline-documents/inline-documents.html');
       const jsDocuments = document.getFeatures({kind: 'js-document'});
@@ -144,7 +144,7 @@ suite('Analyzer', () => {
 ~~`);
     });
 
-    test('analyzes inline styles correctly', async() => {
+    test('analyzes inline styles correctly', async () => {
       const document = await analyzeDocument(
           'static/inline-documents/inline-documents.html');
       const cssDocuments = document.getFeatures({kind: 'css-document'});
@@ -164,7 +164,7 @@ suite('Analyzer', () => {
 ~~`);
     });
 
-    test('analyzes a document with an import', async() => {
+    test('analyzes a document with an import', async () => {
       const document =
           await analyzeDocument('static/analysis/behaviors/behavior.html');
       const behaviors =
@@ -176,7 +176,7 @@ suite('Analyzer', () => {
 
     test(
         'creates "missing behavior" warnings on imported documents without elements',
-        async() => {
+        async () => {
           const document = await analyzeDocument(
               'static/chained-missing-behavior/index.html');
           const chainedDocument = getOnly(document.getFeatures({
@@ -207,7 +207,7 @@ suite('Analyzer', () => {
 
     test(
         'an inline document can find features from its container document',
-        async() => {
+        async () => {
           const document =
               await analyzeDocument('static/analysis/behaviors/behavior.html');
           const localDocuments =
@@ -220,8 +220,8 @@ suite('Analyzer', () => {
 
           const inlineDocuments =
               Array.from(document.getFeatures({imported: false}))
-                  .filter(
-                      (d) => d instanceof Document && d.isInline) as Document[];
+                  .filter((d) => d instanceof Document && d.isInline) as
+              Document[];
           assert.equal(inlineDocuments.length, 1);
 
           // This is the main purpose of the test: get a feature from
@@ -238,7 +238,7 @@ suite('Analyzer', () => {
 
     test(
         'an inline script can find features from its container document',
-        async() => {
+        async () => {
           const document = await analyzeDocument(
               'static/script-tags/inline/test-element.html');
           const inlineDocuments = Array
@@ -257,7 +257,7 @@ suite('Analyzer', () => {
 
     test(
         'an external script can find features from its container document',
-        async() => {
+        async () => {
           const document = await analyzeDocument(
               'static/script-tags/external/test-element.html');
 
@@ -283,7 +283,7 @@ suite('Analyzer', () => {
     // resolution, then the element can't find them and throws.
     test(
         'an inline document can find behaviors from its container document',
-        async() => {
+        async () => {
           const document = await analyzeDocument(
               'static/analysis/behaviors/elementdir/element.html');
 
@@ -291,8 +291,9 @@ suite('Analyzer', () => {
               document.getFeatures({kind: 'document', imported: false});
           assert.equal(documents.size, 2);
 
-          const inlineDocuments = Array.from(documents).filter(
-              (d) => d instanceof Document && d.isInline) as Document[];
+          const inlineDocuments =
+              Array.from(documents).filter(
+                  (d) => d instanceof Document && d.isInline) as Document[];
           assert.equal(inlineDocuments.length, 1);
 
           // This is the main purpose of the test: get a feature
@@ -307,12 +308,13 @@ suite('Analyzer', () => {
           assert.equal(subBehavior.className, 'MyNamespace.SubBehavior');
         });
 
-    test('returns a Document with warnings for malformed files', async() => {
+    test('returns a Document with warnings for malformed files', async () => {
       const document = await analyzeDocument('static/malformed.html');
-      assert(document.getWarnings({imported: false}).length >= 1);
+      const warnings = document.getWarnings({imported: false}).length;
+      assert(warnings >= 1, `Expected 1 or more warnings, but got ${warnings}`);
     });
 
-    test('analyzes transitive dependencies', async() => {
+    test('analyzes transitive dependencies', async () => {
       const root = await analyzeDocument('static/dependencies/root.html');
 
       // If we ask for documents we get every document in evaluation order.
@@ -415,19 +417,19 @@ suite('Analyzer', () => {
           inFolder);
     });
 
-    test(`warns for files that don't exist`, async() => {
+    test(`warns for files that don't exist`, async () => {
       const url = '/static/does_not_exist';
       const result = await analyzer.analyze([url]);
       const warning = result.getDocument(url);
       assert.isFalse(warning instanceof Document);
     });
 
-    test('handles documents from multiple calls to analyze()', async() => {
+    test('handles documents from multiple calls to analyze()', async () => {
       await analyzer.analyze(['static/caching/file1.html']);
       await analyzer.analyze(['static/caching/file2.html']);
     });
 
-    test('handles mutually recursive documents', async() => {
+    test('handles mutually recursive documents', async () => {
       const document = await analyzeDocument('static/circular/mutual-a.html');
       const shallowFeatures = document.getFeatures({imported: false});
       assert.deepEqual(
@@ -456,7 +458,7 @@ suite('Analyzer', () => {
 
     test(
         'handles parallel analyses of mutually recursive documents',
-        async() => {
+        async () => {
           // At one point this deadlocked, or threw
           // a _makeDocument error.
           await Promise.all([
@@ -465,7 +467,7 @@ suite('Analyzer', () => {
           ]);
         });
 
-    test('handles a document importing itself', async() => {
+    test('handles a document importing itself', async () => {
       const document =
           await analyzeDocument('static/circular/self-import.html');
       const features = document.getFeatures({imported: true});
@@ -486,7 +488,7 @@ suite('Analyzer', () => {
 
     suite('handles documents with spaces in filename', () => {
 
-      test('given a url with unencoded spaces to analyze', async() => {
+      test('given a url with unencoded spaces to analyze', async () => {
         const document = await analyzeDocument('static/spaces in file.html');
         const features = document.getFeatures({imported: true});
         assert.deepEqual(
@@ -504,7 +506,7 @@ suite('Analyzer', () => {
             ['static/dependencies/spaces%20in%20import.html']);
       });
 
-      test('given a url with encoded spaces to analyze', async() => {
+      test('given a url with encoded spaces to analyze', async () => {
         const document =
             await analyzeDocument('static/spaces%20in%20file.html');
         const features = document.getFeatures({imported: true});
@@ -528,28 +530,28 @@ suite('Analyzer', () => {
   // TODO: reconsider whether we should test these private methods.
   suite('_parse()', () => {
 
-    test('loads and parses an HTML document', async() => {
+    test('loads and parses an HTML document', async () => {
       const context = await getContext(analyzer);
       const doc = await context['_parse']('static/html-parse-target.html');
       assert.instanceOf(doc, ParsedHtmlDocument);
       assert.equal(doc.url, 'static/html-parse-target.html');
     });
 
-    test('loads and parses a JavaScript document', async() => {
+    test('loads and parses a JavaScript document', async () => {
       const context = await getContext(analyzer);
       const doc = await context['_parse']('static/js-elements.js');
       assert.instanceOf(doc, JavaScriptDocument);
       assert.equal(doc.url, 'static/js-elements.js');
     });
 
-    test('returns a Promise that rejects for non-existant files', async() => {
+    test('returns a Promise that rejects for non-existant files', async () => {
       const context = await getContext(analyzer);
       await invertPromise(context['_parse']('static/not-found'));
     });
   });
 
   suite('_getScannedFeatures()', () => {
-    test('default import scanners', async() => {
+    test('default import scanners', async () => {
       const contents = `<html><head>
           <link rel="import" href="polymer.html">
           <script src="foo.js"></script>
@@ -557,8 +559,9 @@ suite('Analyzer', () => {
         </head></html>`;
       const document = new HtmlParser().parse(contents, 'test.html');
       const context = await getContext(analyzer);
-      const features = ((await context['_getScannedFeatures'](document))
-                            .features as ScannedImport[]);
+      const features =
+          ((await context['_getScannedFeatures'](document)).features as
+           ScannedImport[]);
       assert.deepEqual(
           features.map((e) => e.type),
           ['html-import', 'html-script', 'html-style']);
@@ -567,7 +570,7 @@ suite('Analyzer', () => {
           ['polymer.html', 'foo.js', 'foo.css']);
     });
 
-    test('polymer css import scanner', async() => {
+    test('polymer css import scanner', async () => {
       const contents = `<html><head>
           <link rel="import" type="css" href="foo.css">
         </head>
@@ -580,22 +583,23 @@ suite('Analyzer', () => {
       const context = await getContext(analyzer);
       const features =
           (await context['_getScannedFeatures'](document))
-              .features.filter(
-                  (e) => e instanceof ScannedImport) as ScannedImport[];
+              .features.filter((e) => e instanceof ScannedImport) as
+          ScannedImport[];
       assert.equal(features.length, 1);
       assert.equal(features[0].type, 'css-import');
       assert.equal(features[0].url, 'bar.css');
     });
 
-    test('HTML inline document scanners', async() => {
+    test('HTML inline document scanners', async () => {
       const contents = `<html><head>
           <script>console.log('hi')</script>
           <style>body { color: red; }</style>
         </head></html>`;
       const context = await getContext(analyzer);
       const document = new HtmlParser().parse(contents, 'test.html');
-      const features = ((await context['_getScannedFeatures'](document))
-                            .features) as ScannedInlineDocument[];
+      const features =
+          ((await context['_getScannedFeatures'](document)).features) as
+          ScannedInlineDocument[];
 
       assert.equal(features.length, 2);
       assert.instanceOf(features[0], ScannedInlineDocument);
@@ -604,7 +608,7 @@ suite('Analyzer', () => {
 
     const testName =
         'HTML inline documents can be cloned, modified, and stringified';
-    test(testName, async() => {
+    test(testName, async () => {
       const contents = stripIndent(`
         <div>
           <script>
@@ -620,7 +624,6 @@ suite('Analyzer', () => {
       const modifiedContents = stripIndent(`
         <div>
           <script>
-            console.log('bar');
           </script>
           <style>
             body {
@@ -667,7 +670,7 @@ suite('Analyzer', () => {
   });
 
   suite('documentation extraction', () => {
-    test('we get the wrong description for paper-input', async() => {
+    test('we get the wrong description for paper-input', async () => {
       const document = await analyzeDocument('static/paper-input.html');
       const [element] =
           document.getFeatures({kind: 'element', id: 'paper-input'});
@@ -680,7 +683,7 @@ suite('Analyzer', () => {
     });
   });
 
-  test('analyzes a document with a namespace', async() => {
+  test('analyzes a document with a namespace', async () => {
     const document = await analyzeDocument('static/namespaces/import-all.html');
     if (!(document instanceof Document)) {
       throw new Error(`Expected Document, got ${document}`);
@@ -705,7 +708,7 @@ suite('Analyzer', () => {
   // TODO(rictic): move duplicate checks into scopes/analysis results.
   //     No where else has reliable knowledge of the clash.
   test.skip(
-      'creates warnings when duplicate namespaces are analyzed', async() => {
+      'creates warnings when duplicate namespaces are analyzed', async () => {
         const document = await analyzer.analyze(
             ['static/namespaces/import-duplicates.html']);
         const namespaces =
@@ -730,7 +733,7 @@ var DuplicateNamespace = {};
 
   suite('analyzePackage', () => {
 
-    test('produces a package with the right documents', async() => {
+    test('produces a package with the right documents', async () => {
       const analyzer = new Analyzer({
         urlLoader: new FSUrlLoader(path.join(testDir, 'static', 'project'))
       });
@@ -803,7 +806,7 @@ var DuplicateNamespace = {};
           packageElements.concat(['imported-dependency']).sort());
     });
 
-    test('can get warnings from within and without the package', async() => {
+    test('can get warnings from within and without the package', async () => {
       const analyzer = new Analyzer({
         urlLoader:
             new FSUrlLoader(path.join(testDir, 'static', 'project-with-errors'))
@@ -822,7 +825,7 @@ var DuplicateNamespace = {};
   });
 
   suite('_fork', () => {
-    test('returns an independent copy of Analyzer', async() => {
+    test('returns an independent copy of Analyzer', async () => {
       inMemoryOverlay.urlContentsMap.set('a.html', 'a is shared');
       await analyzer.analyze(['a.html']);
       // Unmap a.html so that future reads of it will fail, thus testing the
@@ -847,9 +850,15 @@ var DuplicateNamespace = {};
       assert.equal(b2.parsedDocument.contents, 'b for analyzer2');
     });
 
-    test('supports overriding of urlLoader', async() => {
-      const loader1 = {canLoad: () => true, load: async(u: string) => `${u} 1`};
-      const loader2 = {canLoad: () => true, load: async(u: string) => `${u} 2`};
+    test('supports overriding of urlLoader', async () => {
+      const loader1 = {
+        canLoad: () => true,
+        load: async (u: string) => `${u} 1`
+      };
+      const loader2 = {
+        canLoad: () => true,
+        load: async (u: string) => `${u} 2`
+      };
       const analyzer1 = new Analyzer({urlLoader: loader1});
       const a1 = await analyzeDocument('a.html', analyzer1);
       const analyzer2 = await analyzer1._fork({urlLoader: loader2});
@@ -865,7 +874,7 @@ var DuplicateNamespace = {};
   });
 
   suite('race conditions and caching', () => {
-    test('maintain caches across multiple edits', async() => {
+    test('maintain caches across multiple edits', async () => {
       // This is a regression test of a scenario where changing a dependency
       // did not properly update warnings of a file. The bug turned out to
       // be in the dependency graph, but this test seems useful enough to
@@ -930,7 +939,7 @@ var DuplicateNamespace = {};
       }
     }
 
-    const editorSimulator = async(waitFn: () => Promise<void>) => {
+    const editorSimulator = async (waitFn: () => Promise<void>) => {
       // Here we're simulating a lot of noop-changes to base.html,
       // which has
       // two imports, which mutually import a common dep. This
@@ -962,7 +971,7 @@ var DuplicateNamespace = {};
               analyzer.filesChanged([path]);
               const p = analyzer.analyze([path]);
               const cacheContext = await getContext(analyzer);
-              intermediatePromises.push((async() => {
+              intermediatePromises.push((async () => {
                 await p;
                 const docs = Array.from(
                     cacheContext['_cache'].analyzedDocuments.values());
@@ -1021,7 +1030,7 @@ var DuplicateNamespace = {};
       }
     };
 
-    test('editor simulator of imports that import a common dep', async() => {
+    test('editor simulator of imports that import a common dep', async () => {
       const waitTimes: number[] = [];
       const randomWait = () => new Promise<void>((resolve) => {
         const waitTime = Math.random() * 30;
@@ -1054,7 +1063,7 @@ var DuplicateNamespace = {};
      * end
      * up being very useful. If it isn't, we should delete it.
      */
-    test.skip('somewhat more reproducable editor simulator', async() => {
+    test.skip('somewhat more reproducable editor simulator', async () => {
       // Replace waitTimes' value with the array of wait times
       // that's logged
       // to the console when the random editor test fails.
@@ -1164,7 +1173,7 @@ var DuplicateNamespace = {};
        * This test came out of debugging this issue:
        *     https://github.com/Polymer/polymer-analyzer/issues/406
        */
-      test('two edits of the same file back to back', async() => {
+      test('two edits of the same file back to back', async () => {
         const overlay = new InMemoryOverlayUrlLoader(new NoopUrlLoader);
         const analyzer = new Analyzer({urlLoader: overlay});
 
@@ -1176,7 +1185,7 @@ var DuplicateNamespace = {};
         await Promise.all([p1, p2]);
       });
 
-      test('handles a shared dependency', async() => {
+      test('handles a shared dependency', async () => {
         const initialPaths =
             ['static/diamond/a.html', 'static/diamond/root.html'];
         let result = await analyzer.analyze(initialPaths);
@@ -1198,7 +1207,7 @@ var DuplicateNamespace = {};
         ]);
       });
 
-      test('all files in a cycle wait for the whole cycle', async() => {
+      test('all files in a cycle wait for the whole cycle', async () => {
         const loader = new DeterministicUrlLoader();
         const analyzer = new Analyzer({urlLoader: loader});
         const aAnalyzed = analyzer.analyze(['a.html']);
@@ -1224,7 +1233,7 @@ var DuplicateNamespace = {};
         await Promise.all([aAnalyzedDone, bAnalyzedDone]);
       });
 
-      test('analyzes multiple imports of the same behavior', async() => {
+      test('analyzes multiple imports of the same behavior', async () => {
         const documentA = await analyzer.analyze(
             ['static/multiple-behavior-imports/element-a.html']);
         const documentB = await analyzer.analyze(
@@ -1235,7 +1244,7 @@ var DuplicateNamespace = {};
 
       test(
           'analyzes multiple imports of the same behavior simultaneously',
-          async() => {
+          async () => {
             const result = await Promise.all([
               analyzer.analyze(
                   ['static/multiple-behavior-imports/element-a.html']),

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -100,9 +100,12 @@ suite('JavaScriptParser', () => {
   suite(`stringify()`, () => {
     test('pretty prints output', () => {
       const contents = stripIndent(`
+        /* this is a block comment*/
+        // hello world
         class Foo extends HTMLElement {
           constructor() {
             super();
+            /* block comment in the middle of file */
             this.bar = () => {
             };
             const let = 'let const';

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -45,7 +45,7 @@ suite('JavaScriptParser', () => {
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
-      assert.equal(document.parsedAsSourceType, 'script');
+      assert.equal(document.parsedAsSourceType, 'module');
       // First statement is a class declaration
       assert.equal(document.ast.body[0].type, 'ClassDeclaration');
     });
@@ -60,7 +60,7 @@ suite('JavaScriptParser', () => {
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
-      assert.equal(document.parsedAsSourceType, 'script');
+      assert.equal(document.parsedAsSourceType, 'module');
       // First statement is an async function declaration
       const functionDecl = document.ast.body[0];
       if (functionDecl.type !== 'FunctionDeclaration') {

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -299,10 +299,10 @@ suite('PolymerElementScanner', () => {
             [
               `
             computed: 'let let let',
-                           ~`,
+                               ~`,
               `
             observer: 'let let let',
-                           ~`
+                               ~`
             ],
             [
               `
@@ -316,7 +316,7 @@ suite('PolymerElementScanner', () => {
       assert.deepEqual(await underliner.underline(element.warnings), [
         `
           'let let let parseError',
-               ~`,
+                   ~`,
         `
           'foo'
            ~~~`

--- a/src/test/polymer/polymer-element_test.ts
+++ b/src/test/polymer/polymer-element_test.ts
@@ -58,17 +58,16 @@ suite('PolymerElement', () => {
       attributes: Array.from(element.attributes.values()).map((a) => ({
                                                                 name: a.name,
                                                               })),
-      methods: Array.from(element.methods.values()).map((m) => ({
-                                                          name: m.name,
-                                                          params: m.params,
-                                                          return: m.return,
-                                                          inheritedFrom:
-                                                              m.inheritedFrom
-                                                        })),
+      methods: Array.from(element.methods.values())
+                   .map((m) => ({
+                          name: m.name,
+                          params: m.params, return: m.return,
+                          inheritedFrom: m.inheritedFrom
+                        })),
     };
   }
 
-  test('Scans and resolves base and sub-class', async () => {
+  test('Scans and resolves base and sub-class', async() => {
     const elements = await getElements('test-element-3.js');
     const elementData = Array.from(elements).map(getTestProps);
     assert.deepEqual(elementData, [
@@ -132,7 +131,7 @@ suite('PolymerElement', () => {
     ]);
   });
 
-  test('Computes correct property information', async () => {
+  test('Computes correct property information', async() => {
     const elements = await getElements('test-element-17.js');
     const elementData = Array.from(elements).map(getTestProps);
     assert.deepEqual(elementData, [
@@ -156,7 +155,7 @@ suite('PolymerElement', () => {
     ]);
   });
 
-  test('Elements inherit from mixins and base classes', async () => {
+  test('Elements inherit from mixins and base classes', async() => {
     const elements = await getElements('test-element-7.js');
     const elementData = Array.from(elements).map(getTestProps);
     assert.deepEqual(elementData, [
@@ -185,8 +184,7 @@ suite('PolymerElement', () => {
         ],
         methods: [{
           name: 'customMethodOnBaseElement',
-          params: [],
-          return: undefined,
+          params: [], return: undefined,
           inheritedFrom: undefined
         }],
       },
@@ -237,20 +235,17 @@ suite('PolymerElement', () => {
         methods: [
           {
             name: 'customMethodOnBaseElement',
-            params: [],
-            return: undefined,
+            params: [], return: undefined,
             inheritedFrom: 'BaseElement'
           },
           {
             name: 'customMethodOnMixin',
-            params: [],
-            return: undefined,
+            params: [], return: undefined,
             inheritedFrom: 'Mixin'
           },
           {
             name: 'customMethodOnSubElement',
-            params: [],
-            return: undefined,
+            params: [], return: undefined,
             inheritedFrom: undefined
           },
         ],
@@ -267,14 +262,14 @@ suite('PolymerElement', () => {
       return [...elements][0]!;
     }
 
-    test('Elements with only one doc comment have no warning', async () => {
+    test('Elements with only one doc comment have no warning', async() => {
       const element = await getElement('test-element-14.html');
       const warning = element.warnings.find(
           (w: Warning) => w.code === 'multiple-doc-comments');
       assert.isUndefined(warning);
     });
 
-    test('Elements with more than one doc comment have warning', async () => {
+    test('Elements with more than one doc comment have warning', async() => {
       const element = await getElement('test-element-15.html');
       const warning = element.warnings.find(
           (w: Warning) => w.code === 'multiple-doc-comments')!;

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -487,10 +487,10 @@ namespaced name.`,
               warningUnderlines: [
                 `
         computed: 'let let let',
-                       ~`,
+                           ~`,
                 `
         observer: 'let let let',
-                       ~`,
+                           ~`,
               ]
             },
             {
@@ -515,7 +515,7 @@ namespaced name.`,
           warningUnderlines: [
             `
       'let let let parseError',
-           ~`,
+               ~`,
             `
       'foo',
        ~~~`

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -487,10 +487,10 @@ namespaced name.`,
               warningUnderlines: [
                 `
         computed: 'let let let',
-                       ~`,
+                           ~`,
                 `
         observer: 'let let let',
-                       ~`,
+                           ~`,
               ]
             },
             {
@@ -515,7 +515,7 @@ namespaced name.`,
           warningUnderlines: [
             `
       'let let let parseError',
-           ~`,
+               ~`,
             `
       'foo',
        ~~~`


### PR DESCRIPTION
While working with `document.stringify()`, I discovered that comments in JS ASTs are duplicated. This seemed to be an artifact of `espree`. By switching to `recast`, this issue is fixed.This also opens the door for parsing Typescript, when https://github.com/benjamn/recast/issues/424 is resolved.

There are still some outstanding issues regarding unreported malformedness, but also it seems to fail on parsing `console.log()` with the following error:
```js
Analyzer _getScannedFeatures() HTML inline documents can be cloned, modified, and stringified:
     TypeError: Cannot read property 'infos' of undefined
      at Lines.Lp.charAt (node_modules/recast/lib/lines.js:283:23)
      at Lines.Lp.skipSpaces (node_modules/recast/lib/lines.js:580:38)
      at Object.util.getTrueLoc (node_modules/recast/lib/util.js:122:11)
      at node_modules/recast/lib/printer.js:1701:18
      at Array.forEach (native)
      at printStatementSequence (node_modules/recast/lib/printer.js:1691:14)
      at node_modules/recast/lib/printer.js:236:20
      at FastPath.call (node_modules/recast/lib/fast-path.js:119:16)
      at genericPrintNoParens (node_modules/recast/lib/printer.js:235:25)
      at genericPrint (node_modules/recast/lib/printer.js:164:9)
      at printRootGenerically (node_modules/recast/lib/printer.js:105:15)
      at maybeReprint (node_modules/recast/lib/printer.js:97:16)
      at print (node_modules/recast/lib/printer.js:81:16)
      at exports.printComments (node_modules/recast/lib/comments.js:324:22)
      at printWithComments (node_modules/recast/lib/printer.js:61:16)
      at print (node_modules/recast/lib/printer.js:66:20)
      at Printer.print (node_modules/recast/lib/printer.js:118:21)
      at Object.print (node_modules/recast/main.js:6:33)
      at JavaScriptDocument.stringify (lib/javascript/javascript/javascript-document.ts:169:19)
      at ParsedHtmlDocument.stringify (lib/html/html/html-document.ts:193:51)
      at Document.stringify (lib/model/model/document.ts:402:32)
      at Object.<anonymous> (lib/test/core/test/core/analyzer_test.ts:667:33)
      at Generator.next (<anonymous>)
      at fulfilled (lib/test/core/analyzer_test.js:17:58)
      at <anonymous>
```
I have no clue what is going on there. Modifying the test does not seem to report any other error and sadly this issue manifests in my usage of the analyzer as well.

Any pointers for fixing the last few test errors would be greatly appreciated, as I seem to be stuck on fixing them :cry: 

 - [ ] CHANGELOG.md has been updated
