### PR TITLE
Prepare to release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+
+## [2.7.0] - 2017-11-16
+
 * Emit more accurate super classes for Elements when generating analysis JSON.
 * Added the concept of automatically safe fixes and less-safe edit actions for Warnings. This is an upstreaming of functionality originally defined in polymer-linter.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,15 +192,6 @@
         }
       }
     },
-    "ansi-escape-sequences": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
-      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      }
-    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -225,20 +216,6 @@
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
-      }
-    },
-    "app-usage-stats": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/app-usage-stats/-/app-usage-stats-0.4.1.tgz",
-      "integrity": "sha1-l+ubibVnj6LdyXk7EphijMIYQp8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.1",
-        "feature-detect-es6": "1.3.1",
-        "home-path": "1.0.5",
-        "test-value": "2.1.0",
-        "usage-stats": "0.8.6"
       }
     },
     "archy": {
@@ -271,15 +248,6 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
-    "array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-      "dev": true,
-      "requires": {
-        "typical": "2.6.1"
-      }
-    },
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
@@ -297,28 +265,6 @@
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
       "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
       "dev": true
-    },
-    "array-tools": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-1.8.6.tgz",
-      "integrity": "sha1-FFdx9/nJTpjMXqQZapm4MjruGK4=",
-      "dev": true,
-      "requires": {
-        "object-tools": "1.6.7",
-        "typical": "2.6.1"
-      },
-      "dependencies": {
-        "object-tools": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6",
-            "typical": "2.6.1"
-          }
-        }
-      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -345,12 +291,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "assertion-error": {
@@ -395,25 +335,6 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -477,12 +398,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
       "dev": true
     },
     "bower": {
@@ -648,19 +563,6 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
-    "cache-point": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
-      "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.1",
-        "feature-detect-es6": "1.3.1",
-        "fs-then-native": "1.0.2",
-        "mkdirp": "0.5.1"
-      }
-    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -687,15 +589,6 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
-    },
-    "catharsis": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
-      "dev": true,
-      "requires": {
-        "underscore-contrib": "0.3.0"
-      }
     },
     "chai": {
       "version": "2.3.0",
@@ -780,18 +673,6 @@
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
-    "cli-commands": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cli-commands/-/cli-commands-0.1.0.tgz",
-      "integrity": "sha1-xXysxAa7z57iFkZgcWHtQy71oFo=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "command-line-args": "3.0.5",
-        "command-line-commands": "1.0.4",
-        "command-line-usage": "3.0.8"
-      }
-    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -841,46 +722,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "collect-all": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
-      "integrity": "sha1-ciX7RYXCLU/6yIbwq69avFY6Gmo=",
-      "dev": true,
-      "requires": {
-        "stream-connect": "1.0.2",
-        "stream-via": "0.1.1",
-        "typical": "2.6.1"
-      }
-    },
-    "collect-json": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.8.tgz",
-      "integrity": "sha1-qi+lK00dlETOaQ8HoeNherdLuCc=",
-      "dev": true,
-      "requires": {
-        "collect-all": "1.0.3",
-        "stream-connect": "1.0.2",
-        "stream-via": "1.0.4"
-      },
-      "dependencies": {
-        "collect-all": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-          "dev": true,
-          "requires": {
-            "stream-connect": "1.0.2",
-            "stream-via": "1.0.4"
-          }
-        },
-        "stream-via": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-          "dev": true
-        }
-      }
-    },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
@@ -902,74 +743,6 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
-    "column-layout": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
-      "integrity": "sha1-7ShXCSzPgzgCb+U4N52WctcLNkE=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-back": "1.0.4",
-        "collect-json": "1.0.8",
-        "command-line-args": "2.1.6",
-        "core-js": "2.5.1",
-        "deep-extend": "0.4.2",
-        "feature-detect-es6": "1.3.1",
-        "object-tools": "2.0.6",
-        "typical": "2.6.1",
-        "wordwrapjs": "1.2.1"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
-        },
-        "command-line-args": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "command-line-usage": "2.0.5",
-            "core-js": "2.5.1",
-            "feature-detect-es6": "1.3.1",
-            "find-replace": "1.0.3",
-            "typical": "2.6.1"
-          }
-        },
-        "command-line-usage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "column-layout": "2.1.4",
-            "feature-detect-es6": "1.3.1",
-            "typical": "2.6.1",
-            "wordwrapjs": "1.2.1"
-          }
-        },
-        "wordwrapjs": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
-          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
     "combined-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
