### PR TITLE
Parse script v parse module

### DIFF
--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -43,8 +43,8 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
       JavaScriptDocument {
     const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
-    const result =
-        parseJs(contents, url, inlineInfo.locationOffset, this.sourceType);
+    const result = parseJs(
+        contents, url, inlineInfo.locationOffset, undefined, this.sourceType);
     if (result.type === 'failure') {
       // TODO(rictic): define and return a ParseResult instead of throwing.
       const minimalDocument = new JavaScriptDocument({

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -111,23 +111,19 @@ export function parseJs(
   let program: estree.Program;
 
   try {
+    // If sourceType is not provided, we will try script first and if that
+    // fails, we will try module, since failure is probably that it can't parse
+    // the 'import' or 'export' syntax as a script.
     if (!sourceType) {
       try {
         sourceType = 'script';
-        program = espree.parse(
-            contents,
-            Object.assign(
-                {sourceType: 'script' as SourceType}, baseParseOptions));
+        program = espree.parse(contents, {sourceType, ...baseParseOptions});
       } catch (_ignored) {
         sourceType = 'module';
-        program = espree.parse(
-            contents,
-            Object.assign(
-                {sourceType: 'module' as SourceType}, baseParseOptions));
+        program = espree.parse(contents, {sourceType, ...baseParseOptions});
       }
     } else {
-      program =
-          espree.parse(contents, Object.assign({sourceType}, baseParseOptions));
+      program = espree.parse(contents, {sourceType, ...baseParseOptions});
     }
     return {
       type: 'success',

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -20,6 +20,8 @@ import {Parser} from '../parser/parser';
 
 import {JavaScriptDocument} from './javascript-document';
 
+export type SourceType = 'script' | 'module';
+
 declare class SyntaxError {
   message: string;
   lineNumber: number;
@@ -35,11 +37,14 @@ export const baseParseOptions = {
 };
 
 export class JavaScriptParser implements Parser<JavaScriptDocument> {
+  sourceType: SourceType;
+
   parse(contents: string, url: string, inlineInfo?: InlineDocInfo<any>):
       JavaScriptDocument {
     const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
-    const result = parseJs(contents, url, inlineInfo.locationOffset);
+    const result =
+        parseJs(contents, url, inlineInfo.locationOffset, this.sourceType);
     if (result.type === 'failure') {
       // TODO(rictic): define and return a ParseResult instead of throwing.
       const minimalDocument = new JavaScriptDocument({
@@ -47,8 +52,7 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
         contents,
         ast: null as any,
         locationOffset: inlineInfo.locationOffset,
-        astNode: inlineInfo.astNode,
-        isInline,
+        astNode: inlineInfo.astNode, isInline,
         parsedAsSourceType: 'script',
       });
       throw new WarningCarryingException(
@@ -60,19 +64,25 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
       contents,
       ast: result.program,
       locationOffset: inlineInfo.locationOffset,
-      astNode: inlineInfo.astNode,
-      isInline,
+      astNode: inlineInfo.astNode, isInline,
       parsedAsSourceType: result.sourceType,
     });
   }
 }
 
+export class JavaScriptModuleParser extends JavaScriptParser {
+  sourceType: SourceType = 'module';
+}
+
+export class JavaScriptScriptParser extends JavaScriptParser {
+  sourceType: SourceType = 'script';
+}
 
 export type ParseResult = {
   type: 'success',
-  sourceType: 'script'|'module',
+  sourceType: SourceType,
   program: estree.Program
-}|{
+} | {
   type: 'failure',
   warning: {
     sourceRange: SourceRange,
@@ -92,45 +102,56 @@ export function parseJs(
     contents: string,
     file: string,
     locationOffset?: LocationOffset,
-    warningCode?: string): ParseResult {
+    warningCode?: string,
+    sourceType?: SourceType): ParseResult {
   if (!warningCode) {
     warningCode = 'parse-error';
   }
-  const options = Object.assign(
-      {sourceType: 'script' as ('script' | 'module')}, baseParseOptions);
+
+  let program: estree.Program;
+
   try {
+    if (!sourceType) {
+      try {
+        sourceType = 'script';
+        program = espree.parse(
+            contents,
+            Object.assign(
+                {sourceType: 'script' as SourceType}, baseParseOptions));
+      } catch (_ignored) {
+        sourceType = 'module';
+        program = espree.parse(
+            contents,
+            Object.assign(
+                {sourceType: 'module' as SourceType}, baseParseOptions));
+      }
+    } else {
+      program =
+          espree.parse(contents, Object.assign({sourceType}, baseParseOptions));
+    }
     return {
       type: 'success',
-      sourceType: 'script',
-      program: espree.parse(contents, options)
+      sourceType: sourceType,
+      program: program,
     };
-  } catch (_ignored) {
-    try {
-      options.sourceType = 'module';
+  } catch (err) {
+    if (err instanceof SyntaxError) {
       return {
-        type: 'success',
-        sourceType: 'module',
-        program: espree.parse(contents, options)
+        type: 'failure',
+        warning: {
+          message: err.message.split('\n')[0],
+          severity: Severity.ERROR,
+          code: warningCode,
+          sourceRange: correctSourceRange(
+              {
+                file,
+                start: {line: err.lineNumber - 1, column: err.column - 1},
+                end: {line: err.lineNumber - 1, column: err.column - 1}
+              },
+              locationOffset)!
+        }
       };
-    } catch (err) {
-      if (err instanceof SyntaxError) {
-        return {
-          type: 'failure',
-          warning: {
-            message: err.message.split('\n')[0],
-            severity: Severity.ERROR,
-            code: warningCode,
-            sourceRange: correctSourceRange(
-                {
-                  file,
-                  start: {line: err.lineNumber - 1, column: err.column - 1},
-                  end: {line: err.lineNumber - 1, column: err.column - 1}
-                },
-                locationOffset)!
-          }
-        };
-      }
-      throw err;
     }
+    throw err;
   }
 }

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -19,7 +19,7 @@ import stripIndent = require('strip-indent');
 
 import * as esutil from '../../javascript/esutil';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
+import {JavaScriptParser, JavaScriptModuleParser, JavaScriptScriptParser} from '../../javascript/javascript-parser';
 
 suite('JavaScriptParser', () => {
   let parser: JavaScriptParser;
@@ -112,5 +112,43 @@ suite('JavaScriptParser', () => {
       const document = parser.parse(contents, 'test-file.js');
       assert.deepEqual(document.stringify({}), contents);
     });
+  });
+});
+
+suite('JavaScriptModuleParser', () => {
+
+  let parser: JavaScriptModuleParser;
+
+  setup(() => {
+    parser = new JavaScriptModuleParser();
+  });
+
+  suite('parse()', () => {
+    test('parses an ES6 module', () => {
+      const contents = `
+    import foo from 'foo';
+  `;
+      const document = parser.parse(contents, '/static/es6-support.js');
+      assert.instanceOf(document, JavaScriptDocument);
+      assert.equal(document.url, '/static/es6-support.js');
+      assert.equal(document.ast.type, 'Program');
+      assert.equal(document.parsedAsSourceType, 'module');
+    });
+  });
+});
+
+suite('JavaScriptScriptParser', () => {
+
+  let parser: JavaScriptScriptParser;
+
+  setup(() => {
+    parser = new JavaScriptScriptParser();
+  });
+
+  test('throws a syntax error when parsing es6 module', () => {
+    const contents = `
+      import foo from 'foo';
+    `;
+    assert.throws(() => parser.parse(contents, '/static/es6-support.js'));
   });
 });


### PR DESCRIPTION
In preparation for supporting explicit module import graph traversal and handling of JS modules vs JS scripts, I updated the `javascript-parser.ts` code and tests to add `JavaScriptScriptParser` and `JavaScriptModuleParser` classes.

We had discussed `parseScript` and `parseModule` methods as part of `JavaScriptParser` except the interface for `Parser` in analyzer is they provide a single `parse()` method and this was the way to continue support for that interface without losing anything.

Also, I preserve the `JavaScriptParser` behavior precisely because the analyzer has a file-extension-to-parser map which would have to be redesigned if a single extension could refer to parsers of different types.  That can be refactored later, but this provides a way to add the desired strictness without refactoring the entire analyzer in this step.