### PR TITLE
[Redesigned URLS 3] Remove UrlResolver#canResolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* Add Analyzer.forDirectory() for easily getting a well configured analyzer
+  for a given directory.
+* Removed the `UrlResolver#canResolve` method. A UrlResolver should return
+  `undefined` when `resolve` is called to indicate that it can't resolve a URL.
 * Analyzer#urlResolver is a property that exposes the analyzer's url resolver,
   for cases where more direct access to url resolution is desired.
 <!-- Add new, unreleased changes here. -->

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -487,7 +487,7 @@ export class AnalysisContext {
    * Returns true if the url given is resovable by the Analyzer's `UrlResolver`.
    */
   canResolveUrl(url: PackageRelativeUrl): boolean {
-    return this.resolver.canResolve(url);
+    return this.resolver.resolve(url) !== undefined;
   }
 
   /**
@@ -495,7 +495,10 @@ export class AnalysisContext {
    * URL if it can not be resolved.
    */
   resolveUrl(url: PackageRelativeUrl): ResolvedUrl {
-    return this.resolver.canResolve(url) ? this.resolver.resolve(url) :
-                                           (url as any as ResolvedUrl);
+    const resolved = this.resolver.resolve(url);
+    if (resolved === undefined) {
+      return url as any as ResolvedUrl;
+    }
+    return resolved;
   }
 }

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -484,13 +484,6 @@ export class AnalysisContext {
   }
 
   /**
-   * Returns true if the url given is resovable by the Analyzer's `UrlResolver`.
-   */
-  canResolveUrl(url: PackageRelativeUrl): boolean {
-    return this.resolver.resolve(url) !== undefined;
-  }
-
-  /**
    * Resolves a URL with this Analyzer's `UrlResolver` or returns the given
    * URL if it can not be resolved.
    */

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -494,9 +494,7 @@ export class AnalysisContext {
   }
 
   /**
-   * Resolves all resolvable URLs in the list.
-   *
-   * Unresolvable URLs will be filtered out.
+   * Resolves all resolvable URLs in the list, removes unresolvable ones.
    */
   resolveUrls(urls: PackageRelativeUrl[]): ResolvedUrl[] {
     return urls.map((u) => this.resolveUrl(u)!).filter((u) => u !== undefined);

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -139,8 +139,7 @@ export class AnalysisContext {
    * Returns a copy of this cache context with proper cache invalidation.
    */
   filesChanged(urls: PackageRelativeUrl[]) {
-    const newCache =
-        this._cache.invalidate(urls.map((url) => this.resolveUrl(url)));
+    const newCache = this._cache.invalidate(this.resolveUrls(urls));
     return this._fork(newCache);
   }
 
@@ -148,7 +147,7 @@ export class AnalysisContext {
    * Implements Analyzer#analyze, see its docs.
    */
   async analyze(urls: PackageRelativeUrl[]): Promise<AnalysisContext> {
-    const resolvedUrls = urls.map((url) => this.resolveUrl(url));
+    const resolvedUrls = this.resolveUrls(urls);
 
     // 1. Await current analysis if there is one, so we can check to see if has
     // all of the requested URLs.
@@ -320,7 +319,7 @@ export class AnalysisContext {
                     (e) => e instanceof ScannedImport) as ScannedImport[];
 
             // Update dependency graph
-            const importUrls = imports.map((i) => this.resolveUrl(i.url));
+            const importUrls = this.resolveUrls(imports.map((i) => i.url));
             this._cache.dependencyGraph.addDocument(resolvedUrl, importUrls);
 
             return scannedDocument;
@@ -345,6 +344,9 @@ export class AnalysisContext {
           // Scan imports
           for (const scannedImport of imports) {
             const importUrl = this.resolveUrl(scannedImport.url);
+            if (!importUrl) {
+              continue;
+            }
             // Request a scan of `importUrl` but do not wait for the results to
             // avoid deadlock in the case of cycles. Later we use the
             // DependencyGraph to wait for all transitive dependencies to load.
@@ -487,11 +489,22 @@ export class AnalysisContext {
    * Resolves a URL with this Analyzer's `UrlResolver` or returns the given
    * URL if it can not be resolved.
    */
-  resolveUrl(url: PackageRelativeUrl): ResolvedUrl {
+  resolveUrl(url: PackageRelativeUrl): ResolvedUrl|undefined {
     const resolved = this.resolver.resolve(url);
     if (resolved === undefined) {
       return url as any as ResolvedUrl;
     }
     return resolved;
+  }
+
+  resolveUrls(urls: PackageRelativeUrl[]): ResolvedUrl[] {
+    const results = [];
+    for (const url of urls) {
+      const resolved = this.resolveUrl(url);
+      if (resolved !== undefined) {
+        results.push(resolved);
+      }
+    }
+    return results;
   }
 }

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -497,6 +497,10 @@ export class AnalysisContext {
    * Resolves all resolvable URLs in the list, removes unresolvable ones.
    */
   resolveUrls(urls: PackageRelativeUrl[]): ResolvedUrl[] {
-    return urls.map((u) => this.resolveUrl(u)!).filter((u) => u !== undefined);
+    return filterOutUndefineds(urls.map((u) => this.resolveUrl(u)));
   }
+}
+
+function filterOutUndefineds<T>(arr: ReadonlyArray<T|undefined>): T[] {
+  return arr.filter((t) => t !== undefined) as T[];
 }

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -490,21 +490,15 @@ export class AnalysisContext {
    * URL if it can not be resolved.
    */
   resolveUrl(url: PackageRelativeUrl): ResolvedUrl|undefined {
-    const resolved = this.resolver.resolve(url);
-    if (resolved === undefined) {
-      return url as any as ResolvedUrl;
-    }
-    return resolved;
+    return this.resolver.resolve(url);
   }
 
+  /**
+   * Resolves all resolvable URLs in the list.
+   *
+   * Unresolvable URLs will be filtered out.
+   */
   resolveUrls(urls: PackageRelativeUrl[]): ResolvedUrl[] {
-    const results = [];
-    for (const url of urls) {
-      const resolved = this.resolveUrl(url);
-      if (resolved !== undefined) {
-        results.push(resolved);
-      }
-    }
-    return results;
+    return urls.map((u) => this.resolveUrl(u)!).filter((u) => u !== undefined);
   }
 }

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -101,7 +101,7 @@ export class Analyzer {
       return await previousContext.analyze(uiUrls);
     })();
     const context = await this._analysisComplete;
-    const resolvedUrls = uiUrls.map((url) => context.resolveUrl(url));
+    const resolvedUrls = context.resolveUrls(this.brandUserInputUrls(urls));
     return this._constructAnalysis(context, resolvedUrls);
   }
 
@@ -125,9 +125,7 @@ export class Analyzer {
           (fn) => extensions.has(path.extname(fn).substring(1)));
 
       const newContext = await previousContext.analyze(filesWithParsers);
-      const resolvedFilesWithParsers =
-          filesWithParsers.map((url) => newContext.resolveUrl(url));
-
+      const resolvedFilesWithParsers = newContext.resolveUrls(filesWithParsers);
       analysis = this._constructAnalysis(newContext, resolvedFilesWithParsers);
       return newContext;
     })();

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -222,13 +222,6 @@ export class Analyzer {
   }
 
   /**
-   * Returns `true` if the given `url` can be resolved.
-   */
-  canResolveUrl(url: string): boolean {
-    return this.urlResolver.resolve(this.brandUserInputUrl(url)) !== undefined;
-  }
-
-  /**
    * Resoves `url` to a new location.
    */
   resolveUrl(url: string): ResolvedUrl|undefined {

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -225,13 +225,13 @@ export class Analyzer {
    * Returns `true` if the given `url` can be resolved.
    */
   canResolveUrl(url: string): boolean {
-    return this.urlResolver.canResolve(this.brandUserInputUrl(url));
+    return this.urlResolver.resolve(this.brandUserInputUrl(url)) !== undefined;
   }
 
   /**
    * Resoves `url` to a new location.
    */
-  resolveUrl(url: string): ResolvedUrl {
+  resolveUrl(url: string): ResolvedUrl|undefined {
     return this.urlResolver.resolve(this.brandUserInputUrl(url));
   }
 

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -32,7 +32,8 @@ export class ScriptTagBackReferenceImport extends Import {
 
 export class ScannedScriptTagImport extends ScannedImport {
   resolve(document: Document): ScriptTagImport|undefined {
-    if (!document._analysisContext.canResolveUrl(this.url)) {
+    const resolvedUrl = document._analysisContext.resolver.resolve(this.url);
+    if (resolvedUrl === undefined) {
       return;
     }
 
@@ -48,8 +49,8 @@ export class ScannedScriptTagImport extends ScannedImport {
     //
     // See https://github.com/Polymer/polymer-analyzer/issues/615
 
-    const scannedDocument = document._analysisContext._getScannedDocument(
-        document._analysisContext.resolveUrl(this.url));
+    const scannedDocument =
+        document._analysisContext._getScannedDocument(resolvedUrl);
     if (scannedDocument) {
       const importedDocument =
           new Document(scannedDocument, document._analysisContext);
@@ -75,7 +76,7 @@ export class ScannedScriptTagImport extends ScannedImport {
       importedDocument.resolve();
 
       return new ScriptTagImport(
-          document._analysisContext.resolveUrl(this.url),
+          resolvedUrl,
           this.type,
           importedDocument,
           this.sourceRange,

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -68,11 +68,12 @@ export class ScannedImport implements Resolvable {
   }
 
   resolve(document: Document): Import|undefined {
-    if (!document._analysisContext.canResolveUrl(this.url)) {
+    const resolvedUrl = document._analysisContext.resolver.resolve(this.url);
+    if (resolvedUrl === undefined) {
       return;
     }
-    const importedDocumentOrWarning = document._analysisContext.getDocument(
-        document._analysisContext.resolveUrl(this.url));
+    const importedDocumentOrWarning =
+        document._analysisContext.getDocument(resolvedUrl);
     if (!(importedDocumentOrWarning instanceof Document)) {
       const error = this.error ? (this.error.message || this.error) : '';
       document.warnings.push(new Warning({
@@ -85,7 +86,7 @@ export class ScannedImport implements Resolvable {
       return undefined;
     }
     return new Import(
-        document._analysisContext.resolveUrl(this.url),
+        resolvedUrl,
         this.type,
         importedDocumentOrWarning,
         this.sourceRange,

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -82,16 +82,6 @@ suite('Analyzer', () => {
         'http://host/path');
   });
 
-  suite('canResolveUrl()', () => {
-    test('canResolveUrl defaults to not resolving external urls', () => {
-      assert.isTrue(analyzer.canResolveUrl('/path'), '/path');
-      assert.isTrue(analyzer.canResolveUrl('../path'), '../path');
-      assert.isFalse(analyzer.canResolveUrl('http://host'), 'http://host');
-      assert.isFalse(
-          analyzer.canResolveUrl('http://host/path'), 'http://host/path');
-    });
-  });
-
   suite('analyze()', () => {
     let testName = 'analyzes a document with an inline Polymer element feature';
     test(testName, async () => {

--- a/src/test/typescript/typescript-analyzer_test.ts
+++ b/src/test/typescript/typescript-analyzer_test.ts
@@ -27,7 +27,7 @@ async function getTypeScriptAnalyzer(files: Map<PackageRelativeUrl, string>) {
   const urlLoader = new InMemoryOverlayUrlLoader();
   const urlResolver = new PackageUrlResolver();
   for (const [url, contents] of files) {
-    urlLoader.urlContentsMap.set(urlResolver.resolve(url), contents);
+    urlLoader.urlContentsMap.set(urlResolver.resolve(url)!, contents);
   }
   const analysisContext = new AnalysisContext({
     parsers: new Map([['ts', new TypeScriptPreparser()]]),

--- a/src/test/typescript/typescript-import-scanner_test.ts
+++ b/src/test/typescript/typescript-import-scanner_test.ts
@@ -41,7 +41,7 @@ suite('TypeScriptImportScanner', () => {
     const urlLoader = new InMemoryOverlayUrlLoader();
     const analyzer = new Analyzer(
         {parsers: new Map([['ts', new TypeScriptPreparser()]]), urlLoader});
-    urlLoader.urlContentsMap.set(analyzer.resolveUrl('test.ts'), source);
+    urlLoader.urlContentsMap.set(analyzer.resolveUrl('test.ts')!, source);
     const {features} =
         await runScanner(analyzer, new TypeScriptImportScanner(), 'test.ts');
     assert.deepEqual(features.map((f: ScannedImport) => [f.type, f.url]), [

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -14,49 +14,10 @@
 
 import {assert} from 'chai';
 
-import {PackageRelativeUrl} from '../../model/url';
+import {PackageRelativeUrl, ResolvedUrl} from '../../model/url';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 suite('PackageUrlResolver', function() {
-  suite('canResolve', () => {
-    test('is true an in-package URL', () => {
-      const r = new PackageUrlResolver();
-      assert.isTrue(r.canResolve('foo.html'));
-      assert.isTrue(r.canResolve('/foo.html'));
-      assert.isTrue(r.canResolve('./foo.html'));
-    });
-
-    test('is true for a sibling URL', () => {
-      assert.isTrue(new PackageUrlResolver().canResolve('../foo/foo.html'));
-    });
-
-    test('is false for a cousin URL', () => {
-      assert.isFalse(new PackageUrlResolver().canResolve('../../foo/foo.html'));
-    });
-
-    test('is false for URL with a hostname', () => {
-      const r = new PackageUrlResolver();
-      assert.isFalse(r.canResolve('http://abc.xyz/foo.html'));
-      assert.isFalse(r.canResolve('//abc.xyz/foo.html'));
-    });
-
-    test('is true for a URL with the right hostname', () => {
-      const r = new PackageUrlResolver({
-        hostname: 'abc.xyz',
-      });
-      assert.isTrue(r.canResolve('http://abc.xyz/foo.html'));
-      assert.isTrue(r.canResolve('http://abc.xyz/./foo.html'));
-      assert.isTrue(r.canResolve('http://abc.xyz/../foo.html'));
-      assert.isTrue(r.canResolve('http://abc.xyz/foo/../foo.html'));
-      assert.isTrue(r.canResolve('//abc.xyz/foo.html'));
-    });
-
-    test('is false for an undecodable URL', () => {
-      const r = new PackageUrlResolver();
-      assert.isFalse(r.canResolve('%><><%='));
-    });
-  });
-
   suite('resolve', () => {
     test('resolves an in-package URL', () => {
       const r = new PackageUrlResolver();
@@ -72,16 +33,20 @@ suite('PackageUrlResolver', function() {
               '../foo/foo.html' as PackageRelativeUrl));
     });
 
-    test('throws for a cousin URL', () => {
-      assert.throws(
-          () => new PackageUrlResolver().resolve(
-              '../../foo/foo.html' as PackageRelativeUrl));
+    test('returns undefined for a cousin URL', () => {
+      assert.equal(
+          new PackageUrlResolver().resolve(
+              '../../foo/foo.html' as PackageRelativeUrl),
+          undefined);
     });
 
-    test('throws for a URL with a hostname', () => {
-      assert.throws(
-          () => new PackageUrlResolver().resolve(
-              'http://abc.xyz/foo.html' as PackageRelativeUrl));
+    test('returns undefined for a URL with a hostname', () => {
+      const r = new PackageUrlResolver();
+      assert.equal(
+          r.resolve('http://abc.xyz/foo.html' as PackageRelativeUrl),
+          undefined);
+      assert.equal(
+          r.resolve('//abc.xyz/foo.html' as PackageRelativeUrl), undefined);
     });
 
     test('resolves a URL with the right hostname', () => {
@@ -122,7 +87,12 @@ suite('PackageUrlResolver', function() {
       const r = new PackageUrlResolver();
       assert.equal(
           r.resolve('spaced name.html' as PackageRelativeUrl),
-          'spaced%20name.html');
+          'spaced%20name.html' as ResolvedUrl);
+    });
+
+    test('resolves an undecodable URL to undefined', () => {
+      const r = new PackageUrlResolver();
+      assert.equal(r.resolve('%><><%=' as PackageRelativeUrl), undefined);
     });
   });
 });

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -14,46 +14,29 @@
 
 import {assert} from 'chai';
 
-import {PackageRelativeUrl} from '../../model/url';
+import {PackageRelativeUrl, ResolvedUrl} from '../../model/url';
 import {RedirectResolver} from '../../url-loader/redirect-resolver';
 
 
 suite('RedirectResolver', function() {
-  suite('canResolve', () => {
-    test('canResolve is true if the prefix matches with protocol', () => {
-      const resolver = new RedirectResolver('proto://site/', 'some/path');
-      assert.isTrue(resolver.canResolve(
-          'proto://site/something.html' as PackageRelativeUrl));
-    });
-
-    test('canResolve is true if the prefix matches without protocol', () => {
-      const resolver = new RedirectResolver('/site/', 'some/path');
-      assert.isTrue(
-          resolver.canResolve('/site/something.html' as PackageRelativeUrl));
-    });
-
-    test('canResolve is false if the prefix doesn\'t match', () => {
-      const resolver = new RedirectResolver('proto://site/', 'some/path');
-      assert.isFalse(
-          resolver.canResolve('/site/something.html' as PackageRelativeUrl));
-      assert.isFalse(resolver.canResolve(
-          'protzo://site/something.html' as PackageRelativeUrl));
-    });
-  });
-
   suite('resolve', () => {
     test('if prefix matches, url is rewritten', () => {
-      const resolver = new RedirectResolver('proto://site/', 'some/path/');
+      let resolver = new RedirectResolver('proto://site/', 'some/path/');
       assert.equal(
           resolver.resolve('proto://site/something.html' as PackageRelativeUrl),
-          'some/path/something.html');
+          'some/path/something.html' as ResolvedUrl);
+      resolver = new RedirectResolver('/site/', 'some/path/');
+      assert.equal(
+          resolver.resolve('/site/something.html' as PackageRelativeUrl),
+          'some/path/something.html' as ResolvedUrl);
     });
-    test('if prefix doesn\'t match, resolve throws', () => {
+
+    test(`if prefix doesn't match, returns undefined`, () => {
       const resolver = new RedirectResolver('proto://site/', 'some/path/');
-      assert.throws(
-          () => resolver.resolve(
+      assert.equal(
+          resolver.resolve(
               'protoz://site/something.html' as PackageRelativeUrl),
-          /RedirectResolver/);
+          undefined);
     });
   });
 });

--- a/src/typescript/typescript-analyzer.ts
+++ b/src/typescript/typescript-analyzer.ts
@@ -18,7 +18,7 @@ import * as ts from 'typescript';
 
 import {AnalysisContext} from '../core/analysis-context';
 import {LanguageAnalyzer} from '../core/language-analyzer';
-import {PackageRelativeUrl} from '../model/url';
+import {PackageRelativeUrl, ResolvedUrl} from '../model/url';
 
 import {ParsedTypeScriptDocument} from './typescript-document';
 
@@ -96,7 +96,7 @@ class AnalyzerCompilerHost implements ts.CompilerHost {
       // in the dependency graph have been loaded, so it can call a synchronous
       // method to get the source of a file.
       const scannedDocument =
-          this.context._getScannedDocument(this.context.resolveUrl(fileName));
+          this.context._getScannedDocument(this._failSafeResolveUrl(fileName));
       if (scannedDocument != null) {
         const typescriptDocument =
             scannedDocument.document as ParsedTypeScriptDocument;
@@ -134,7 +134,7 @@ class AnalyzerCompilerHost implements ts.CompilerHost {
   }
 
   getCanonicalFileName(fileName: PackageRelativeUrl) {
-    return this.context.resolveUrl(fileName);
+    return this._failSafeResolveUrl(fileName);
   }
 
   getNewLine() {
@@ -146,14 +146,14 @@ class AnalyzerCompilerHost implements ts.CompilerHost {
   }
 
   fileExists(fileName: PackageRelativeUrl) {
-    const resolvedUrl = this.context.resolveUrl(fileName);
+    const resolvedUrl = this._failSafeResolveUrl(fileName);
     return isLibraryPath(resolvedUrl) &&
         getLibrarySource(resolvedUrl) != null ||
         this.context._getScannedDocument(resolvedUrl) != null;
   }
 
   readFile(fileName: PackageRelativeUrl): string {
-    const resolvedUrl = this.context.resolveUrl(fileName);
+    const resolvedUrl = this._failSafeResolveUrl(fileName);
     if (isLibraryPath(resolvedUrl)) {
       const libPath = require.resolve(`typescript/lib/${fileName}`);
       return fs.readFileSync(libPath, {encoding: 'utf-8'});
@@ -173,8 +173,13 @@ class AnalyzerCompilerHost implements ts.CompilerHost {
       // since we have a path, we can simply resolve it
       const fileName = path.resolve(path.dirname(containingFile), moduleName) as
           PackageRelativeUrl;
-      const resolvedFileName = this.context.resolveUrl(fileName);
+      const resolvedFileName = this._failSafeResolveUrl(fileName);
       return {resolvedFileName};
     });
+  }
+
+  private _failSafeResolveUrl(url: string): ResolvedUrl {
+    const resolved = this.context.resolveUrl(url as PackageRelativeUrl);
+    return resolved === undefined ? url as any as ResolvedUrl : resolved;
   }
 }

--- a/src/typescript/typescript-analyzer.ts
+++ b/src/typescript/typescript-analyzer.ts
@@ -178,6 +178,12 @@ class AnalyzerCompilerHost implements ts.CompilerHost {
     });
   }
 
+  /**
+   * Resolves the given url.
+   *
+   * If the url is unresolvable, the given unresolved URL is returned as a
+   * resolved URL.
+   */
   private _failSafeResolveUrl(url: string): ResolvedUrl {
     const resolved = this.context.resolveUrl(url as PackageRelativeUrl);
     return resolved === undefined ? url as any as ResolvedUrl : resolved;

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -20,26 +20,17 @@ import {UrlResolver} from './url-resolver';
  * Resolves a URL using multiple resolvers.
  */
 export class MultiUrlResolver extends UrlResolver {
-  constructor(private _resolvers: Array<UrlResolver>) {
+  constructor(private _resolvers: ReadonlyArray<UrlResolver>) {
     super();
-    if (!this._resolvers) {
-      this._resolvers = [];
-    }
   }
 
-  canResolve(url: PackageRelativeUrl): boolean {
-    return this._resolvers.some((resolver) => {
-      return resolver.canResolve(url);
-    });
-  }
-
-  resolve(url: PackageRelativeUrl): ResolvedUrl {
-    for (let i = 0; i < this._resolvers.length; i++) {
-      const resolver = this._resolvers[i];
-      if (resolver.canResolve(url)) {
-        return resolver.resolve(url);
+  resolve(url: PackageRelativeUrl): ResolvedUrl|undefined {
+    for (const resolver of this._resolvers) {
+      const resolved = resolver.resolve(url);
+      if (resolved !== undefined) {
+        return resolved;
       }
     }
-    throw new Error('No resolver can resolve: ' + url);
+    return undefined;
   }
 }

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -39,30 +39,21 @@ export class PackageUrlResolver extends UrlResolver {
     this.hostname = options.hostname || null;
   }
 
-  canResolve(url: string): boolean {
-    const urlObject = parseUrl(url);
-    let decodedUrl;
-    try {
-      decodedUrl = decodeURI(urlObject.pathname || '');
-    } catch (e) {
-      return false;
-    }
-
-    const pathname = pathlib.normalize(decodedUrl);
-    return this._isValid(urlObject, pathname);
-  }
-
-  _isValid(urlObject: Url, pathname: string) {
+  private _isValid(urlObject: Url, pathname: string) {
     return (urlObject.hostname === this.hostname || !urlObject.hostname) &&
         !pathname.startsWith('../../');
   }
 
-  resolve(url: PackageRelativeUrl): ResolvedUrl {
+  resolve(url: PackageRelativeUrl): ResolvedUrl|undefined {
     const urlObject = parseUrl(url);
-    let pathname = pathlib.normalize(decodeURI(urlObject.pathname || ''));
-
+    let pathname;
+    try {
+      pathname = pathlib.normalize(decodeURI(urlObject.pathname || ''));
+    } catch (e) {
+      return undefined;  // undecodable url
+    }
     if (!this._isValid(urlObject, pathname)) {
-      throw new Error(`Invalid URL ${url}`);
+      return undefined;
     }
 
     // If the path points to a sibling directory, resolve it to the

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -24,15 +24,9 @@ export class RedirectResolver extends UrlResolver {
     super();
   }
 
-  canResolve(url: PackageRelativeUrl): boolean {
-    return url.startsWith(this._redirectFrom);
-  }
-
-  resolve(url: PackageRelativeUrl): ResolvedUrl {
-    if (!this.canResolve(url)) {
-      throw new Error(
-          `RedirectResolver cannot resolve: "${url}" from:` +
-          `"${this._redirectFrom}" to: "${this._redirectTo}"`);
+  resolve(url: PackageRelativeUrl): ResolvedUrl|undefined {
+    if (!url.startsWith(this._redirectFrom)) {
+      return undefined;
     }
     return this.brandAsResolved(
         this._redirectTo + url.slice(this._redirectFrom.length));

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -24,14 +24,11 @@ import {PackageRelativeUrl, ResolvedUrl} from '../model/url';
  */
 export abstract class UrlResolver {
   /**
-   * Returns `true` if this resolver can resolve the given `url`.
-   */
-  abstract canResolve(url: PackageRelativeUrl): boolean;
-
-  /**
    * Resoves `url` to a new location.
+   *
+   * Returns `undefined` if the given url cannot be resolved.
    */
-  abstract resolve(url: PackageRelativeUrl): ResolvedUrl;
+  abstract resolve(url: PackageRelativeUrl): ResolvedUrl|undefined;
 
   protected brandAsResolved(url: string): ResolvedUrl {
     return url as ResolvedUrl;


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

This revealed a number of places where we were not handling unresolvable URLs well. Places where we'd have thrown errors rather than gracefully failing.