@@ -977,67 +750,6 @@
       "dev": true,
       "requires": {
         "delayed-stream": "0.0.5"
-      }
-    },
-    "command-line-args": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.3.1",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
-      }
-    },
-    "command-line-commands": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-1.0.4.tgz",
-      "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.3.1"
-      }
-    },
-    "command-line-tool": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.5.2.tgz",
-      "integrity": "sha1-+H1pd/VrvdLV38+UY0XdLNnGpTo=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-back": "1.0.4",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "feature-detect-es6": "1.3.1",
-        "typical": "2.6.1"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
-        }
-      }
-    },
-    "command-line-usage": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
-      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.3.1",
-        "table-layout": "0.3.0",
-        "typical": "2.6.1"
       }
     },
     "commander": {
@@ -1048,12 +760,6 @@
       "requires": {
         "graceful-readlink": "1.0.1"
       }
-    },
-    "common-sequence": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
-      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1102,17 +808,6 @@
             "safe-buffer": "5.1.1"
           }
         }
-      }
-    },
-    "config-master": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/config-master/-/config-master-2.0.4.tgz",
-      "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "feature-detect-es6": "1.3.1",
-        "walk-back": "2.0.1"
       }
     },
     "configstore": {
@@ -1240,22 +935,6 @@
       "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
-    "ddata": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/ddata/-/ddata-0.1.28.tgz",
-      "integrity": "sha1-UxOPr6PwF0nqJFHRK2tt2d8dWx8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.1",
-        "handlebars": "3.0.3",
-        "marked": "0.3.6",
-        "object-get": "2.1.0",
-        "reduce-flatten": "1.0.1",
-        "string-tools": "1.0.0",
-        "test-value": "2.1.0"
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1326,12 +1005,6 @@
           "dev": true
         }
       }
-    },
-    "defer-promise": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/defer-promise/-/defer-promise-1.0.1.tgz",
-      "integrity": "sha1-HKb/7dvO8XFd16riXHYW+a4iky8=",
-      "dev": true
     },
     "del": {
       "version": "2.2.2",
@@ -1419,30 +1092,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
-    },
-    "dmd": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-1.4.2.tgz",
-      "integrity": "sha1-sTBLmKVwCmv+Xc+RvmV8mBcApLw=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "command-line-tool": "0.5.2",
-        "common-sequence": "1.0.2",
-        "ddata": "0.1.28",
-        "file-set": "1.1.1",
-        "handlebars-array": "0.2.1",
-        "handlebars-comparison": "2.0.1",
-        "handlebars-json": "1.0.1",
-        "handlebars-regexp": "1.0.1",
-        "handlebars-string": "2.0.2",
-        "object-tools": "2.0.6",
-        "reduce-unique": "1.0.0",
-        "reduce-without": "1.0.1",
-        "stream-handlebars": "0.1.6",
-        "string-tools": "1.0.0",
-        "walk-back": "2.0.1"
-      }
     },
     "doctrine": {
       "version": "2.0.0",
@@ -1865,15 +1514,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "feature-detect-es6": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz",
-      "integrity": "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      }
-    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -1910,16 +1550,6 @@
         }
       }
     },
-    "file-set": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
-      "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "glob": "7.1.2"
-      }
-    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -1939,42 +1569,11 @@
         "repeat-string": "1.6.1"
       }
     },
-    "filter-where": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/filter-where/-/filter-where-1.0.1.tgz",
-      "integrity": "sha1-GwQlae3ONrwcTp9zdA0sTi/u930=",
-      "dev": true,
-      "requires": {
-        "test-value": "1.1.0"
-      },
-      "dependencies": {
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
-    },
-    "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
-      }
     },
     "find-up": {
       "version": "1.1.2",
@@ -2112,15 +1711,6 @@
         "klaw": "1.3.1",
         "path-is-absolute": "1.0.1",
         "rimraf": "2.6.2"
-      }
-    },
-    "fs-then-native": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
-      "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
-      "dev": true,
-      "requires": {
-        "feature-detect-es6": "1.3.1"
       }
     },
     "fs.realpath": {
@@ -3720,76 +3310,6 @@
         "glogg": "1.0.0"
       }
     },
