### PR TITLE
Handle method rest parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
+* Handle method rest parameters correctly.
 <!-- Add new, unreleased changes here. -->
 
 ## [2.4.1] - 2017-10-31

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -255,7 +255,12 @@ export function toScannedMethod(
       let description = undefined;
       // With ES6 we can have a lot of param patterns. Best to leave the
       // formatting to escodegen.
-      const name = escodegen.generate(nodeParam);
+      let name = escodegen.generate(nodeParam);
+      // Rest parameters look like `...foo` in the parameter list, but are
+      // annotated as `@param {...T} foo` in the JSDoc.
+      if (name.startsWith('...')) {
+        name = name.substring(3);
+      }
       const tag = paramTags.get(name);
       if (tag) {
         if (tag.type) {

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -217,6 +217,27 @@ suite('Class', () => {
               description: 'This is the description for\n' +
                   'customInstanceFunctionWithParamsAndPrivateJSDoc.',
             },
+            {
+              name: 'customInstanceFunctionWithRestParam',
+              description: 'This is the description for ' +
+                  'customInstanceFunctionWithRestParam.',
+              params: [
+                {
+                  name: 'a',
+                  type: 'Number',
+                  description: 'The first argument.',
+                },
+                {
+                  name: 'b',
+                  type: '...Number',
+                  description: 'The second argument.',
+                }
+              ],
+              return: {
+                desc: 'The number 9, always.',
+                type: 'Number',
+              },
+            },
           ]
         },
       ]);
@@ -386,6 +407,27 @@ suite('Class', () => {
               name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
               description: 'This is the description for\n' +
                   'customInstanceFunctionWithParamsAndPrivateJSDoc.',
+            },
+            {
+              name: 'customInstanceFunctionWithRestParam',
+              description: 'This is the description for ' +
+                  'customInstanceFunctionWithRestParam.',
+              params: [
+                {
+                  name: 'a',
+                  type: 'Number',
+                  description: 'The first argument.',
+                },
+                {
+                  name: 'b',
+                  type: '...Number',
+                  description: 'The second argument.',
+                }
+              ],
+              return: {
+                desc: 'The number 9, always.',
+                type: 'Number',
+              },
             },
           ]
         },

--- a/src/test/static/class/class-methods.js
+++ b/src/test/static/class/class-methods.js
@@ -46,4 +46,14 @@ class Class {
   customInstanceFunctionWithParamsAndPrivateJSDoc() {
     return 8;
   }
+
+  /**
+   * This is the description for customInstanceFunctionWithRestParam.
+   * @param {Number} a The first argument.
+   * @param {...Number} b The second argument.
+   * @returns {Number} - The number 9, always.
+   */
+  customInstanceFunctionWithRestParam(a, ...b) {
+    return 9;
+  }
 }


### PR DESCRIPTION
Before this change, rest parameters (e.g. `foo(...args)`) would have the `...` included in their name, and would not include any information from their JSDoc annotation.

Now the parameter name does not include the `...`, and the JSDoc annotations are correctly linked (note that the *type* includes the `...` to make it clear this is a rest parameter). This is how regular functions already work in Analyzer

 - [X] CHANGELOG.md has been updated
