### PR TITLE
Create ScriptTagBackReferenceImport

### DIFF
--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -54,10 +54,14 @@ export class ScannedScriptTagImport extends ScannedImport {
       const importedDocument =
           new Document(scannedDocument, document._analysisContext);
 
-      // Since JavaScript defined within `<script>` tags or loaded into by a
-      // `<script src=...>` inherits/shares scope with other scripts previously
-      // loaded by the page, add this synthetic import to support queries for
-      // features of the HTML document from the JavaScript document.
+      // Scripts regularly make use of global variables or functions (e.g.
+      // `Polymer()`, `$('#some-id')`, etc) that are defined in libraries
+      // which are loaded via prior script tags or HTML imports.  Since
+      // JavaScript defined within `<script>` tags or loaded by a
+      // `<script src=...>` share scope with other scripts previously
+      // loaded by the page, this synthetic import is added to support
+      // queries for features of the HTML document which should be "visible"
+      // to the JavaScript document.
       const backReference = new ScriptTagBackReferenceImport(
           document.url,
           'html-script-back-reference',

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -53,10 +53,9 @@ export class ScannedScriptTagImport extends ScannedImport {
     if (scannedDocument) {
       const importedDocument =
           new Document(scannedDocument, document._analysisContext);
-      // TODO(usergenic): This _addFeature() line just basically adds the whole
-      // current document feature set into the imported document, which makes it
-      // really hard to reason about where the features are coming from *after*
-      // analysis.
+      // Connect the javascript document defined/referenced by the script tag to
+      // the html document which contained the script tag with a synthetic
+      // import.
       const backReference = new ScriptTagBackReferenceImport(
           this.url,
           'html-script-back-reference',

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -53,9 +53,11 @@ export class ScannedScriptTagImport extends ScannedImport {
     if (scannedDocument) {
       const importedDocument =
           new Document(scannedDocument, document._analysisContext);
-      // Connect the javascript document defined/referenced by the script tag to
-      // the html document which contained the script tag with a synthetic
-      // import.
+
+      // Since JavaScript defined within `<script>` tags or loaded into by a
+      // `<script src=...>` inherits/shares scope with other scripts previously
+      // loaded by the page, add this synthetic import to support queries for
+      // features of the HTML document from the JavaScript document.
       const backReference = new ScriptTagBackReferenceImport(
           document.url,
           'html-script-back-reference',

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -57,7 +57,7 @@ export class ScannedScriptTagImport extends ScannedImport {
       // the html document which contained the script tag with a synthetic
       // import.
       const backReference = new ScriptTagBackReferenceImport(
-          this.url,
+          document.url,
           'html-script-back-reference',
           document,
           this.sourceRange,


### PR DESCRIPTION
Creates a synthetic back-reference import for script tags instead of adding the container html document as a feature to the scanned javascript document.

A slightly less ugly hack than what was in place as of https://github.com/Polymer/polymer-analyzer/issues/615
