### PR TITLE
Resolve several TODO's and implement getDocumentContaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `result.successful` is true, `result.value` is a Document. When
   `result.successful` is false, then `result.value` is
   either a Warning or undefined.
+* Introduce getDocumentContaining to find containing inline document for a feature
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.5] - 2017-12-15

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -14,6 +14,7 @@
 
 import * as path from 'path';
 
+
 import {ForkOptions, LazyEdgeMap, NoKnownParserError, Options, ScannerTable} from '../core/analyzer';
 import {CssCustomPropertyScanner} from '../css/css-custom-property-scanner';
 import {CssParser} from '../css/css-parser';

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -77,3 +77,10 @@ export class Deferred<T> {
     };
   }
 }
+
+export function addAll<T>(set1: Set<T>, set2: Set<T>): Set<T> {
+  for (const val of set2) {
+    set1.add(val);
+  }
+  return set1;
+}

--- a/src/html/html-document.ts
+++ b/src/html/html-document.ts
@@ -187,8 +187,16 @@ export class ParsedHtmlDocument extends ParsedDocument<ASTNode, HtmlVisitor> {
     const selfClone = mutableDocuments.shift()!;
 
     for (const doc of mutableDocuments) {
-      // TODO(rictic): infer this from doc.astNode's indentation.
-      const expectedIndentation = 2;
+      let expectedIndentation;
+      if (doc.astNode.__location) {
+        expectedIndentation = doc.astNode.__location.col;
+
+        if (doc.astNode.parentNode && doc.astNode.parentNode.__location) {
+          expectedIndentation -= doc.astNode.parentNode.__location.col;
+        }
+      } else {
+        expectedIndentation = 2;
+      }
 
       dom5.setTextContent(doc.astNode, '\n' + doc.stringify({
         indent: expectedIndentation

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -30,8 +30,7 @@ declare class SyntaxError {
   column: number;
 }
 
-// TODO(rictic): stop exporting this.
-export const baseParseOptions: babylon.BabylonOptions = {
+const baseParseOptions: babylon.BabylonOptions = {
   plugins: [
     'asyncGenerators',
     'dynamicImport',

--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -152,21 +152,25 @@ export class Analysis implements Queryable {
    * @param sourceRange Source range to search for in a document
    */
    getDocumentContaining(sourceRange: SourceRange|undefined) {
-   if (!sourceRange) {
-     return undefined;
-   }
-   let mostSpecificDocument: undefined|Document = undefined;
-   for (const doc of this.getFeatures({kind: 'document'})) {
-     if (isPositionInsideRange(sourceRange.start, doc.sourceRange)) {
-       if (!mostSpecificDocument ||
-           isPositionInsideRange(
-               doc.sourceRange!.start, mostSpecificDocument.sourceRange)) {
-         mostSpecificDocument = doc;
+     if (!sourceRange) {
+       return undefined;
+     }
+     let mostSpecificDocument: undefined|Document = undefined;
+     const [outerDocument] = this.getFeatures({kind: 'document', id: sourceRange.file});
+     if (!outerDocument) {
+       return undefined;
+     }
+     for (const doc of outerDocument.getFeatures({kind: 'document'})) {
+       if (isPositionInsideRange(sourceRange.start, doc.sourceRange)) {
+         if (!mostSpecificDocument ||
+             isPositionInsideRange(
+                 doc.sourceRange!.start, mostSpecificDocument.sourceRange)) {
+           mostSpecificDocument = doc;
+         }
        }
      }
+     return mostSpecificDocument;
    }
-   return mostSpecificDocument;
- }
 
   private _getDocumentQuery(query: Query = {}): DocumentQuery {
     return {

--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -12,13 +12,16 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {SourceRange} from '../analysis-format/analysis-format';
 import {AnalysisContext} from '../core/analysis-context';
+import {addAll} from '../core/utils';
 import {PackageRelativeUrl} from '../index';
 
 import {Document} from './document';
 import {Feature} from './feature';
 import {ImmutableMap, ImmutableSet} from './immutable';
 import {AnalysisQuery as Query, AnalysisQueryWithKind as QueryWithKind, DocumentQuery, FeatureKind, FeatureKindMap, Queryable} from './queryable';
+import {isPositionInsideRange} from './source-range';
 import {ResolvedUrl} from './url';
 import {Warning} from './warning';
 
@@ -147,26 +150,23 @@ export class Analysis implements Queryable {
    * will narrow down the document to the most specific inline document.
    *
    * @param sourceRange Source range to search for in a document
-   * @param document The document that contains the source range
    */
-  getDocumentContaining(sourceRange: SourceRange|undefined, document: Document):
-      Document|undefined {
-    if (!sourceRange) {
-      return undefined;
-    }
-    let mostSpecificDocument: undefined|Document = undefined;
-    for (const doc of document.getFeatures({kind: 'document'})) {
-      if (isPositionInsideRange(sourceRange.start, doc.sourceRange)) {
-        if (!mostSpecificDocument ||
-            isPositionInsideRange(
-                doc.sourceRange!.start, mostSpecificDocument.sourceRange)) {
-          mostSpecificDocument = doc;
-        }
-      }
-    }
-    mostSpecificDocument = mostSpecificDocument || document;
-    return mostSpecificDocument;
-  }
+   getDocumentContaining(sourceRange: SourceRange|undefined) {
+   if (!sourceRange) {
+     return undefined;
+   }
+   let mostSpecificDocument: undefined|Document = undefined;
+   for (const doc of this.getFeatures({kind: 'document'})) {
+     if (isPositionInsideRange(sourceRange.start, doc.sourceRange)) {
+       if (!mostSpecificDocument ||
+           isPositionInsideRange(
+               doc.sourceRange!.start, mostSpecificDocument.sourceRange)) {
+         mostSpecificDocument = doc;
+       }
+     }
+   }
+   return mostSpecificDocument;
+ }
 
   private _getDocumentQuery(query: Query = {}): DocumentQuery {
     return {

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -263,6 +263,24 @@ suite('Analyzer', () => {
       assert.equal(narrowedDocument, inlineJsDocument);
     });
 
+    testName = 'a feature in the top level document narrows down to the full document';
+    test(testName, async () => {
+      const url = 'static/script-tags/inline/test-element.html';
+      const result = (await analyzer.analyze([url]));
+      const document = result.getDocument(url);
+      if (!document.successful) {
+        throw new Error(`Could not get document for url: ${url}`);
+      }
+
+      // The inline document can find the container's imported
+      // features
+      const HTMLImport = getOnly(document.value.getFeatures(
+          {kind: 'html-import'}));
+      const narrowedDocument =
+          result.getDocumentContaining(HTMLImport.sourceRange);
+      assert.equal(narrowedDocument, document.value);
+    });
+
     testName =
         'an external script can find features from its container document';
     test(testName, async () => {

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -239,6 +239,31 @@ suite('Analyzer', () => {
       assert.equal(subBehavior!.className, 'TestBehavior');
     });
 
+    testName = 'an inline feature can narrow down its containing document';
+    test.only(testName, async () => {
+      const url = 'static/script-tags/inline/test-element.html';
+      const result = (await analyzer.analyze([url]));
+      const document = result.getDocument(url);
+      if (!document.successful) {
+        throw new Error(`Could not get document for url: ${url}`);
+      }
+      const inlineDocuments = Array
+                                  .from(document.value.getFeatures(
+                                      {kind: 'document', imported: false}))
+                                  .filter((d) => d.isInline);
+      assert.equal(inlineDocuments.length, 1);
+      const inlineJsDocument = inlineDocuments[0];
+
+      // The inline document can find the container's imported
+      // features
+      const subBehavior = getOnly(document.value.getFeatures(
+          {kind: 'polymer-element', id: 'test-element', imported: true}));
+      const narrowedDocument =
+          result.getDocumentContaining(subBehavior.sourceRange);
+          console.log(inlineJsDocument.type, inlineJsDocument.url)
+      assert.equal(narrowedDocument, inlineJsDocument);
+    });
+
     testName =
         'an external script can find features from its container document';
     test(testName, async () => {

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -240,7 +240,7 @@ suite('Analyzer', () => {
     });
 
     testName = 'an inline feature can narrow down its containing document';
-    test.only(testName, async () => {
+    test(testName, async () => {
       const url = 'static/script-tags/inline/test-element.html';
       const result = (await analyzer.analyze([url]));
       const document = result.getDocument(url);
@@ -260,7 +260,6 @@ suite('Analyzer', () => {
           {kind: 'polymer-element', id: 'test-element', imported: true}));
       const narrowedDocument =
           result.getDocumentContaining(subBehavior.sourceRange);
-          console.log(inlineJsDocument.type, inlineJsDocument.url)
       assert.equal(narrowedDocument, inlineJsDocument);
     });
 


### PR DESCRIPTION
Introduce `getDocumentContaining` to find containing inline document for a feature, originally from https://github.com/Polymer/polymer-linter/blob/9d692d3dbc621b9be898006d92f516ffa4a56eaf/src/polymer/call-super-in-callbacks.ts#L125

Also fix several other easy TODO's.

Fixes #557

 - [x] CHANGELOG.md has been updated