-    "handlebars": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-      "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-      "dev": true,
-      "requires": {
-        "optimist": "0.6.1",
-        "source-map": "0.1.43",
-        "uglify-js": "2.3.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
-    "handlebars-array": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/handlebars-array/-/handlebars-array-0.2.1.tgz",
-      "integrity": "sha1-3Vg5WlJh1mGYjo13Ug67+q3GvSQ=",
-      "dev": true,
-      "requires": {
-        "array-tools": "1.8.6"
-      }
-    },
-    "handlebars-comparison": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handlebars-comparison/-/handlebars-comparison-2.0.1.tgz",
-      "integrity": "sha1-sXuV0sKYV45K6tOPX6xG6PYAWFU=",
-      "dev": true,
-      "requires": {
-        "array-tools": "1.8.6"
-      }
-    },
-    "handlebars-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/handlebars-json/-/handlebars-json-1.0.1.tgz",
-      "integrity": "sha1-Lvh7t4JVHNZFu0aRuCTpZT7AJQQ=",
-      "dev": true
-    },
-    "handlebars-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/handlebars-regexp/-/handlebars-regexp-1.0.1.tgz",
-      "integrity": "sha1-X0fwZyYOm6jlLxooCRf3DeOfEeQ=",
-      "dev": true
-    },
-    "handlebars-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/handlebars-string/-/handlebars-string-2.0.2.tgz",
-      "integrity": "sha1-ufkiCKl5z89R/0qQ3voYPcYpQso=",
-      "dev": true,
-      "requires": {
-        "array-tools": "1.8.6",
-        "string-tools": "0.1.8"
-      },
-      "dependencies": {
-        "string-tools": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-0.1.8.tgz",
-          "integrity": "sha1-cIhOhqJu5RA6B4vvZwM9VY024zc=",
-          "dev": true
-        }
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3823,12 +3343,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/herit/-/herit-2.2.2.tgz",
       "integrity": "sha1-DhGb3K6AfKLqbV2VwWt1x7Bj6Yc=",
-      "dev": true
-    },
-    "home-path": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
       "dev": true
     },
     "homedir-polyfill": {
@@ -4212,261 +3726,6 @@
         }
       }
     },
