### PR TITLE
Scan behavior shorthand methods as methods, not properties.

### DIFF
--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -104,7 +104,7 @@ class BehaviorVisitor implements Visitor {
       }
       if (name in this.propertyHandlers) {
         this.propertyHandlers[name](prop.value);
-      } else if (babel.isFunction(prop.value)) {
+      } else if (babel.isMethod(prop) || babel.isFunction(prop.value)) {
         const method = esutil.toScannedMethod(
             prop, this.document.sourceRangeForNode(prop)!, this.document);
         this.currentBehavior.addMethod(method);

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -108,7 +108,9 @@ suite('BehaviorScanner', () => {
     if (!behavior) {
       throw new Error('Could not find Polymer.SimpleNamespacedBehavior');
     }
-    assert.deepEqual([...behavior.methods.keys()], ['method']);
+    assert.deepEqual(
+        [...behavior.methods.keys()],
+        ['method', 'shorthandMethod']);
     assert.deepEqual(
         [...behavior.properties.keys()],
         ['simple', 'object', 'array', 'attached', 'templateLiteral']);

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -9,9 +9,8 @@ var SimpleBehavior = {
  * */
 var SimpleNamespacedBehavior = {
   simple: true,
-  method: function(paramA, paramB) {
-
-  },
+  method: function(paramA, paramB) {},
+  shorthandMethod(paramA, paramB) {},
   object: {},
   array: [],
   attached: true ? null : function() {},


### PR DESCRIPTION
This was a regression from the espree version because babel scans this
syntax differently.

Fixes #769

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
