### PR TITLE
Add UrlResolver#resolveFileUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
-
-* Added missing model typings for branded `url` types to top-level package exports.
+* Add `Import#originalUrl` which has the original url of the import as it was
+  encountered in the document, before it was resolved relative to the base url
+  of its containing document.
+* Added missing model typings for branded `url` types to top-level package
+  exports.
 
 ## [3.0.0-pre.2] - 2017-11-30
 
-* Added `js-import` feature with `lazy: true` for dynamic imports call expressions of the form `import()`.
-* Functions will now be scanned if they have a `@global` annotation. Previously they would only be scanned if they had a `@memberof` annotation. One of these annotations is required because otherwise a lot of functions that aren't really public are included in the analysis (e.g. because they are hidden due to their scoping).
+* Added `js-import` feature with `lazy: true` for dynamic imports call
+  expressions of the form `import()`.
+* Functions will now be scanned if they have a `@global` annotation. Previously
+  they would only be scanned if they had a `@memberof` annotation. One of these
+  annotations is required because otherwise a lot of functions that aren't
+  really public are included in the analysis (e.g. because they are hidden due
+  to their scoping).
 * Function names can now be overridden with e.g. `@function MyNewName`.
 
 ## [3.0.0-pre.1] - 2017-11-29
 
-* [BREAKING] Switched the underlying parser/AST for JavaScript from `espree/estree` to `babylon/babel-types`.  This was needed to support parsing of important platform features such as dynamic imports and moves us closer to supporting TypeScript.
-* When printing Warnings, use one-based indexes for lines and columns, as most text editors and other tools do.
+* [BREAKING] Switched the underlying parser/AST for JavaScript from
+  `espree/estree` to `babylon/babel-types`.  This was needed to support parsing
+  of important platform features such as dynamic imports and moves us closer to
+  supporting TypeScript.
+* When printing Warnings, use one-based indexes for lines and columns, as most
+  text editors and other tools do.
 
 ## [2.7.0] - 2017-11-16
 
 * Emit more accurate super classes for Elements when generating analysis JSON.
-* Added the concept of automatically safe fixes and less-safe edit actions for Warnings. This is an upstreaming of functionality originally defined in polymer-linter.
+* Added the concept of automatically safe fixes and less-safe edit actions for
+  Warnings. This is an upstreaming of functionality originally defined in
+  polymer-linter.
 
 ## [2.6.0] - 2017-11-06
 

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -321,7 +321,7 @@ export class AnalysisContext {
 
             // Update dependency graph
             const importUrls = imports.map(
-                (i) => this.resolveUrlFromFile(i.url, parsedDoc.baseUrl));
+                (i) => this.resolveUrlFromFile(i.url, parsedDoc.baseUrl, i));
             this._cache.dependencyGraph.addDocument(resolvedUrl, importUrls);
 
             return scannedDocument;