-    "js2xmlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-      "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
-      "dev": true
-    },
-    "jsdoc-75lb": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
-      "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.4.7",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "espree": "3.1.7",
-        "js2xmlparser": "1.0.0",
-        "klaw": "1.3.1",
-        "marked": "0.3.6",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
-        "taffydb": "2.6.2",
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        },
-        "espree": {
-          "version": "3.1.7",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
-          "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
-          "dev": true,
-          "requires": {
-            "acorn": "3.3.0",
-            "acorn-jsx": "3.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-api": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-1.2.4.tgz",
-      "integrity": "sha1-UBIjWSe/rR4nvIjQew3d2y06ilk=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "cache-point": "0.3.4",
-        "collect-all": "1.0.3",
-        "core-js": "2.5.1",
-        "feature-detect-es6": "1.3.1",
-        "file-set": "1.1.1",
-        "jsdoc-75lb": "3.6.0",
-        "object-to-spawn-args": "1.1.1",
-        "promise.prototype.finally": "1.0.1",
-        "temp-path": "1.0.0",
-        "then-fs": "2.0.0",
-        "walk-back": "2.0.1"
-      },
-      "dependencies": {
-        "collect-all": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-          "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-          "dev": true,
-          "requires": {
-            "stream-connect": "1.0.2",
-            "stream-via": "1.0.4"
-          }
-        },
-        "stream-via": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-          "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-parse": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-1.2.7.tgz",
-      "integrity": "sha1-VLdIGzzWvLfBc9xPpp7pJzXqJSU=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "2.2.2",
-        "array-tools": "2.0.9",
-        "collect-json": "1.0.8",
-        "command-line-args": "2.1.6",
-        "command-line-tool": "0.1.0",
-        "core-js": "2.5.1",
-        "feature-detect-es6": "1.3.1",
-        "file-set": "0.2.8",
-        "jsdoc-api": "1.2.4",
-        "object-tools": "2.0.6",
-        "stream-connect": "1.0.2",
-        "test-value": "1.1.0"
-      },
-      "dependencies": {
-        "ansi-escape-sequences": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
-          "integrity": "sha1-F0x41vi33nX4lXroHH9yIQxwFjU=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "collect-all": "0.2.1"
-          }
-        },
-        "array-tools": {
-          "version": "2.0.9",
-          "resolved": "https://registry.npmjs.org/array-tools/-/array-tools-2.0.9.tgz",
-          "integrity": "sha1-WlEd56Qb4O7J/9zUkS0K+fDKyjU=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "collect-json": "1.0.8",
-            "filter-where": "1.0.1",
-            "object-get": "2.1.0",
-            "reduce-extract": "1.0.0",
-            "reduce-flatten": "1.0.1",
-            "reduce-unique": "1.0.0",
-            "reduce-without": "1.0.1",
-            "sort-array": "1.1.2",
-            "test-value": "1.1.0"
-          }
-        },
-        "command-line-args": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
-          "integrity": "sha1-8ZfW6v80yQhVd0hLKGQ3WylPVpc=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "command-line-usage": "2.0.5",
-            "core-js": "2.5.1",
-            "feature-detect-es6": "1.3.1",
-            "find-replace": "1.0.3",
-            "typical": "2.6.1"
-          }
-        },
-        "command-line-tool": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.1.0.tgz",
-          "integrity": "sha1-kaEbpIrGOkpodVQ2eYD3xkI8FJ0=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4"
-          }
-        },
-        "command-line-usage": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
-          "integrity": "sha1-+Aw1yl6GJIQZI+o747m/v0974ns=",
-          "dev": true,
-          "requires": {
-            "ansi-escape-sequences": "2.2.2",
-            "array-back": "1.0.4",
-            "column-layout": "2.1.4",
-            "feature-detect-es6": "1.3.1",
-            "typical": "2.6.1",
-            "wordwrapjs": "1.2.1"
-          }
-        },
-        "file-set": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/file-set/-/file-set-0.2.8.tgz",
-          "integrity": "sha1-c6ZXHpy+UaxZJsiL1WfREfg28Xg=",
-          "dev": true,
-          "requires": {
-            "array-tools": "2.0.9",
-            "glob": "4.5.3"
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        },
-        "wordwrapjs": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
-          "integrity": "sha1-dUpeoGZM+/9QVA3DLWe9oyifw0s=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
-    "jsdoc-to-markdown": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-1.3.9.tgz",
-      "integrity": "sha1-d0wOzg69C8wyYbLJoqqNE5mmFHI=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "3.0.0",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "config-master": "2.0.4",
-        "dmd": "1.4.2",
-        "jsdoc-parse": "1.2.7",
-        "jsdoc2md-stats": "1.0.6",
-        "object-tools": "2.0.6",
-        "stream-connect": "1.0.2"
-      }
-    },
-    "jsdoc2md-stats": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/jsdoc2md-stats/-/jsdoc2md-stats-1.0.6.tgz",
-      "integrity": "sha1-3A4AKuu9D7rlEjU0+Scyr7xlH78=",
-      "dev": true,
-      "requires": {
-        "app-usage-stats": "0.4.1",
-        "feature-detect-es6": "1.3.1"
-      }
-    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -4779,12 +4038,6 @@
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
-    },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -4864,12 +4117,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
       "dev": true
     },
     "memory-streams": {
@@ -5016,12 +4263,6 @@
         }
       }
     },
-    "mkdirp2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz",
-      "integrity": "sha1-zI3YJl8fBuLY9bELblL04FC+0hs=",
-      "dev": true
-    },
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
@@ -5151,43 +4392,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
       "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
       "dev": true
-    },
-    "object-get": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
-      "dev": true
-    },
-    "object-to-spawn-args": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
-      "dev": true
-    },
-    "object-tools": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
-      "integrity": "sha1-8/4cNQzaSm9dmdlkbcSJKgJHbd0=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "collect-json": "1.0.8",
-        "object-get": "2.1.0",
-        "test-value": "1.1.0",
-        "typical": "2.6.1"
-      },
-      "dependencies": {
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
     },
     "object.defaults": {
       "version": "1.1.0",
@@ -5556,21 +4760,6 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
-    "promise.prototype.finally": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-1.0.1.tgz",
-      "integrity": "sha1-kRgvkckkhplXQPoF4NqUKsmGvvo=",
-      "dev": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5749,48 +4938,6 @@
       "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
       "dev": true
     },
