### PR TITLE
Fix parsing of non-primitive Expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Scan for CSS custom variable uses and assignments.
 * Fix value of reflectToAttribute for polymer properties
 * Remove scriptElement from PolymerElement
+* Fix handling of types of properties defined in a behavior
 
 ## [2.2.2] - 2017-07-20
 

--- a/src/polymer/js-utils.ts
+++ b/src/polymer/js-utils.ts
@@ -50,6 +50,10 @@ export function toScannedPolymerProperty(
   if (typeTag) {
     type = doctrine.type.stringify(typeTag.type!) || type;
   }
+  if (type instanceof Warning) {
+    warnings.push(type);
+    type = 'Object';
+  }
   const name = maybeName || '';
   const result: ScannedPolymerProperty = {
     name,

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -111,7 +111,7 @@ suite('BehaviorScanner', () => {
     assert.deepEqual([...behavior.methods.keys()], ['method']);
     assert.deepEqual(
         [...behavior.properties.keys()],
-        ['simple', 'object', 'array', 'attached']);
+        ['simple', 'object', 'array', 'attached', 'templateLiteral']);
   });
 
   test('Correctly transforms property types', function() {
@@ -126,7 +126,8 @@ suite('BehaviorScanner', () => {
           {name: 'simple', type: 'boolean'},
           {name: 'object', type: 'Object'},
           {name: 'array', type: 'Array'},
-          {name: 'attached', type: 'Object'}
+          {name: 'attached', type: 'Object'},
+          {name: 'templateLiteral', type: 'string'}
         ]);
   });
 });

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -30,7 +30,7 @@ suite('BehaviorScanner', () => {
   let behaviors: Map<string, ScannedBehavior>;
   let behaviorsList: ScannedBehavior[];
 
-  suiteSetup(async() => {
+  suiteSetup(async () => {
     const parser = new JavaScriptParser();
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/js-behaviors.js'), 'utf8');
@@ -74,8 +74,8 @@ suite('BehaviorScanner', () => {
   test('Supports behaviors On.Property.Paths', () => {
     assert(behaviors.has('Really.Really.Deep.Behavior'));
     assert.equal(
-        behaviors.get('Really.Really.Deep.Behavior')!.properties
-            .get('deep')!.name,
+        behaviors.get('Really.Really.Deep.Behavior')!.properties.get('deep')!
+            .name,
         'deep');
   });
 
@@ -109,6 +109,24 @@ suite('BehaviorScanner', () => {
       throw new Error('Could not find Polymer.SimpleNamespacedBehavior');
     }
     assert.deepEqual([...behavior.methods.keys()], ['method']);
-    assert.deepEqual([...behavior.properties.keys()], ['simple']);
+    assert.deepEqual(
+        [...behavior.properties.keys()],
+        ['simple', 'object', 'array', 'attached']);
+  });
+
+  test('Correctly transforms property types', function() {
+    const behavior = behaviors.get('Polymer.SimpleNamespacedBehavior');
+    if (!behavior) {
+      throw new Error('Could not find Polymer.SimpleNamespacedBehavior');
+    }
+    assert.deepEqual(
+        [...behavior.properties.values()].map(
+            (p) => ({name: p.name, type: p.type})),
+        [
+          {name: 'simple', type: 'boolean'},
+          {name: 'object', type: 'Object'},
+          {name: 'array', type: 'Array'},
+          {name: 'attached', type: 'Object'}
+        ]);
   });
 });

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -14,7 +14,8 @@ var SimpleNamespacedBehavior = {
   },
   object: {},
   array: [],
-  attached: true ? null : function() {}
+  attached: true ? null : function() {},
+  templateLiteral: `foo`
 };
 
 

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -9,9 +9,12 @@ var SimpleBehavior = {
  * */
 var SimpleNamespacedBehavior = {
   simple: true,
-  method: function (paramA, paramB) {
+  method: function(paramA, paramB) {
 
   },
+  object: {},
+  array: [],
+  attached: true ? null : function() {}
 };
 
 


### PR DESCRIPTION
This came up during parsing of
https://github.com/PolymerElements/iron-form-element-behavior/blob/6087b69013619e5b3e023a10824d25cf7530d1fc/iron-form-element-behavior.html#L74-L84 where conditionals are used instead of direct assignments.
 - [x] CHANGELOG.md has been updated
