### PR TITLE
Updated CHANGELOG for 3.0.0-pre.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
 
-## [3.0.0-pre.2] - 2017-12-01
+## [3.0.0-pre.2] - 2017-11-30
 
 * Added `js-import` feature with `lazy: true` for dynamic imports call expressions of the form `import()`.
 * Functions will now be scanned if they have a `@global` annotation. Previously they would only be scanned if they had a `@memberof` annotation. One of these annotations is required because otherwise a lot of functions that aren't really public are included in the analysis (e.g. because they are hidden due to their scoping).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
-* Added `js-import` feature with `lazy: true` for dynamic imports call expressions of the form `import()`.
 
+## [3.0.0-pre.2] - 2017-12-01
+
+* Added `js-import` feature with `lazy: true` for dynamic imports call expressions of the form `import()`.
 * Functions will now be scanned if they have a `@global` annotation. Previously they would only be scanned if they had a `@memberof` annotation. One of these annotations is required because otherwise a lot of functions that aren't really public are included in the analysis (e.g. because they are hidden due to their scoping).
 * Function names can now be overridden with e.g. `@function MyNewName`.
 


### PR DESCRIPTION
## [3.0.0-pre.2] - 2017-12-01
 * Added `js-import` feature with `lazy: true` for dynamic imports call expressions of the form `import()`.
 * Functions will now be scanned if they have a `@global` annotation. Previously they would only be scanned if they had a `@memberof` annotation. One of these annotations is required because otherwise a lot of functions that aren't really public are included in the analysis (e.g. because they are hidden due to their scoping).
 * Function names can now be overridden with e.g. `@function MyNewName`.
 - [x] CHANGELOG.md has been updated
 - This release will make possible to test bundler PR treating dynamic es module imports as lazy edges.