-    "reduce-extract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
-      "dev": true,
-      "requires": {
-        "test-value": "1.1.0"
-      },
-      "dependencies": {
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
-    "reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-      "dev": true
-    },
-    "reduce-unique": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
-      "dev": true
-    },
-    "reduce-without": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
-      "dev": true,
-      "requires": {
-        "test-value": "2.1.0"
-      }
-    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
@@ -5849,19 +4996,6 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
-    "req-then": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/req-then/-/req-then-0.5.1.tgz",
-      "integrity": "sha1-McbgtW9N3SrNbeC6G86ne2B5398=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "defer-promise": "1.0.1",
-        "feature-detect-es6": "1.3.1",
-        "lodash.pick": "4.4.0",
-        "typical": "2.6.1"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5888,23 +5022,6 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
-      }
-    },
-    "requizzle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
       }
     },
     "resolve": {
@@ -6083,17 +5200,6 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "sort-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
-      "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "object-get": "2.1.0",
-        "typical": "2.6.1"
-      }
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6170,59 +5276,16 @@
       "integrity": "sha1-h6o3n/sLLLmqIaq6HIPXfxrH8cE=",
       "dev": true
     },
-    "stream-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      }
-    },
     "stream-consume": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
-    "stream-handlebars": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stream-handlebars/-/stream-handlebars-0.1.6.tgz",
-      "integrity": "sha1-cwW1BkID2hcWCMR4rPZCoUmJKi8=",
-      "dev": true,
-      "requires": {
-        "handlebars": "3.0.3",
-        "object-tools": "1.6.7"
-      },
-      "dependencies": {
-        "object-tools": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-1.6.7.tgz",
-          "integrity": "sha1-UtQA/IdSUJk9u7O6KY18ebsGmNA=",
-          "dev": true,
-          "requires": {
-            "array-tools": "1.8.6",
-            "typical": "2.6.1"
-          }
-        }
-      }
-    },
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
-    },
-    "stream-via": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
-      "integrity": "sha1-DO5d+clZ+x0/TtpIGfKJ1fkgWvw=",
-      "dev": true
-    },
-    "string-tools": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-tools/-/string-tools-1.0.0.tgz",
-      "integrity": "sha1-xpqdV4iFiZfaZvHZI7pxE+pGa1o=",
       "dev": true
     },
     "string-width": {
@@ -6383,26 +5446,6 @@
         }
       }
     },
-    "table-layout": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
-      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "core-js": "2.5.1",
-        "deep-extend": "0.4.2",
-        "feature-detect-es6": "1.3.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "2.0.0"
-      }
-    },
-    "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-      "dev": true
-    },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -6420,12 +5463,6 @@
           "dev": true
         }
       }
-    },
-    "temp-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
-      "dev": true
     },
     "term-size": {
       "version": "1.2.0",
@@ -6453,30 +5490,11 @@
         }
       }
     },
-    "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "then-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
-      "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
-      "dev": true,
-      "requires": {
-        "promise": "7.3.1"
-      }
     },
     "through": {
       "version": "2.3.8",
@@ -6667,60 +5685,6 @@
         }
       }
     },
-    "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async": "0.2.10",
-        "optimist": "0.3.7",
-        "source-map": "0.1.43"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wordwrap": "0.0.3"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -6732,23 +5696,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
-    },
-    "underscore-contrib": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
-      }
     },
     "unique-stream": {
       "version": "1.0.0",
@@ -6802,23 +5749,6 @@
         "prepend-http": "1.0.4"
       }
     },
-    "usage-stats": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/usage-stats/-/usage-stats-0.8.6.tgz",
-      "integrity": "sha512-QS1r7a1h5g1jo6KulvVGV+eQM+Jfj87AjJBfr1iaIJYz+N7+Qh7ezaVFCulwBGd8T1EidRiSYphG17gra2y0kg==",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "cli-commands": "0.1.0",
-        "core-js": "2.5.1",
-        "feature-detect-es6": "1.3.1",
-        "home-path": "1.0.5",
-        "mkdirp2": "1.0.3",
-        "req-then": "0.5.1",
-        "typical": "2.6.1",
-        "uuid": "3.1.0"
-      }
-    },
     "user-home": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
@@ -6846,12 +5776,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
     "v8flags": {
@@ -6979,12 +5903,6 @@
         }
       }
     },
-    "walk-back": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
-      "dev": true
-    },
     "walkdir": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
@@ -7032,18 +5950,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "wordwrapjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
-      "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "feature-detect-es6": "1.3.1",
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
-      }
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^7.0.1",
     "gulp-typescript": "^2.13.4",
-    "jsdoc-to-markdown": "^1.0.3",
     "knuth-shuffle": "^1.0.8",
     "memory-streams": "^0.1.1",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

- also removed an unused dependency on jsdoc-to-markdown which I think was previously used to produce docs back in the hydrolysis days. This should clear up github's warning about our deps being vulnerable: https://github.com/Polymer/polymer-analyzer/network/dependencies#487603