### PR TITLE
Added `url` to the top-level/model exports and sorted import sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
 
+* Added missing model typings for branded `url` types to top-level package exports.
+
 ## [3.0.0-pre.2] - 2017-11-30
 
 * Added `js-import` feature with `lazy: true` for dynamic imports call expressions of the form `import()`.

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -34,13 +34,14 @@
 
 // TODO(rictic): export document and package query options...
 
+export {Analysis} from './analysis';
 export * from './attribute';
 export * from './class';
 export {Document, ScannedDocument} from './document';
 export * from './element';
 export * from './element-base';
-export {ElementReference, ScannedElementReference} from './element-reference';
 export * from './element-mixin';
+export {ElementReference, ScannedElementReference} from './element-reference';
 export * from './event';
 export * from './feature';
 export * from './import';
@@ -48,9 +49,9 @@ export * from './inline-document';
 export * from './literal';
 export * from './property';
 export * from './method';
-export {Analysis} from './analysis';
+export {Queryable, FeatureKindMap, DocumentQuery, AnalysisQuery} from './queryable';
 export * from './reference';
 export * from './resolvable';
 export * from './source-range';
+export * from './url';
 export * from './warning';
-export {Queryable, FeatureKindMap, DocumentQuery, AnalysisQuery} from './queryable';


### PR DESCRIPTION
- Since the branded URLs are a part of the external interface they should be exported top-level.
- Also, alphabetically ordered package names in model.ts where they were out-of-order.
- [x] CHANGELOG.md has been updated
