### PR TITLE
Fix type mismatch arising from c07b68b8c9f1871c64968f51187a054b1abe1efd conversion to ReadonlyArray.

### DIFF
--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -60,7 +60,7 @@ suite('Class', () => {
       privacy: string,
       properties?: any[],
       methods?: any[],
-      warnings?: string[],
+      warnings?: ReadonlyArray<string>,
       mixins?: any[],
       superClass?: string,
     };


### PR DESCRIPTION
tsc was complaining that this particular value in the test file was not a ReadonlyArray after c07b68b8c9f1871c64968f51187a054b1abe1efd 