@@ -346,7 +346,9 @@ export class AnalysisContext {
           // Scan imports
           for (const scannedImport of imports) {
             const importUrl = this.resolveUrlFromFile(
-                scannedImport.url, scannedDocument.document.baseUrl);
+                scannedImport.url,
+                scannedDocument.document.baseUrl,
+                scannedImport);
             // Request a scan of `importUrl` but do not wait for the results to
             // avoid deadlock in the case of cycles. Later we use the
             // DependencyGraph to wait for all transitive dependencies to load.
@@ -501,9 +503,11 @@ export class AnalysisContext {
                                            (url as any as ResolvedUrl);
   }
 
-  resolveUrlFromFile(url: FileRelativeUrl, baseUrl: ResolvedUrl): ResolvedUrl {
+  resolveUrlFromFile(
+      url: FileRelativeUrl, baseUrl: ResolvedUrl,
+      scannedImport: ScannedImport|undefined): ResolvedUrl {
     return this.resolver.canResolve(url) ?
-        this.resolver.resolveFileUrl(url, baseUrl) :
+        this.resolver.resolveFileUrl(url, baseUrl, scannedImport) :
         (url as any as ResolvedUrl);
   }
 }

--- a/src/css/css-parser.ts
+++ b/src/css/css-parser.ts
@@ -17,6 +17,7 @@ import * as shadyCss from 'shady-css-parser';
 import {InlineDocInfo} from '../model/model';
 import {ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
+import {UrlResolver} from '../url-loader/url-resolver';
 
 import {ParsedCssDocument} from './css-document';
 
@@ -27,8 +28,9 @@ export class CssParser implements Parser<ParsedCssDocument> {
     this._parser = new shadyCss.Parser();
   }
 
-  parse(contents: string, url: ResolvedUrl, inlineInfo?: InlineDocInfo<any>):
-      ParsedCssDocument {
+  parse(
+      contents: string, url: ResolvedUrl, _urlResolver: UrlResolver,
+      inlineInfo?: InlineDocInfo<any>): ParsedCssDocument {
     const ast = this._parser.parse(contents);
     const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};

--- a/src/html/html-import-scanner.ts
+++ b/src/html/html-import-scanner.ts
@@ -66,7 +66,7 @@ export class HtmlImportScanner implements HtmlScanner {
       const href = dom5.getAttribute(node, 'href')! as FileRelativeUrl;
       imports.push(new ScannedImport(
           type,
-          ScannedImport.resolveUrl(document.baseUrl, href),
+          href,
           document.sourceRangeForNode(node)!,
           document.sourceRangeForAttributeValue(node, 'href')!,
           node,
@@ -76,8 +76,8 @@ export class HtmlImportScanner implements HtmlScanner {
       const edges = this._lazyEdges.get(document.url);
       if (edges) {
         for (const edge of edges) {
-          imports.push(
-              new ScannedImport(type, edge, undefined, undefined, null, true));
+          imports.push(new ScannedImport(
+              type, edge as any, undefined, undefined, null, true));
         }
       }
     }

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -45,7 +45,7 @@ export class HtmlParser implements Parser<ParsedHtmlDocument> {
     let baseUrl;
     if (baseTag) {
       const baseHref = getAttribute(baseTag, 'href')! as FileRelativeUrl;
-      baseUrl = urlResolver.resolveFileUrl(baseHref, url);
+      baseUrl = urlResolver.resolveFileUrl(baseHref, url, undefined);
     } else {
       baseUrl = url;
     }

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -15,10 +15,10 @@
 import {getAttribute, predicates as p, query} from 'dom5';
 import {parse as parseHtml} from 'parse5';
 
-import {ScannedImport} from '../index';
 import {InlineDocInfo} from '../model/model';
 import {FileRelativeUrl, ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
+import {UrlResolver} from '../url-loader/url-resolver';
 
 import {ParsedHtmlDocument} from './html-document';
 
@@ -29,8 +29,9 @@ export class HtmlParser implements Parser<ParsedHtmlDocument> {
    * @param {string} htmlString an HTML document.
    * @param {string} href is the path of the document.
    */
-  parse(contents: string, url: ResolvedUrl, inlineInfo?: InlineDocInfo<any>):
-      ParsedHtmlDocument {
+  parse(
+      contents: string, url: ResolvedUrl, urlResolver: UrlResolver,
+      inlineInfo?: InlineDocInfo<any>): ParsedHtmlDocument {
     const ast = parseHtml(contents, {locationInfo: true});
 
     // There should be at most one <base> tag and it must be inside <head> tag.
@@ -44,7 +45,7 @@ export class HtmlParser implements Parser<ParsedHtmlDocument> {
     let baseUrl;
     if (baseTag) {
       const baseHref = getAttribute(baseTag, 'href')! as FileRelativeUrl;
-      baseUrl = ScannedImport.resolveUrl(url, baseHref) as any as ResolvedUrl;
+      baseUrl = urlResolver.resolveFileUrl(baseHref, url);
     } else {
       baseUrl = url;
     }

--- a/src/html/html-script-scanner.ts
+++ b/src/html/html-script-scanner.ts
@@ -44,7 +44,7 @@ export class HtmlScriptScanner implements HtmlScanner {
         if (src) {
           features.push(new ScannedScriptTagImport(
               'html-script',
-              ScannedScriptTagImport.resolveUrl(document.baseUrl, src),
+              src,
               document.sourceRangeForNode(node)!,
               document.sourceRangeForAttributeValue(node, 'src')!,
               node,

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -50,7 +50,8 @@ export class ScannedScriptTagImport extends ScannedImport {
     // See https://github.com/Polymer/polymer-analyzer/issues/615
 
     const scannedDocument = document._analysisContext._getScannedDocument(
-        document._analysisContext.resolveUrlFromFile(this.url, document.url));
+        document._analysisContext.resolveUrlFromFile(
+            this.url, document.url, undefined));
     if (scannedDocument) {
       const importedDocument =
           new Document(scannedDocument, document._analysisContext);
@@ -77,7 +78,8 @@ export class ScannedScriptTagImport extends ScannedImport {
       importedDocument.resolve();
 
       return new ScriptTagImport(
-          document._analysisContext.resolveUrlFromFile(this.url, document.url),
+          document._analysisContext.resolveUrlFromFile(
+              this.url, document.url, this),
           this.url,
           this.type,
           importedDocument,

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -13,6 +13,7 @@
  */
 
 import {Document, Import, ScannedImport, Severity, Warning} from '../model/model';
+import {FileRelativeUrl} from '../model/url';
 
 /**
  * <script> tags are represented in two different ways: as inline documents,
@@ -49,7 +50,7 @@ export class ScannedScriptTagImport extends ScannedImport {
     // See https://github.com/Polymer/polymer-analyzer/issues/615
 
     const scannedDocument = document._analysisContext._getScannedDocument(
-        document._analysisContext.resolveUrl(this.url));
+        document._analysisContext.resolveUrlFromFile(this.url, document.url));
     if (scannedDocument) {
       const importedDocument =
           new Document(scannedDocument, document._analysisContext);
@@ -64,6 +65,7 @@ export class ScannedScriptTagImport extends ScannedImport {
       // to the JavaScript document.
       const backReference = new ScriptTagBackReferenceImport(
           document.url,
+          'fake url' as FileRelativeUrl,
           'html-script-back-reference',
           document,
           this.sourceRange,
@@ -75,7 +77,8 @@ export class ScannedScriptTagImport extends ScannedImport {
       importedDocument.resolve();
 
       return new ScriptTagImport(
-          document._analysisContext.resolveUrl(this.url),
+          document._analysisContext.resolveUrlFromFile(this.url, document.url),
+          this.url,
           this.type,
           importedDocument,
           this.sourceRange,

--- a/src/html/html-style-scanner.ts
+++ b/src/html/html-style-scanner.ts
@@ -47,7 +47,7 @@ export class HtmlStyleScanner implements HtmlScanner {
           const href = dom5.getAttribute(node, 'href')! as FileRelativeUrl;
           features.push(new ScannedImport(
               'html-style',
-              ScannedImport.resolveUrl(document.baseUrl, href),
+              href,
               document.sourceRangeForNode(node)!,
               document.sourceRangeForAttributeValue(node, 'href')!,
               node,

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -41,14 +41,14 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
           // TODO(usergenic): push a warning
           return;
         }
-        const source = arg.value as string;
+        const source = arg.value as FileRelativeUrl;
         if (!isPathImport(source)) {
           // TODO(usergenic): push a warning
           return;
         }
         imports.push(new ScannedImport(
             'js-import',
-            ScannedImport.resolveUrl(document.url, source as FileRelativeUrl),
+            source,
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.callee)!,
             node,
@@ -63,7 +63,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
         }
         imports.push(new ScannedImport(
             'js-import',
-            ScannedImport.resolveUrl(document.url, source),
+            source,
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.source)!,
             node,

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -18,6 +18,7 @@ import * as babylon from 'babylon';
 import {correctSourceRange, InlineDocInfo, LocationOffset, Severity, SourceRange, Warning, WarningCarryingException} from '../model/model';
 import {ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
+import {UrlResolver} from '../url-loader/url-resolver';
 
 import {JavaScriptDocument} from './javascript-document';
 
@@ -46,8 +47,9 @@ export const baseParseOptions: babylon.BabylonOptions = {
 export class JavaScriptParser implements Parser<JavaScriptDocument> {
   sourceType: SourceType;
 
-  parse(contents: string, url: ResolvedUrl, inlineInfo?: InlineDocInfo<any>):
-      JavaScriptDocument {
+  parse(
+      contents: string, url: ResolvedUrl, _urlResolver: UrlResolver,
+      inlineInfo?: InlineDocInfo<any>): JavaScriptDocument {
     const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
     const result = parseJs(

--- a/src/json/json-parser.ts
+++ b/src/json/json-parser.ts
@@ -1,26 +1,14 @@
-/**
- * @license
- * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
-
 import {InlineDocInfo} from '../model/model';
 import {ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
+import {UrlResolver} from '../url-loader/url-resolver';
 
 import {ParsedJsonDocument} from './json-document';
 
 export class JsonParser implements Parser<ParsedJsonDocument> {
-  parse(contents: string, url: ResolvedUrl, inlineDocInfo: InlineDocInfo<any>):
-      ParsedJsonDocument {
+  parse(
+      contents: string, url: ResolvedUrl, _urlResolver: UrlResolver,
+      inlineDocInfo: InlineDocInfo<any>): ParsedJsonDocument {
     const isInline = !!inlineDocInfo;
     inlineDocInfo = inlineDocInfo || {};
     return new ParsedJsonDocument({

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -70,7 +70,7 @@ export class ScannedImport implements Resolvable {
       return;
     }
     const resolvedUrl = document._analysisContext.resolveUrlFromFile(
-        this.url, document.parsedDocument.baseUrl);
+        this.url, document.parsedDocument.baseUrl, this);
     const importedDocumentOrWarning =
         document._analysisContext.getDocument(resolvedUrl);
     if (!(importedDocumentOrWarning instanceof Document)) {

--- a/src/model/url.ts
+++ b/src/model/url.ts
@@ -34,7 +34,7 @@ export type FileRelativeUrl = string&FileRelativeUrlBrand;
  *
  * This is the assumed format of user input to Analyzer methods.
  *
- * Use ScannedImport.resolveUrl to transform a FileRelativeUrl to a
+ * Use UrlResolver#resolveFileUrl to transform a FileRelativeUrl to a
  * PackageRelativeUrl.
  */
 export type PackageRelativeUrl = string&PackageRelativeUrlBrand;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -14,10 +14,12 @@
 
 import {InlineDocInfo} from '../model/model';
 import {ResolvedUrl} from '../model/url';
+import {UrlResolver} from '../url-loader/url-resolver';
 
 import {ParsedDocument} from './document';
 
 export interface Parser<D extends ParsedDocument<any, any>> {
-  parse(contents: string, url: ResolvedUrl, inlineDocInfo?: InlineDocInfo<any>):
-      D;
+  parse(
+      contents: string, url: ResolvedUrl, urlResolver: UrlResolver,
+      inlineDocInfo?: InlineDocInfo<any>, ): D;
 }

--- a/src/polymer/css-import-scanner.ts
+++ b/src/polymer/css-import-scanner.ts
@@ -39,7 +39,7 @@ export class CssImportScanner implements HtmlScanner {
         const href = dom5.getAttribute(node, 'href')! as FileRelativeUrl;
         imports.push(new ScannedImport(
             'css-import',
-            ScannedImport.resolveUrl(document.baseUrl, href),
+            href,
             document.sourceRangeForNode(node)!,
             document.sourceRangeForAttributeValue(node, 'href')!,
             node,

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -37,6 +37,7 @@ import chaiAsPromised = require('chai-as-promised');
 import chaiSubset = require('chai-subset');
 import stripIndent = require('strip-indent');
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 use(chaiSubset);
 use(chaiAsPromised);
@@ -558,8 +559,8 @@ suite('Analyzer', () => {
           <script src="foo.js"></script>
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
       const context = await getContext(analyzer);
       const features =
           ((await context['_getScannedFeatures'](document)).features as
@@ -581,8 +582,8 @@ suite('Analyzer', () => {
             <link rel="import" type="css" href="bar.css">
           </dom-module>
         </body></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
       const context = await getContext(analyzer);
       const features =
           (await context['_getScannedFeatures'](document))
@@ -600,7 +601,7 @@ suite('Analyzer', () => {
         </head></html>`;
       const context = await getContext(analyzer);
       const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl,  new PackageUrlResolver());
       const features =
           ((await context['_getScannedFeatures'](document)).features) as
           ScannedInlineDocument[];

--- a/src/test/css/css-parser_test.ts
+++ b/src/test/css/css-parser_test.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 
 import {ParsedCssDocument} from '../../css/css-document';
 import {CssParser} from '../../css/css-parser';
+import {PackageUrlResolver} from '../../index';
 import {ResolvedUrl} from '../../model/url';
 
 suite('CssParser', () => {
@@ -32,16 +33,20 @@ suite('CssParser', () => {
     });
 
     test('parses css', () => {
-      const document =
-          parser.parse(fileContents, '/static/stylesheet.css' as ResolvedUrl);
+      const document = parser.parse(
+          fileContents,
+          '/static/stylesheet.css' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.instanceOf(document, ParsedCssDocument);
       assert.equal(document.url, '/static/stylesheet.css');
       assert(document.ast != null);
     });
 
     test('stringifies css', () => {
-      const document =
-          parser.parse(fileContents, '/static/stylesheet.css' as ResolvedUrl);
+      const document = parser.parse(
+          fileContents,
+          '/static/stylesheet.css' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.deepEqual(document.stringify(), fileContents);
     });
   });

--- a/src/test/html/html-document_test.ts
+++ b/src/test/html/html-document_test.ts
@@ -23,6 +23,7 @@ import {ParsedHtmlDocument} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {ResolvedUrl} from '../../model/url';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('ParsedHtmlDocument', () => {
@@ -30,7 +31,8 @@ suite('ParsedHtmlDocument', () => {
   const url = './source-ranges/html-complicated.html' as ResolvedUrl;
   const basedir = path.join(__dirname, '../static/');
   const file = fs.readFileSync(path.join(basedir, `${url}`), 'utf8');
-  const document: ParsedHtmlDocument = parser.parse(file, url);
+  const document: ParsedHtmlDocument =
+      parser.parse(file, url, new PackageUrlResolver());
   const urlLoader = new FSUrlLoader(basedir);
   const analyzer = new Analyzer({urlLoader});
   const underliner = new CodeUnderliner(urlLoader);
@@ -113,7 +115,8 @@ suite('ParsedHtmlDocument', () => {
         'works for unclosed tags with attributes and no text content';
     test(testName, async () => {
       const url = 'unclosed-tag-attributes.html' as ResolvedUrl;
-      const document = parser.parse(await analyzer.load(url), url);
+      const document =
+          parser.parse(await analyzer.load(url), url, new PackageUrlResolver());
 
       const tag = dom5.query(document.ast, dom5.predicates.hasTagName('tag'))!;
       assert.deepEqual(

--- a/src/test/html/html-element-reference-scanner_test.ts
+++ b/src/test/html/html-element-reference-scanner_test.ts
@@ -18,6 +18,7 @@ import {HtmlVisitor} from '../../html/html-document';
 import {HtmlCustomElementReferenceScanner, HtmlElementReferenceScanner} from '../../html/html-element-reference-scanner';
 import {HtmlParser} from '../../html/html-parser';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('HtmlElementReferenceScanner', () => {
@@ -28,7 +29,7 @@ suite('HtmlElementReferenceScanner', () => {
       scanner = new HtmlElementReferenceScanner();
     });
 
-    test('finds element references', async () => {
+    test('finds element references', async() => {
       const contents = `<html><head></head>
       <body>
         <div>Foo</div>
@@ -38,9 +39,11 @@ suite('HtmlElementReferenceScanner', () => {
         </div>
       </body></html>`;
 
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+      const document = new HtmlParser().parse(
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
 
@@ -62,7 +65,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
       scanner = new HtmlCustomElementReferenceScanner();
     });
 
-    test('finds custom element references', async () => {
+    test('finds custom element references', async() => {
       contents = `<html><body>
           <div>Foo</div>
           <x-foo a=5 b="test" c></x-foo>
@@ -75,9 +78,11 @@ suite('HtmlCustomElementReferenceScanner', () => {
           </template>
         </body></html>`;
 
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+      const document = new HtmlParser().parse(
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
+      const visit = async(visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
 
@@ -90,7 +95,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
           [['a', '5'], ['b', 'test'], ['c', '']]);
 
       const sourceRanges = await Promise.all(
-          features.map(async (f) => await underliner.underline(f.sourceRange)));
+          features.map(async(f) => await underliner.underline(f.sourceRange)));
 
       assert.deepEqual(sourceRanges, [
         `
@@ -105,11 +110,10 @@ suite('HtmlCustomElementReferenceScanner', () => {
       ]);
 
       const attrRanges = await Promise.all(features.map(
-          async (f) =>
-              await Promise.all(Array.from(f.attributes.values())
-                                    .map(
-                                        async (a) => await underliner.underline(
-                                            a.sourceRange)))));
+          async(f) => await Promise.all(
+              Array.from(f.attributes.values())
+                  .map(
+                      async(a) => await underliner.underline(a.sourceRange)))));
 
       assert.deepEqual(attrRanges, [
         [
@@ -128,7 +132,7 @@ suite('HtmlCustomElementReferenceScanner', () => {
       ]);
 
       const attrNameRanges = await Promise.all(features.map(
-          async (f) =>
+          async(f) =>
               await underliner.underline(Array.from(f.attributes.values())
                                              .map((a) => a.nameSourceRange))));
 
@@ -149,10 +153,10 @@ suite('HtmlCustomElementReferenceScanner', () => {
       ]);
 
       const attrValueRanges = await Promise.all(features.map(
-          async (f) =>
+          async(f) =>
               await Promise.all(Array.from(f.attributes.values())
                                     .map(
-                                        async (a) => await underliner.underline(
+                                        async(a) => await underliner.underline(
                                             a.valueSourceRange)))));
 
       assert.deepEqual(attrValueRanges, [

--- a/src/test/html/html-parser_test.ts
+++ b/src/test/html/html-parser_test.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 
 import {HtmlParser} from '../../html/html-parser';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('HtmlParser', () => {
   suite('parse()', () => {
@@ -32,14 +33,18 @@ suite('HtmlParser', () => {
           path.resolve(__dirname, '../static/html-parse-target.html'), 'utf8');
 
       test('parses a well-formed document', () => {
-        const document =
-            parser.parse(file, '/static/html-parse-target.html' as ResolvedUrl);
+        const document = parser.parse(
+            file,
+            '/static/html-parse-target.html' as ResolvedUrl,
+            new PackageUrlResolver());
         assert.equal(document.url, '/static/html-parse-target.html');
       });
 
       test('can stringify back a well-formed document', () => {
-        const document =
-            parser.parse(file, '/static/html-parse-target.html' as ResolvedUrl);
+        const document = parser.parse(
+            file,
+            '/static/html-parse-target.html' as ResolvedUrl,
+            new PackageUrlResolver());
         assert.deepEqual(document.stringify(), file);
       });
     });
@@ -49,9 +54,11 @@ suite('HtmlParser', () => {
           path.resolve(__dirname, '../static/base-href/doc-with-base.html'),
           'utf8');
       const document = parser.parse(
-          file, '/static/base-href/doc-with-base.html' as ResolvedUrl);
+          file,
+          '/static/base-href/doc-with-base.html' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.equal(document.url, '/static/base-href/doc-with-base.html');
-      assert.equal(document.baseUrl, '/static/');
+      assert.equal(document.baseUrl, 'static/');
     });
   });
 });

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -24,6 +24,7 @@ import {Analysis} from '../../model/analysis';
 import {ScannedImport, ScannedInlineDocument} from '../../model/model';
 import {ResolvedUrl} from '../../model/url';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 const fixturesDir = path.resolve(__dirname, '../static');
 suite('HtmlScriptScanner', () => {
@@ -39,8 +40,10 @@ suite('HtmlScriptScanner', () => {
           <script src="foo.js"></script>
           <script>console.log('hi')</script>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -60,8 +63,10 @@ suite('HtmlScriptScanner', () => {
       const contents = `<html><head><base href="/aybabtu/">
           <script src="foo.js"></script>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -69,7 +74,7 @@ suite('HtmlScriptScanner', () => {
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = features[0] as ScannedImport;
       assert.equal(feature0.type, 'html-script');
-      assert.equal(feature0.url, '/aybabtu/foo.js');
+      assert.equal(feature0.url, 'foo.js');
     });
 
     suite('modules', () => {

--- a/src/test/html/html-style-scanner_test.ts
+++ b/src/test/html/html-style-scanner_test.ts
@@ -19,6 +19,7 @@ import {HtmlParser} from '../../html/html-parser';
 import {HtmlStyleScanner} from '../../html/html-style-scanner';
 import {ScannedImport, ScannedInlineDocument} from '../../model/model';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('HtmlStyleScanner', () => {
   suite('scan()', () => {
@@ -33,8 +34,10 @@ suite('HtmlStyleScanner', () => {
           <link rel="stylesheet" type="text/css" href="foo.css">
           <style>h1 { color: green; }</style>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -54,8 +57,10 @@ suite('HtmlStyleScanner', () => {
       const contents = `<html><head><base href="/aybabtu/">
           <link rel="stylesheet" type="text/css" href="foo.css">
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -63,7 +68,7 @@ suite('HtmlStyleScanner', () => {
       assert.instanceOf(features[0], ScannedImport);
       const feature0 = <ScannedImport>features[0];
       assert.equal(feature0.type, 'html-style');
-      assert.equal(feature0.url, '/aybabtu/foo.css');
+      assert.equal(feature0.url, 'foo.css');
     });
   });
 });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -23,6 +23,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {Class, Element, ElementMixin, Method, ScannedClass} from '../../model/model';
 import {ResolvedUrl} from '../../model/url';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 const fixturesDir = path.resolve(__dirname, '../static');
@@ -34,7 +35,8 @@ suite('Class', () => {
   async function getScannedFeatures(filename: string) {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/javascript/function-scanner_test.ts
+++ b/src/test/javascript/function-scanner_test.ts
@@ -22,6 +22,7 @@ import {FunctionScanner} from '../../javascript/function-scanner';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('FunctionScanner', () => {
@@ -33,7 +34,8 @@ suite('FunctionScanner', () => {
       Promise<ScannedFunction[]> {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new FunctionScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -21,6 +21,7 @@ import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptImportScanner} from '../../javascript/javascript-import-scanner';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('JavaScriptImportScanner', () => {
   const parser = new JavaScriptParser();
@@ -29,8 +30,10 @@ suite('JavaScriptImportScanner', () => {
   test('finds imports', async () => {
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/javascript/module.js'), 'utf8');
-    const document =
-        parser.parse(file, '/static/javascript/module.js' as ResolvedUrl);
+    const document = parser.parse(
+        file,
+        '/static/javascript/module.js' as ResolvedUrl,
+        new PackageUrlResolver());
 
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
@@ -39,7 +42,7 @@ suite('JavaScriptImportScanner', () => {
     assert.containSubset(features, [
       {
         type: 'js-import',
-        url: '/static/javascript/submodule.js',
+        url: './submodule.js',
         lazy: false,
       },
     ]);
@@ -50,7 +53,9 @@ suite('JavaScriptImportScanner', () => {
         path.resolve(__dirname, '../static/javascript/dynamic-import.js'),
         'utf8');
     const document = parser.parse(
-        file, '/static/javascript/dynamic-import.js' as ResolvedUrl);
+        file,
+        '/static/javascript/dynamic-import.js' as ResolvedUrl,
+        new PackageUrlResolver());
 
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
@@ -59,7 +64,7 @@ suite('JavaScriptImportScanner', () => {
     assert.containSubset(features, [
       {
         type: 'js-import',
-        url: '/static/javascript/submodule.js',
+        url: './submodule.js',
         lazy: true,
       },
     ]);
@@ -71,7 +76,9 @@ suite('JavaScriptImportScanner', () => {
             __dirname, '../static/javascript/module-with-named-import.js'),
         'utf8');
     const document = parser.parse(
-        file, '/static/javascript/module-with-named-import.js' as ResolvedUrl);
+        file,
+        '/static/javascript/module-with-named-import.js' as ResolvedUrl,
+        new PackageUrlResolver());
 
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -23,6 +23,7 @@ import * as esutil from '../../javascript/esutil';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser, JavaScriptModuleParser, JavaScriptScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('JavaScriptParser', () => {
   let parser: JavaScriptParser;
@@ -45,8 +46,10 @@ suite('JavaScriptParser', () => {
           }
         }
       `;
-      const document =
-          parser.parse(contents, '/static/es6-support.js' as ResolvedUrl);
+      const document = parser.parse(
+          contents,
+          '/static/es6-support.js' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
@@ -61,8 +64,10 @@ suite('JavaScriptParser', () => {
           await Promise.resolve();
         }
       `;
-      const document =
-          parser.parse(contents, '/static/es6-support.js' as ResolvedUrl);
+      const document = parser.parse(
+          contents,
+          '/static/es6-support.js' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
@@ -79,14 +84,19 @@ suite('JavaScriptParser', () => {
       const file = fs.readFileSync(
           path.resolve(__dirname, '../static/js-parse-error.js'), 'utf8');
       assert.throws(
-          () => parser.parse(file, '/static/js-parse-error.js' as ResolvedUrl));
+          () => parser.parse(
+              file,
+              '/static/js-parse-error.js' as ResolvedUrl,
+              new PackageUrlResolver()));
     });
 
     test('attaches comments', () => {
       const file = fs.readFileSync(
           path.resolve(__dirname, '../static/js-elements.js'), 'utf8');
-      const document =
-          parser.parse(file, '/static/js-elements.js' as ResolvedUrl);
+      const document = parser.parse(
+          file,
+          '/static/js-elements.js' as ResolvedUrl,
+          new PackageUrlResolver());
       const ast = document.ast;
       const element1 = ast.body[0];
       const comment = esutil.getAttachedComment(element1)!;
@@ -97,8 +107,10 @@ suite('JavaScriptParser', () => {
       const contents = `
         import foo from 'foo';
       `;
-      const document =
-          parser.parse(contents, '/static/es6-support.js' as ResolvedUrl);
+      const document = parser.parse(
+          contents,
+          '/static/es6-support.js' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
@@ -120,7 +132,8 @@ suite('JavaScriptParser', () => {
 
         }`).trim() +
           '\n';
-      const document = parser.parse(contents, 'test-file.js' as ResolvedUrl);
+      const document = parser.parse(
+          contents, 'test-file.js' as ResolvedUrl, new PackageUrlResolver());
       assert.deepEqual(document.stringify({}), contents);
     });
   });
@@ -138,8 +151,10 @@ suite('JavaScriptModuleParser', () => {
       const contents = `
     import foo from 'foo';
   `;
-      const document =
-          parser.parse(contents, '/static/es6-support.js' as ResolvedUrl);
+      const document = parser.parse(
+          contents,
+          '/static/es6-support.js' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
       assert.equal(document.ast.type, 'Program');
@@ -160,6 +175,9 @@ suite('JavaScriptScriptParser', () => {
       import foo from 'foo';
     `;
     assert.throws(
-        () => parser.parse(contents, '/static/es6-support.js' as ResolvedUrl));
+        () => parser.parse(
+            contents,
+            '/static/es6-support.js' as ResolvedUrl,
+            new PackageUrlResolver()));
   });
 });

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -22,6 +22,7 @@ import {ScannedNamespace} from '../../javascript/namespace';
 import {NamespaceScanner} from '../../javascript/namespace-scanner';
 import {ResolvedUrl} from '../../model/url';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('NamespaceScanner', () => {
@@ -32,7 +33,8 @@ suite('NamespaceScanner', () => {
   async function getNamespaces(filename: string): Promise<any[]> {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new NamespaceScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -23,6 +23,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {ScannedBehavior, ScannedBehaviorAssignment} from '../../polymer/behavior';
 import {BehaviorScanner} from '../../polymer/behavior-scanner';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('BehaviorScanner', () => {
   let document: JavaScriptDocument;
@@ -33,7 +34,10 @@ suite('BehaviorScanner', () => {
     const parser = new JavaScriptParser();
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/js-behaviors.js'), 'utf8');
-    document = parser.parse(file, '/static/js-behaviors.js' as ResolvedUrl);
+    document = parser.parse(
+        file,
+        '/static/js-behaviors.js' as ResolvedUrl,
+        new PackageUrlResolver());
     const scanner = new BehaviorScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/polymer/dom-module-scanner_test.ts
+++ b/src/test/polymer/dom-module-scanner_test.ts
@@ -19,6 +19,7 @@ import {HtmlVisitor} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {ResolvedUrl} from '../../model/url';
 import {DomModuleScanner} from '../../polymer/dom-module-scanner';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('DomModuleScanner', () => {
@@ -44,8 +45,8 @@ suite('DomModuleScanner', () => {
           </dom-module>
         </body>
         </html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features: domModules} = await scanner.scan(document, visit);
@@ -66,8 +67,8 @@ suite('DomModuleScanner', () => {
           </dom-module>
         </body>
         </html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
       const underliner = CodeUnderliner.withMapping('test.html', contents);
 

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -19,6 +19,7 @@ import {HtmlParser} from '../../html/html-parser';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {AttributeDatabindingExpression, parseExpressionInJsStringLiteral, scanDocumentForExpressions, TextNodeDatabindingExpression} from '../../polymer/expression-scanner';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('ExpressionScanner', () => {
@@ -51,8 +52,8 @@ suite('ExpressionScanner', () => {
         </template>
       `;
       const underliner = CodeUnderliner.withMapping('test.html', contents);
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
 
       const results = await scanDocumentForExpressions(document);
       const generalExpressions = results.expressions;
@@ -117,8 +118,8 @@ suite('ExpressionScanner', () => {
 
       `;
       const underliner = CodeUnderliner.withMapping('test.html', contents);
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
 
       const results = await scanDocumentForExpressions(document);
       const generalExpressions = results.expressions;
@@ -186,8 +187,8 @@ suite('ExpressionScanner', () => {
       `;
 
       const underliner = CodeUnderliner.withMapping('test.html', contents);
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
 
       const results = await scanDocumentForExpressions(document);
       const generalExpressions = results.expressions;
@@ -263,8 +264,8 @@ suite('ExpressionScanner', () => {
       `;
 
       const underliner = CodeUnderliner.withMapping('test.html', contents);
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
 
       const results = await scanDocumentForExpressions(document);
       assert.deepEqual(
@@ -305,8 +306,8 @@ suite('ExpressionScanner', () => {
         ];
       `;
       const underliner = CodeUnderliner.withMapping('test.js', contents);
-      const javascriptDocument =
-          new JavaScriptParser().parse(contents, 'test.js' as ResolvedUrl);
+      const javascriptDocument = new JavaScriptParser().parse(
+          contents, 'test.js' as ResolvedUrl, new PackageUrlResolver());
       const literals: babel.Literal[] =
           (javascriptDocument.ast as any)
               .body[0]['declarations'][0]['init']['elements'];

--- a/src/test/polymer/polymer-core-feature_test.ts
+++ b/src/test/polymer/polymer-core-feature_test.ts
@@ -21,6 +21,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {PolymerCoreFeatureScanner} from '../../polymer/polymer-core-feature-scanner';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('PolymerCoreFeatureScanner', () => {
   test('scans _addFeature calls and the Polymer.Base assignment', async () => {
@@ -55,7 +56,8 @@ suite('PolymerCoreFeatureScanner', () => {
 
     const parser = new JavaScriptParser();
     const scanner = new PolymerCoreFeatureScanner();
-    const doc = parser.parse(js, 'features.js' as ResolvedUrl);
+    const doc = parser.parse(
+        js, 'features.js' as ResolvedUrl, new PackageUrlResolver());
     const visit = (visitor: Visitor) => Promise.resolve(doc.visit([visitor]));
     const {features} = await scanner.scan(doc, visit);
 

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -20,6 +20,7 @@ import {Visitor} from '../../javascript/estree-visitor';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {PolymerElementScanner} from '../../polymer/polymer-element-scanner';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('PolymerElementScanner', () => {
@@ -102,7 +103,9 @@ suite('PolymerElementScanner', () => {
       });`;
 
       const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: Visitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -240,7 +243,9 @@ suite('PolymerElementScanner', () => {
           window.MyElement = Polymer({is: 'my-element'});
       `;
       const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: Visitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -284,7 +289,9 @@ suite('PolymerElementScanner', () => {
       const underliner =
           CodeUnderliner.withMapping('test-document.html', contents);
       const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: Visitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);
@@ -335,7 +342,9 @@ suite('PolymerElementScanner', () => {
       }`;
 
       const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
+          contents,
+          'test-document.html' as ResolvedUrl,
+          new PackageUrlResolver());
       const visit = async (visitor: Visitor) => document.visit([visitor]);
 
       // Scanning should not throw

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -22,6 +22,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
@@ -35,7 +36,8 @@ suite('Polymer2ElementScanner with old jsdoc annotations', () => {
       Promise<ScannedPolymerElement[]> {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
@@ -412,15 +414,13 @@ namespaced name.`,
               {
                 name: 'customInstanceFunction',
                 description: '',
-                params: [],
-                return: undefined
+                params: [], return: undefined
               },
               {
                 name: 'customInstanceFunctionWithJSDoc',
                 description: 'This is the description for ' +
                     'customInstanceFunctionWithJSDoc.',
-                params: [],
-                return: {
+                params: [], return: {
                   desc: 'The number 5, always.',
                   type: 'Number',
                 },
@@ -489,8 +489,7 @@ namespaced name.`,
                 name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
                 description: 'This is the description for\n' +
                     'customInstanceFunctionWithParamsAndPrivateJSDoc.',
-                params: [],
-                return: undefined,
+                params: [], return: undefined,
               },
             ],
             warningUnderlines: [],

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -22,6 +22,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
@@ -31,73 +32,78 @@ suite('Polymer2ElementScanner', () => {
   const urlLoader = new FSUrlLoader(testFilesDir);
   const underliner = new CodeUnderliner(urlLoader);
 
-  async function getElements(filename: string):
-      Promise<ScannedPolymerElement[]> {
+  async function getElements(
+      filename: string): Promise<ScannedPolymerElement[]> {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));
 
     const {features} = await scanner.scan(document, visit);
-    return features.filter((e) => e instanceof ScannedPolymerElement) as
-        ScannedPolymerElement[];
+    return features.filter(
+        (e) => e instanceof ScannedPolymerElement) as ScannedPolymerElement[];
   };
 
-  async function getTestProps(element: ScannedPolymerElement): Promise<any> {
-    const props: any = {
-      className: element.className,
-      superClass: element.superClass && element.superClass.identifier,
-      tagName: element.tagName,
-      description: element.description,
-      summary: element.summary,
-      properties: await Promise.all(
-          Array.from(element.properties.values()).map(async (p) => {
-            const result = {name: p.name, description: p.description} as any;
-            if (p.type) {
-              result.type = p.type;
-            }
-            if (p.observerExpression) {
-              result.propertiesInObserver =
-                  p.observerExpression.properties.map((p) => p.name);
-            }
-            if (p.computedExpression) {
-              result.propertiesInComputed =
-                  p.computedExpression.properties.map((p) => p.name);
-            }
-            if (p.warnings.length > 0) {
-              result.warningUnderlines = await underliner.underline(p.warnings);
-            }
-            return result;
-          })),
-      attributes: Array.from(element.attributes.values()).map((a) => ({
-                                                                name: a.name,
-                                                              })),
-      methods:
-          Array.from(element.methods.values()).map((m) => ({
-                                                     name: m.name,
-                                                     params: m.params,
-                                                     return: m.return,
-                                                     description: m.description
-                                                   })),
+  async function getTestProps(element: ScannedPolymerElement):
+      Promise<any> {
+        const props: any = {
+          className: element.className,
+          superClass: element.superClass && element.superClass.identifier,
+          tagName: element.tagName,
+          description: element.description,
+          summary: element.summary,
+          properties: await Promise.all(
+              Array.from(element.properties.values()).map(async(p) => {
+                const result = {name: p.name,
+                                description: p.description} as any;
+                if (p.type) {
+                  result.type = p.type;
+                }
+                if (p.observerExpression) {
+                  result.propertiesInObserver =
+                      p.observerExpression.properties.map((p) => p.name);
+                }
+                if (p.computedExpression) {
+                  result.propertiesInComputed =
+                      p.computedExpression.properties.map((p) => p.name);
+                }
+                if (p.warnings.length > 0) {
+                  result.warningUnderlines =
+                      await underliner.underline(p.warnings);
+                }
+                return result;
+              })),
+          attributes:
+              Array.from(element.attributes.values()).map((a) => ({
+                                                            name: a.name,
+                                                          })),
+          methods: Array.from(element.methods.values())
+                       .map((m) => ({
+                              name: m.name,
+                              params: m.params, return: m.return,
+                              description: m.description
+                            })),
 
-      warningUnderlines: await underliner.underline(element.warnings),
+          warningUnderlines: await underliner.underline(element.warnings),
 
-    };
-    if (element.observers.length > 0) {
-      props.observers = element.observers.map((o) => o.expression);
-      props.observerProperties =
-          element.observers.filter((o) => o.parsedExpression)
-              .map((o) => o.parsedExpression!.properties.map((p) => p.name));
-    }
-    if (element.mixins.length > 0) {
-      props.mixins = element.mixins.map((m) => m.identifier);
-    }
-    return props;
-  }
+        };
+        if (element.observers.length > 0) {
+          props.observers = element.observers.map((o) => o.expression);
+          props.observerProperties =
+              element.observers.filter((o) => o.parsedExpression)
+                  .map(
+                      (o) => o.parsedExpression!.properties.map((p) => p.name));
+        }
+        if (element.mixins.length > 0) {
+          props.mixins = element.mixins.map((m) => m.identifier);
+        }
+        return props;
+      }
 
-  test('Finds two basic elements', async () => {
+  test('Finds two basic elements', async() => {
     const elements = await getElements('test-element-1.js');
     const elementData = await Promise.all(elements.map(getTestProps));
     assert.deepEqual(elementData, [
@@ -195,7 +201,7 @@ class BaseElement extends Polymer.Element {
 ~`);
   });
 
-  test('Uses static is getter for tagName', async () => {
+  test('Uses static is getter for tagName', async() => {
     const elements = await getElements('test-element-2.js');
     const elementData = await Promise.all(elements.map(getTestProps));
     assert.deepEqual(elementData, [
@@ -213,7 +219,7 @@ class BaseElement extends Polymer.Element {
     ]);
   });
 
-  test('Finds vanilla elements', async () => {
+  test('Finds vanilla elements', async() => {
     const elements = await getElements('test-element-4.js');
     const elementData = await Promise.all(elements.map(getTestProps));
     assert.deepEqual(elementData, [
@@ -238,7 +244,7 @@ class BaseElement extends Polymer.Element {
     ]);
   });
 
-  test('Observed attributes override induced attributes', async () => {
+  test('Observed attributes override induced attributes', async() => {
     const elements = await getElements('test-element-5.js');
     const elementData = await Promise.all(elements.map(getTestProps));
 
@@ -268,7 +274,7 @@ class BaseElement extends Polymer.Element {
     ]);
   });
 
-  test('properly sets className for elements with the memberof tag', async () => {
+  test('properly sets className for elements with the memberof tag', async() => {
     const elements = await getElements('test-element-8.js');
     const elementData = await Promise.all(elements.map(getTestProps));
     assert.deepEqual(elementData, [
@@ -313,7 +319,7 @@ namespaced name.`,
     ]);
   });
 
-  test('Read @appliesMixin annotations', async () => {
+  test('Read @appliesMixin annotations', async() => {
     const elements = await getElements('test-element-6.js');
     const elementData = await Promise.all(elements.map(getTestProps));
 
@@ -333,7 +339,7 @@ namespaced name.`,
     ]);
   });
 
-  test('Reads just @appliesMixin annotation', async () => {
+  test('Reads just @appliesMixin annotation', async() => {
     const elements = await getElements('test-element-9.js');
     const elementData = await Promise.all(elements.map(getTestProps));
 
@@ -390,7 +396,7 @@ namespaced name.`,
 
   test(
       'properly reads properties and methods of elements and element classes',
-      async () => {
+      async() => {
         const elements = await getElements('test-element-10.js');
         const elementData = await Promise.all(elements.map(getTestProps));
         assert.deepEqual(elementData, [
@@ -412,15 +418,13 @@ namespaced name.`,
               {
                 name: 'customInstanceFunction',
                 description: '',
-                params: [],
-                return: undefined
+                params: [], return: undefined
               },
               {
                 name: 'customInstanceFunctionWithJSDoc',
                 description: 'This is the description for ' +
                     'customInstanceFunctionWithJSDoc.',
-                params: [],
-                return: {
+                params: [], return: {
                   desc: 'The number 5, always.',
                   type: 'Number',
                 },
@@ -489,8 +493,7 @@ namespaced name.`,
                 name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
                 description: 'This is the description for\n' +
                     'customInstanceFunctionWithParamsAndPrivateJSDoc.',
-                params: [],
-                return: undefined,
+                params: [], return: undefined,
               },
             ],
             warningUnderlines: [],
@@ -498,7 +501,7 @@ namespaced name.`,
         ]);
       });
 
-  test('warns for bad observers and computed properties', async () => {
+  test('warns for bad observers and computed properties', async() => {
     const elements = await getElements('test-element-12.js');
     const elementData = await Promise.all(elements.map(getTestProps));
     assert.deepEqual(
@@ -557,7 +560,7 @@ namespaced name.`,
         }]);
   });
 
-  test('can identify elements registered with ClassName.is', async () => {
+  test('can identify elements registered with ClassName.is', async() => {
     const elements = await getElements('test-element-11.js');
     const elementData = await Promise.all(elements.map(getTestProps));
     assert.deepEqual(
@@ -574,7 +577,7 @@ namespaced name.`,
         }]);
   });
 
-  test('can infer properties assigned to in the constructor', async () => {
+  test('can infer properties assigned to in the constructor', async() => {
     const elements = await getElements('test-element-16.js');
     const [element] = elements;
     const elementData = await Promise.all(elements.map(getTestProps));

--- a/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -24,6 +24,7 @@ import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 
 //
@@ -46,7 +47,10 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
     const parser = new JavaScriptParser();
     const file = fs.readFileSync(
         path.resolve(__dirname, '../static/vanilla-elements.js'), 'utf8');
-    document = parser.parse(file, '/static/vanilla-elements.js' as ResolvedUrl);
+    document = parser.parse(
+        file,
+        '/static/vanilla-elements.js' as ResolvedUrl,
+        new PackageUrlResolver());
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -23,6 +23,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('Polymer2MixinScanner with old jsdoc annotations', () => {
@@ -34,7 +35,8 @@ suite('Polymer2MixinScanner with old jsdoc annotations', () => {
   async function getScannedMixins(filename: string) {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -23,6 +23,7 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {ResolvedUrl} from '../../model/url';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {CodeUnderliner} from '../test-utils';
 
 suite('Polymer2MixinScanner', () => {
@@ -34,7 +35,8 @@ suite('Polymer2MixinScanner', () => {
   async function getScannedMixins(filename: string) {
     const file = await urlLoader.load(filename);
     const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
+    const document =
+        parser.parse(file, filename as ResolvedUrl, new PackageUrlResolver());
     const scanner = new ClassScanner();
     const visit = (visitor: Visitor) =>
         Promise.resolve(document.visit([visitor]));

--- a/src/test/polymer/pseudo-element-scanner_test.ts
+++ b/src/test/polymer/pseudo-element-scanner_test.ts
@@ -18,6 +18,7 @@ import {HtmlVisitor} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {ResolvedUrl} from '../../model/url';
 import {PseudoElementScanner} from '../../polymer/pseudo-element-scanner';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('PseudoElementScanner', () => {
   suite('scan()', () => {
@@ -37,8 +38,8 @@ suite('PseudoElementScanner', () => {
           -->
         </body>
         </html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
+      const document = new HtmlParser().parse(
+          contents, 'test.html' as ResolvedUrl, new PackageUrlResolver());
       const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
       const {features} = await scanner.scan(document, visit);

--- a/src/test/typescript/typescript-import-scanner_test.ts
+++ b/src/test/typescript/typescript-import-scanner_test.ts
@@ -18,6 +18,7 @@ import {ResolvedUrl} from '../../model/url';
 import {Visitor} from '../../typescript/typescript-document';
 import {TypeScriptImportScanner} from '../../typescript/typescript-import-scanner';
 import {TypeScriptPreparser} from '../../typescript/typescript-preparser';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('TypeScriptImportScanner', () => {
   suite('scan()', () => {
@@ -30,7 +31,8 @@ suite('TypeScriptImportScanner', () => {
     test('finds no imports', async () => {
       const source = ``;
       const parser = new TypeScriptPreparser();
-      const document = parser.parse(source, 'test.ts' as ResolvedUrl);
+      const document = parser.parse(
+          source, 'test.ts' as ResolvedUrl, new PackageUrlResolver());
       const visit = async (visitor: Visitor) => document.visit([visitor]);
       const {features} = await scanner.scan(document, visit);
       assert.equal(features.length, 0);
@@ -43,11 +45,12 @@ suite('TypeScriptImportScanner', () => {
         import * as z from '../z.ts';
       `;
       const parser = new TypeScriptPreparser();
-      const document = parser.parse(source, 'test.ts' as ResolvedUrl);
+      const document = parser.parse(
+          source, 'test.ts' as ResolvedUrl, new PackageUrlResolver());
       const visit = async (visitor: Visitor) => document.visit([visitor]);
       const {features} = await scanner.scan(document, visit);
       assert.deepEqual(features.map((f) => [f.type, f.url]), [
-        ['js-import', 'x.ts'],
+        ['js-import', './x.ts'],
         ['js-import', '/y.ts'],
         ['js-import', '../z.ts'],
       ]);

--- a/src/test/typescript/typescript-preparser_test.ts
+++ b/src/test/typescript/typescript-preparser_test.ts
@@ -22,6 +22,7 @@ import {TypeScriptPreparser} from '../../typescript/typescript-preparser';
 import {WarningCarryingException} from '../../model/model';
 import {CodeUnderliner} from '../test-utils';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('TypeScriptParser', () => {
   let parser: TypeScriptPreparser;
@@ -39,8 +40,10 @@ suite('TypeScriptParser', () => {
           bar: string = 'baz';
         }
       `;
-      const document =
-          parser.parse(contents, '/typescript/test.ts' as ResolvedUrl);
+      const document = parser.parse(
+          contents,
+          '/typescript/test.ts' as ResolvedUrl,
+          new PackageUrlResolver());
       assert.instanceOf(document, ParsedTypeScriptDocument);
       assert.equal(document.url, '/typescript/test.ts');
       const sourceFile = document.ast as ts.SourceFile;
@@ -56,7 +59,7 @@ suite('TypeScriptParser', () => {
       const url = 'ts-parse-error.ts';
       let error: WarningCarryingException|undefined = undefined;
       try {
-        parser.parse(contents, url as ResolvedUrl);
+        parser.parse(contents, url as ResolvedUrl, new PackageUrlResolver());
       } catch (e) {
         if (!(e instanceof WarningCarryingException)) {
           console.log(e);
@@ -86,7 +89,8 @@ const const const const const #!@(~~)!();
           }
         }`).trim() +
             '\n';
-        const document = parser.parse(contents, 'test-file.js' as ResolvedUrl);
+        const document = parser.parse(
+            contents, 'test-file.js' as ResolvedUrl, new PackageUrlResolver());
         assert.deepEqual(document.stringify({}), contents);
       });
     });

--- a/src/test/warning/warning-printer_test.ts
+++ b/src/test/warning/warning-printer_test.ts
@@ -21,14 +21,17 @@ import * as path from 'path';
 import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {Severity, Warning} from '../../model/model';
 import {ResolvedUrl} from '../../model/url';
+import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {WarningPrinter} from '../../warning/warning-printer';
 
 const parser = new JavaScriptParser();
 const staticTestDir = path.join(__dirname, '../static');
 const vanillaSources =
     fs.readFileSync(path.join(staticTestDir, 'vanilla-elements.js'), 'utf-8');
-const parsedDocument =
-    parser.parse(vanillaSources, 'vanilla-elements.js' as ResolvedUrl);
+const parsedDocument = parser.parse(
+    vanillaSources,
+    'vanilla-elements.js' as ResolvedUrl,
+    new PackageUrlResolver());
 
 const dumbNameWarning = new Warning({
   message: 'This is a dumb name for an element.',

--- a/src/typescript/typescript-import-scanner.ts
+++ b/src/typescript/typescript-import-scanner.ts
@@ -23,7 +23,7 @@ import {Node, ParsedTypeScriptDocument, Visitor} from './typescript-document';
 export class TypeScriptImportScanner implements
     Scanner<ParsedTypeScriptDocument, Node, Visitor> {
   async scan(
-      document: ParsedTypeScriptDocument,
+      _document: ParsedTypeScriptDocument,
       visit: (visitor: Visitor) => Promise<void>) {
     const imports: ScannedImport[] = [];
     class ImportVisitor extends Visitor {
@@ -36,7 +36,7 @@ export class TypeScriptImportScanner implements
             FileRelativeUrl;
         imports.push(new ScannedImport(
             'js-import',
-            ScannedImport.resolveUrl(document.baseUrl, specifierUrl),
+            specifierUrl,
             // TODO(justinfagnani): make SourceRanges work
             null as any as SourceRange,
             null as any as SourceRange,

--- a/src/typescript/typescript-preparser.ts
+++ b/src/typescript/typescript-preparser.ts
@@ -17,6 +17,7 @@ import * as ts from 'typescript';
 import {correctSourceRange, InlineDocInfo, Severity, Warning, WarningCarryingException} from '../model/model';
 import {ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
+import {UrlResolver} from '../url-loader/url-resolver';
 
 import {ParsedTypeScriptDocument} from './typescript-document';
 
@@ -34,8 +35,9 @@ import {ParsedTypeScriptDocument} from './typescript-document';
  * function, it could be that a full parse is needed anyway.
  */
 export class TypeScriptPreparser implements Parser<ParsedTypeScriptDocument> {
-  parse(contents: string, url: ResolvedUrl, inlineInfo?: InlineDocInfo<any>):
-      ParsedTypeScriptDocument {
+  parse(
+      contents: string, url: ResolvedUrl, _urlResolver: UrlResolver,
+      inlineInfo?: InlineDocInfo<any>): ParsedTypeScriptDocument {
     const isInline = !!inlineInfo;
     inlineInfo = inlineInfo || {};
     const sourceFile =

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {resolve as urlLibResolver} from 'url';
+
+import {ScannedImport} from '../index';
 import {FileRelativeUrl, PackageRelativeUrl, ResolvedUrl} from '../model/url';
 
 /**
@@ -33,7 +35,9 @@ export abstract class UrlResolver {
    */
   abstract resolve(url: PackageRelativeUrl): ResolvedUrl;
 
-  resolveFileUrl(url: FileRelativeUrl, baseUrl: ResolvedUrl): ResolvedUrl {
+  resolveFileUrl(
+      url: FileRelativeUrl, baseUrl: ResolvedUrl,
+      _scannedImport: ScannedImport|undefined): ResolvedUrl {
     const packageRelativeUrl =
         urlLibResolver(baseUrl, url) as PackageRelativeUrl;
     return this.resolve(packageRelativeUrl);

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -11,8 +11,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-
-import {PackageRelativeUrl, ResolvedUrl} from '../model/url';
+import {resolve as urlLibResolver} from 'url';
+import {FileRelativeUrl, PackageRelativeUrl, ResolvedUrl} from '../model/url';
 
 /**
  * Resolves the given URL to the concrete URL that a resource can
@@ -26,12 +26,18 @@ export abstract class UrlResolver {
   /**
    * Returns `true` if this resolver can resolve the given `url`.
    */
-  abstract canResolve(url: PackageRelativeUrl): boolean;
+  abstract canResolve(url: PackageRelativeUrl|FileRelativeUrl): boolean;
 
   /**
    * Resoves `url` to a new location.
    */
   abstract resolve(url: PackageRelativeUrl): ResolvedUrl;
+
+  resolveFileUrl(url: FileRelativeUrl, baseUrl: ResolvedUrl): ResolvedUrl {
+    const packageRelativeUrl =
+        urlLibResolver(baseUrl, url) as PackageRelativeUrl;
+    return this.resolve(packageRelativeUrl);
+  }
 
   protected brandAsResolved(url: string): ResolvedUrl {
     return url as ResolvedUrl;


### PR DESCRIPTION
 - [x] CHANGELOG.md updated for user-visible change

Recommend going commit by commit. Most of the interesting stuff is in the first and last commits. The middle one is updating a bajillion scanner tests because this adds a UrlResolver parameter to `Parser#parse`.

I also threw in `Import#originalUrl` because it was quick and easy.

Part of https://github.com/Polymer/polymer-analyzer/issues/765
Fixes https://github.com/Polymer/polymer-analyzer/issues/763