### PR TITLE
[Redesigned URLS 1] Add Analyzer.forDirectory; cleanup tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.0.0-pre.3] - 2017-12-08
 
-* Added missing model typings for branded `url` types to top-level package exports.
-* Added `templateTypes` property to functions, extracted from `@template` annotations.
+* Added missing model typings for branded `url` types to top-level package
+  exports.
+* Added `templateTypes` property to functions, extracted from `@template`
+  annotations.
+* Add Analyzer.forDirectory() for easily getting a well configured analyzer
+  for a given directory.
 
 ## [3.0.0-pre.2] - 2017-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   exports.
 * Added `templateTypes` property to functions, extracted from `@template`
   annotations.
-* Add Analyzer.forDirectory() for easily getting a well configured analyzer
-  for a given directory.
+* Add `Analyzer.createForDirectory()` for easily getting a well configured
+  analyzer for a given directory.
 
 ## [3.0.0-pre.2] - 2017-11-30
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install polymer-analyzer
 ```js
 const {Analyzer} = require('polymer-analyzer');
 
-let analyzer = Analyzer.forDirectory('/path/to/package/root');
+const analyzer = Analyzer.createForDirectory('./');
 
 // This path is relative to the package root
 analyzer.analyze(['./my-element.html']).then((analysis) => {

--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ npm install polymer-analyzer
 
 ## Usage
 ```js
-const {Analyzer, FSUrlLoader} = require('polymer-analyzer');
+const {Analyzer} = require('polymer-analyzer');
 
-let analyzer = new Analyzer({
-  urlLoader: new FSUrlLoader('/path/to/package/root'),
-});
+let analyzer = Analyzer.forDirectory('/path/to/package/root');
 
 // This path is relative to the package root
 analyzer.analyze(['./my-element.html']).then((analysis) => {

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -85,7 +85,7 @@ export class Analyzer {
    * at the given directory, but in the future it may take configuration from
    * files including polymer.json or similar.
    */
-  static forDirectory(dirname: string): Analyzer {
+  static createForDirectory(dirname: string): Analyzer {
     return new Analyzer({urlLoader: new FSUrlLoader(dirname)});
   }
 

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -20,6 +20,7 @@ import {Analysis, Document, Warning} from '../model/model';
 import {PackageRelativeUrl, ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
 import {Scanner} from '../scanning/scanner';
+import {FSUrlLoader} from '../url-loader/fs-url-loader';
 import {UrlLoader} from '../url-loader/url-loader';
 import {UrlResolver} from '../url-loader/url-resolver';
 
@@ -75,6 +76,17 @@ export class Analyzer {
       this._urlLoader = context.loader;
       this._analysisComplete = Promise.resolve(context);
     }
+  }
+
+  /**
+   * Returns the best analyzer for the given directory.
+   *
+   * Currently this just creates a simple analyzer with a FS loader rooted
+   * at the given directory, but in the future it may take configuration from
+   * files including polymer.json or similar.
+   */
+  static forDirectory(dirname: string): Analyzer {
+    return new Analyzer({urlLoader: new FSUrlLoader(dirname)});
   }
 
   /**

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -79,7 +79,7 @@ export class Analyzer {
   }
 
   /**
-   * Returns the best analyzer for the given directory.
+   * Returns an analyzer with configuration inferred for the given directory.
    *
    * Currently this just creates a simple analyzer with a FS loader rooted
    * at the given directory, but in the future it may take configuration from

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -12,17 +12,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Analyzer, Document, FSUrlLoader, PackageUrlResolver, Severity, Warning, WarningPrinter} from '../index';
+import {Analyzer, Document, Severity, Warning, WarningPrinter} from '../index';
 
 /**
  * A basic demo of a linter CLI using the Analyzer API.
  */
 async function main() {
   const basedir = process.cwd();
-  const analyzer = new Analyzer({
-    urlLoader: new FSUrlLoader(basedir),
-    urlResolver: new PackageUrlResolver()
-  });
+  const analyzer = Analyzer.forDirectory(basedir);
   const warnings = await getWarnings(analyzer, process.argv[2]);
   const warningPrinter = new WarningPrinter(process.stderr);
   await warningPrinter.printWarnings(warnings);

--- a/src/demo/polymer-lint.ts
+++ b/src/demo/polymer-lint.ts
@@ -19,7 +19,7 @@ import {Analyzer, Document, Severity, Warning, WarningPrinter} from '../index';
  */
 async function main() {
   const basedir = process.cwd();
-  const analyzer = Analyzer.forDirectory(basedir);
+  const analyzer = Analyzer.createForDirectory(basedir);
   const warnings = await getWarnings(analyzer, process.argv[2]);
   const warningPrinter = new WarningPrinter(process.stderr);
   await warningPrinter.printWarnings(warnings);

--- a/src/test/analysis-format/generate-analysis_test.ts
+++ b/src/test/analysis-format/generate-analysis_test.ts
@@ -20,8 +20,6 @@ import {Analysis} from '../../analysis-format/analysis-format';
 import {generateAnalysis, validateAnalysis, ValidationError} from '../../analysis-format/generate-analysis';
 import {Analyzer} from '../../core/analyzer';
 import {Analysis as AnalysisResult} from '../../model/analysis';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 
 const onlyTests = new Set<string>([]);  // Should be empty when not debugging.
 
@@ -98,10 +96,7 @@ suite('generate-analysis', () => {
     suite('generates from package', () => {
       test('does not include external features', async () => {
         const basedir = path.resolve(fixturesDir, 'analysis/bower_packages');
-        const analyzer = new Analyzer({
-          urlLoader: new FSUrlLoader(basedir),
-          urlResolver: new PackageUrlResolver(),
-        });
+        const analyzer = Analyzer.forDirectory(basedir);
         const _package = await analyzer.analyzePackage();
         const metadata = generateAnalysis(_package, '');
         // The fixture only contains external elements
@@ -110,10 +105,7 @@ suite('generate-analysis', () => {
 
       test('includes package features', async () => {
         const basedir = path.resolve(fixturesDir, 'analysis/simple');
-        const analyzer = new Analyzer({
-          urlLoader: new FSUrlLoader(basedir),
-          urlResolver: new PackageUrlResolver(),
-        });
+        const analyzer = Analyzer.forDirectory(basedir);
         const _package = await analyzer.analyzePackage();
         const metadata = generateAnalysis(_package, '');
         assert.equal(metadata.elements && metadata.elements.length, 1);
@@ -193,10 +185,7 @@ function* walkRecursively(dir: string): Iterable<string> {
 }
 
 async function analyzeDir(baseDir: string): Promise<AnalysisResult> {
-  const analyzer = new Analyzer({
-    urlLoader: new FSUrlLoader(baseDir),
-    urlResolver: new PackageUrlResolver(),
-  });
+  const analyzer = Analyzer.forDirectory(baseDir);
   const allFilenames = Array.from(walkRecursively(baseDir));
   const htmlOrJsFilenames =
       allFilenames.filter((f) => f.endsWith('.html') || f.endsWith('.js'));

--- a/src/test/analysis-format/generate-analysis_test.ts
+++ b/src/test/analysis-format/generate-analysis_test.ts
@@ -96,7 +96,7 @@ suite('generate-analysis', () => {
     suite('generates from package', () => {
       test('does not include external features', async () => {
         const basedir = path.resolve(fixturesDir, 'analysis/bower_packages');
-        const analyzer = Analyzer.forDirectory(basedir);
+        const analyzer = Analyzer.createForDirectory(basedir);
         const _package = await analyzer.analyzePackage();
         const metadata = generateAnalysis(_package, '');
         // The fixture only contains external elements
@@ -105,7 +105,7 @@ suite('generate-analysis', () => {
 
       test('includes package features', async () => {
         const basedir = path.resolve(fixturesDir, 'analysis/simple');
-        const analyzer = Analyzer.forDirectory(basedir);
+        const analyzer = Analyzer.createForDirectory(basedir);
         const _package = await analyzer.analyzePackage();
         const metadata = generateAnalysis(_package, '');
         assert.equal(metadata.elements && metadata.elements.length, 1);
@@ -185,7 +185,7 @@ function* walkRecursively(dir: string): Iterable<string> {
 }
 
 async function analyzeDir(baseDir: string): Promise<AnalysisResult> {
-  const analyzer = Analyzer.forDirectory(baseDir);
+  const analyzer = Analyzer.createForDirectory(baseDir);
   const allFilenames = Array.from(walkRecursively(baseDir));
   const htmlOrJsFilenames =
       allFilenames.filter((f) => f.endsWith('.html') || f.endsWith('.js'));

--- a/src/test/core/dependency-graph_test.ts
+++ b/src/test/core/dependency-graph_test.ts
@@ -68,7 +68,7 @@ suite('DependencyGraph', () => {
   suite('as used in the Analyzer', () => {
     let analyzer: Analyzer;
     setup(() => {
-      analyzer = Analyzer.forDirectory(path.join(__dirname, '..', 'static'));
+      analyzer = Analyzer.createForDirectory(path.join(__dirname, '..', 'static'));
     });
 
     async function assertImportersOf(

--- a/src/test/core/dependency-graph_test.ts
+++ b/src/test/core/dependency-graph_test.ts
@@ -19,7 +19,6 @@ import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {DependencyGraph} from '../../core/dependency-graph';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 
 import chaiAsPromised = require('chai-as-promised');
 import {ResolvedUrl} from '../../model/url';
@@ -69,8 +68,7 @@ suite('DependencyGraph', () => {
   suite('as used in the Analyzer', () => {
     let analyzer: Analyzer;
     setup(() => {
-      analyzer = new Analyzer(
-          {urlLoader: new FSUrlLoader(path.join(__dirname, '..', 'static'))});
+      analyzer = Analyzer.forDirectory(path.join(__dirname, '..', 'static'));
     });
 
     async function assertImportersOf(

--- a/src/test/css/css-custom-property-scanner_test.ts
+++ b/src/test/css/css-custom-property-scanner_test.ts
@@ -26,7 +26,7 @@ suite('CssCustomPropertyScanner', () => {
   let underliner: CodeUnderliner;
 
   setup(() => {
-    analyzer = Analyzer.forDirectory(testDir);
+    analyzer = Analyzer.createForDirectory(testDir);
     underliner = new CodeUnderliner(analyzer);
   });
 

--- a/src/test/css/css-custom-property-scanner_test.ts
+++ b/src/test/css/css-custom-property-scanner_test.ts
@@ -16,7 +16,6 @@ import {assert} from 'chai';
 import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 
 import {CodeUnderliner} from '../test-utils';
 
@@ -27,9 +26,8 @@ suite('CssCustomPropertyScanner', () => {
   let underliner: CodeUnderliner;
 
   setup(() => {
-    const urlLoader = new FSUrlLoader(testDir);
-    analyzer = new Analyzer({urlLoader});
-    underliner = new CodeUnderliner(urlLoader);
+    analyzer = Analyzer.forDirectory(testDir);
+    underliner = new CodeUnderliner(analyzer);
   });
 
   test('finds custom property assignments', async () => {

--- a/src/test/html/html-document_test.ts
+++ b/src/test/html/html-document_test.ts
@@ -30,7 +30,7 @@ suite('ParsedHtmlDocument', () => {
   const basedir = path.join(__dirname, '../static/');
   const file = fs.readFileSync(path.join(basedir, `${url}`), 'utf8');
   const document: ParsedHtmlDocument = parser.parse(file, url);
-  const analyzer = Analyzer.forDirectory(basedir);
+  const analyzer = Analyzer.createForDirectory(basedir);
   const underliner = new CodeUnderliner(analyzer);
 
   suite('sourceRangeForNode()', () => {

--- a/src/test/html/html-document_test.ts
+++ b/src/test/html/html-document_test.ts
@@ -22,7 +22,6 @@ import {Analyzer} from '../../core/analyzer';
 import {ParsedHtmlDocument} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {ResolvedUrl} from '../../model/url';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {CodeUnderliner} from '../test-utils';
 
 suite('ParsedHtmlDocument', () => {
@@ -31,9 +30,8 @@ suite('ParsedHtmlDocument', () => {
   const basedir = path.join(__dirname, '../static/');
   const file = fs.readFileSync(path.join(basedir, `${url}`), 'utf8');
   const document: ParsedHtmlDocument = parser.parse(file, url);
-  const urlLoader = new FSUrlLoader(basedir);
-  const analyzer = new Analyzer({urlLoader});
-  const underliner = new CodeUnderliner(urlLoader);
+  const analyzer = Analyzer.forDirectory(basedir);
+  const underliner = new CodeUnderliner(analyzer);
 
   suite('sourceRangeForNode()', () => {
     test('works for comments', async () => {

--- a/src/test/html/html-import-scanner_test.ts
+++ b/src/test/html/html-import-scanner_test.ts
@@ -14,103 +14,84 @@
 
 import {assert} from 'chai';
 
-import {HtmlVisitor} from '../../html/html-document';
 import {HtmlImportScanner} from '../../html/html-import-scanner';
-import {HtmlParser} from '../../html/html-parser';
+import {ScannedImport} from '../../index';
 import {PackageRelativeUrl, ResolvedUrl} from '../../model/url';
+import {runScannerOnContents} from '../test-utils';
 
 suite('HtmlImportScanner', () => {
-  suite('scan()', () => {
-    let scanner: HtmlImportScanner;
-
-    setup(() => {
-      scanner = new HtmlImportScanner();
-    });
-
-    test('finds HTML Imports', async () => {
-      const contents = `<html><head>
+  test('finds HTML Imports', async () => {
+    const contents = `<html><head>
           <link rel="import" href="polymer.html">
           <link rel="import" type="css" href="polymer.css">
           <script src="foo.js"></script>
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+    const {features} = await runScannerOnContents(
+        new HtmlImportScanner(), 'test.html', contents);
+    const importFeatures = features as ScannedImport[];
+    assert.deepEqual(
+        importFeatures.map((imp) => [imp.type, imp.url]),
+        [['html-import', 'polymer.html']]);
+  });
 
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 1);
-      assert.equal(features[0].type, 'html-import');
-      assert.equal(features[0].url, 'polymer.html');
-    });
-
-    test('resolves HTML Import URLs relative to baseUrl', async () => {
-      const contents = `<html><head><base href="/aybabtu/">
+  test('resolves HTML Import URLs relative to baseUrl', async () => {
+    const contents = `<html><head><base href="/aybabtu/">
           <link rel="import" href="polymer.html">
           <link rel="import" type="css" href="polymer.css">
           <script src="foo.js"></script>
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+    const {features} = await runScannerOnContents(
+        new HtmlImportScanner(), 'test.html', contents);
+    const importFeatures = features as ScannedImport[];
+    assert.deepEqual(
+        importFeatures.map((imp) => [imp.type, imp.url]),
+        [['html-import', '/aybabtu/polymer.html']]);
+  });
 
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 1);
-      assert.equal(features[0].type, 'html-import');
-      assert.equal(features[0].url, '/aybabtu/polymer.html');
-    });
-
-    test('finds lazy HTML Imports', async () => {
-      const contents = `<html><head>
+  test('finds lazy HTML Imports', async () => {
+    const contents = `<html><head>
           <link rel="import" href="polymer.html">
           <dom-module>
           <link rel="lazy-import"  href="lazy-polymer.html">
           </dom-module>
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
-
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 2);
-      assert.equal(features[1].type, 'html-import');
-      assert.equal(features[1].url, 'lazy-polymer.html');
-      assert.equal(features[1].lazy, true);
-    });
+    const {features} = await runScannerOnContents(
+        new HtmlImportScanner(), 'test.html', contents);
+    const importFeatures = features as ScannedImport[];
+    assert.deepEqual(
+        importFeatures.map((imp) => [imp.type, imp.url, imp.lazy]), [
+          ['html-import', 'polymer.html', false],
+          ['html-import', 'lazy-polymer.html', true]
+        ]);
   });
+});
 
-  suite('scan() with lazy import map', () => {
-    let scanner: HtmlImportScanner;
-
-    setup(() => {
-      const lazyEdges = new Map<ResolvedUrl, PackageRelativeUrl[]>();
-      lazyEdges.set(
-          'test.html' as ResolvedUrl,
-          ['lazy1.html', 'lazy2.html', 'lazy3.html'] as PackageRelativeUrl[]);
-      scanner = new HtmlImportScanner(lazyEdges);
-    });
-
-    test('injects synthetic lazy html imports', async () => {
-      const contents = `<html><head>
+suite('scan() with lazy import map', () => {
+  test('injects synthetic lazy html imports', async () => {
+    const contents = `<html><head>
           <link rel="import" href="polymer.html">
           <link rel="import" type="css" href="polymer.css">
           <script src="foo.js"></script>
           <link rel="stylesheet" href="foo.css"></link>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+    const lazyEdges = new Map<ResolvedUrl, PackageRelativeUrl[]>([[
+      'test.html' as ResolvedUrl,
+      ['lazy1.html', 'lazy2.html', 'lazy3.html'] as PackageRelativeUrl[]
+    ]]);
 
-      const {features} = await scanner.scan(document, visit);
-      assert.deepEqual(
-          features.map((f) => f.type),
-          ['html-import', 'html-import', 'html-import', 'html-import']);
-      assert.deepEqual(features.map((i) => i.lazy), [false, true, true, true]);
-      assert.deepEqual(
-          features.map((f) => f.url),
-          ['polymer.html', 'lazy1.html', 'lazy2.html', 'lazy3.html']);
-    });
+    const {features} = await runScannerOnContents(
+        new HtmlImportScanner(lazyEdges), 'test.html', contents);
+    const importFeatures = features as ScannedImport[];
+    assert.deepEqual(
+        importFeatures.map((f) => f.type),
+        ['html-import', 'html-import', 'html-import', 'html-import']);
+    assert.deepEqual(
+        importFeatures.map((i) => i.lazy), [false, true, true, true]);
+    assert.deepEqual(
+        importFeatures.map((f) => f.url),
+        ['polymer.html', 'lazy1.html', 'lazy2.html', 'lazy3.html']);
   });
 });

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -59,7 +59,7 @@ suite('HtmlScriptScanner', () => {
   });
 
   suite('modules', () => {
-    const analyzer = Analyzer.forDirectory(fixturesDir);
+    const analyzer = Analyzer.createForDirectory(fixturesDir);
     let analysis: Analysis;
 
     before(async () => {

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -16,111 +16,94 @@ import {assert} from 'chai';
 import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
-import {HtmlVisitor} from '../../html/html-document';
-import {HtmlParser} from '../../html/html-parser';
 import {HtmlScriptScanner} from '../../html/html-script-scanner';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {Analysis} from '../../model/analysis';
 import {ScannedImport, ScannedInlineDocument} from '../../model/model';
-import {ResolvedUrl} from '../../model/url';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {runScannerOnContents} from '../test-utils';
 
 const fixturesDir = path.resolve(__dirname, '../static');
 suite('HtmlScriptScanner', () => {
-  suite('scan()', () => {
-    let scanner: HtmlScriptScanner;
-
-    setup(() => {
-      scanner = new HtmlScriptScanner();
-    });
-
-    test('finds external and inline scripts', async () => {
-      const contents = `<html><head>
+  test('finds external and inline scripts', async () => {
+    const contents = `<html><head>
           <script src="foo.js"></script>
           <script>console.log('hi')</script>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+    const {features} = await runScannerOnContents(
+        new HtmlScriptScanner(), 'test-document.html', contents);
 
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 2);
-      assert.instanceOf(features[0], ScannedImport);
-      const feature0 = features[0] as ScannedImport;
-      assert.equal(feature0.type, 'html-script');
-      assert.equal(feature0.url, 'foo.js');
-      assert.instanceOf(features[1], ScannedInlineDocument);
-      const feature1 = features[1] as ScannedInlineDocument;
-      assert.equal(feature1.type, 'js');
-      assert.equal(feature1.contents, `console.log('hi')`);
-      assert.deepEqual(feature1.locationOffset, {line: 2, col: 18});
-    });
+    assert.equal(features.length, 2);
+    assert.instanceOf(features[0], ScannedImport);
+    const feature0 = features[0] as ScannedImport;
+    assert.equal(feature0.type, 'html-script');
+    assert.equal(feature0.url, 'foo.js');
+    assert.instanceOf(features[1], ScannedInlineDocument);
+    const feature1 = features[1] as ScannedInlineDocument;
+    assert.equal(feature1.type, 'js');
+    assert.equal(feature1.contents, `console.log('hi')`);
+    assert.deepEqual(feature1.locationOffset, {line: 2, col: 18});
+  });
 
-    test('finds external scripts relative to baseUrl', async () => {
-      const contents = `<html><head><base href="/aybabtu/">
+  test('finds external scripts relative to baseUrl', async () => {
+    const contents = `<html><head><base href="/aybabtu/">
           <script src="foo.js"></script>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
+    const {features} = await runScannerOnContents(
+        new HtmlScriptScanner(), 'test-document.html', contents);
 
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 1);
-      assert.instanceOf(features[0], ScannedImport);
-      const feature0 = features[0] as ScannedImport;
-      assert.equal(feature0.type, 'html-script');
-      assert.equal(feature0.url, '/aybabtu/foo.js');
+    assert.equal(features.length, 1);
+    assert.instanceOf(features[0], ScannedImport);
+    const feature0 = features[0] as ScannedImport;
+    assert.equal(feature0.type, 'html-script');
+    assert.equal(feature0.url, '/aybabtu/foo.js');
+  });
+
+  suite('modules', () => {
+    const analyzer = Analyzer.forDirectory(fixturesDir);
+    let analysis: Analysis;
+
+    before(async () => {
+      analysis = await analyzer.analyze(['js-modules.html']);
     });
 
-    suite('modules', () => {
-      const urlLoader = new FSUrlLoader(fixturesDir);
-      const analyzer = new Analyzer({urlLoader});
-      let analysis: Analysis;
+    test('finds external module scripts', () => {
+      const htmlScripts = [...analysis.getFeatures({kind: 'html-script'})];
+      assert.equal(htmlScripts.length, 1);
+      const js = htmlScripts[0].document.parsedDocument as JavaScriptDocument;
+      assert.equal(js.url, 'javascript/module.js');
+      assert.equal(js.parsedAsSourceType, 'module');
+      assert.equal(
+          js.contents.trim(), `import * as submodule from './submodule.js';`);
+    });
 
-      before(async () => {
-        analysis = await analyzer.analyze(['js-modules.html']);
-      });
+    test('finds inline module scripts', () => {
+      const inlineDocuments =
+          [...analysis.getFeatures({kind: 'inline-document'})];
+      assert.equal(inlineDocuments.length, 1);
+      const js = inlineDocuments[0].parsedDocument as JavaScriptDocument;
+      assert.equal(js.url, 'js-modules.html');
+      assert.equal(js.parsedAsSourceType, 'module');
+      assert.equal(
+          js.contents.trim(),
+          `import * as something from './javascript/module-with-export.js';`);
+    });
 
-      test('finds external module scripts', () => {
-        const htmlScripts = [...analysis.getFeatures({kind: 'html-script'})];
-        assert.equal(htmlScripts.length, 1);
-        const js = htmlScripts[0].document.parsedDocument as JavaScriptDocument;
-        assert.equal(js.url, 'javascript/module.js');
-        assert.equal(js.parsedAsSourceType, 'module');
-        assert.equal(
-            js.contents.trim(), `import * as submodule from './submodule.js';`);
-      });
+    test('follows import statements in modules', async () => {
+      const jsImports = [...analysis.getFeatures({kind: 'js-import'})];
+      assert.equal(jsImports.length, 2);
 
-      test('finds inline module scripts', () => {
-        const inlineDocuments =
-            [...analysis.getFeatures({kind: 'inline-document'})];
-        assert.equal(inlineDocuments.length, 1);
-        const js = inlineDocuments[0].parsedDocument as JavaScriptDocument;
-        assert.equal(js.url, 'js-modules.html');
-        assert.equal(js.parsedAsSourceType, 'module');
-        assert.equal(
-            js.contents.trim(),
-            `import * as something from './javascript/module-with-export.js';`);
-      });
+      // import statement in inline module script in 'js-modules.html'
+      const js0 = jsImports[0].document.parsedDocument as JavaScriptDocument;
+      assert.equal(js0.url, 'javascript/module-with-export.js');
+      assert.equal(js0.parsedAsSourceType, 'module');
+      assert.equal(
+          js0.contents.trim(), `export const someValue = 'value goes here';`);
 
-      test('follows import statements in modules', async () => {
-        const jsImports = [...analysis.getFeatures({kind: 'js-import'})];
-        assert.equal(jsImports.length, 2);
-
-        // import statement in inline module script in 'js-modules.html'
-        const js0 = jsImports[0].document.parsedDocument as JavaScriptDocument;
-        assert.equal(js0.url, 'javascript/module-with-export.js');
-        assert.equal(js0.parsedAsSourceType, 'module');
-        assert.equal(
-            js0.contents.trim(), `export const someValue = 'value goes here';`);
-
-        // import statement in external module script 'javascript/module.js'
-        const js1 = jsImports[1].document.parsedDocument as JavaScriptDocument;
-        assert.equal(js1.url, 'javascript/submodule.js');
-        assert.equal(js1.parsedAsSourceType, 'module');
-        assert.equal(
-            js1.contents.trim(), `export const subThing = 'sub-thing';`);
-      });
+      // import statement in external module script 'javascript/module.js'
+      const js1 = jsImports[1].document.parsedDocument as JavaScriptDocument;
+      assert.equal(js1.url, 'javascript/submodule.js');
+      assert.equal(js1.parsedAsSourceType, 'module');
+      assert.equal(js1.contents.trim(), `export const subThing = 'sub-thing';`);
     });
   });
 });

--- a/src/test/html/html-style-scanner_test.ts
+++ b/src/test/html/html-style-scanner_test.ts
@@ -14,56 +14,42 @@
 
 import {assert} from 'chai';
 
-import {HtmlVisitor} from '../../html/html-document';
-import {HtmlParser} from '../../html/html-parser';
 import {HtmlStyleScanner} from '../../html/html-style-scanner';
 import {ScannedImport, ScannedInlineDocument} from '../../model/model';
-import {ResolvedUrl} from '../../model/url';
+import {runScannerOnContents} from '../test-utils';
 
 suite('HtmlStyleScanner', () => {
-  suite('scan()', () => {
-    let scanner: HtmlStyleScanner;
-
-    setup(() => {
-      scanner = new HtmlStyleScanner();
-    });
-
-    test('finds external and inline styles', async () => {
-      const contents = `<html><head>
+  test('finds external and inline styles', async () => {
+    const contents = `<html><head>
           <link rel="stylesheet" type="text/css" href="foo.css">
           <style>h1 { color: green; }</style>
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 2);
-      assert.instanceOf(features[0], ScannedImport);
-      const feature0 = <ScannedImport>features[0];
-      assert.equal(feature0.type, 'html-style');
-      assert.equal(feature0.url, 'foo.css');
-      assert.instanceOf(features[1], ScannedInlineDocument);
-      const feature1 = <ScannedInlineDocument>features[1];
-      assert.equal(feature1.type, 'css');
-      assert.equal(feature1.contents, `h1 { color: green; }`);
-      assert.deepEqual(feature1.locationOffset, {line: 2, col: 17});
-    });
+    const {features} = await runScannerOnContents(
+        new HtmlStyleScanner(), 'test-document.html', contents);
+    assert.equal(features.length, 2);
+    assert.instanceOf(features[0], ScannedImport);
+    const feature0 = <ScannedImport>features[0];
+    assert.equal(feature0.type, 'html-style');
+    assert.equal(feature0.url, 'foo.css');
+    assert.instanceOf(features[1], ScannedInlineDocument);
+    const feature1 = <ScannedInlineDocument>features[1];
+    assert.equal(feature1.type, 'css');
+    assert.equal(feature1.contents, `h1 { color: green; }`);
+    assert.deepEqual(feature1.locationOffset, {line: 2, col: 17});
+  });
 
-    test('finds external styles relative to baseUrl', async () => {
-      const contents = `<html><head><base href="/aybabtu/">
+  test('finds external styles relative to baseUrl', async () => {
+    const contents = `<html><head><base href="/aybabtu/">
           <link rel="stylesheet" type="text/css" href="foo.css">
         </head></html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
 
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 1);
-      assert.instanceOf(features[0], ScannedImport);
-      const feature0 = <ScannedImport>features[0];
-      assert.equal(feature0.type, 'html-style');
-      assert.equal(feature0.url, '/aybabtu/foo.css');
-    });
+    const {features} = await runScannerOnContents(
+        new HtmlStyleScanner(), 'test-document.html', contents);
+    assert.equal(features.length, 1);
+    assert.instanceOf(features[0], ScannedImport);
+    const feature0 = <ScannedImport>features[0];
+    assert.equal(feature0.type, 'html-style');
+    assert.equal(feature0.url, '/aybabtu/foo.css');
   });
 });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -22,7 +22,7 @@ import {Class, Element, ElementMixin, Method, ScannedClass} from '../../model/mo
 import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('Class', () => {
-  const analyzer = Analyzer.forDirectory(path.resolve(__dirname, '../static'));
+  const analyzer = Analyzer.createForDirectory(path.resolve(__dirname, '../static'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedFeatures(filename: string) {

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -18,28 +18,15 @@ import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {Class, Element, ElementMixin, Method, ScannedClass} from '../../model/model';
-import {ResolvedUrl} from '../../model/url';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
-const fixturesDir = path.resolve(__dirname, '../static');
 suite('Class', () => {
-  const urlLoader = new FSUrlLoader(fixturesDir);
-  const underliner = new CodeUnderliner(urlLoader);
-  const analyzer = new Analyzer({urlLoader});
+  const analyzer = Analyzer.forDirectory(path.resolve(__dirname, '../static'));
+  const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedFeatures(filename: string) {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new ClassScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
+    const {features} = await runScanner(analyzer, new ClassScanner(), filename);
     return features;
   };
 
@@ -320,7 +307,7 @@ suite('Class', () => {
 
       // Ensures no duplicates
       assert.deepEqual(
-          scannedFeatures.map((f) => f.name),
+          scannedFeatures.map((f) => (f as any).name),
           ['Element', 'AnnotatedElement', 'Mixin', 'AnnotatedMixin']);
 
       // Ensures we get the more specific types

--- a/src/test/javascript/function-scanner_test.ts
+++ b/src/test/javascript/function-scanner_test.ts
@@ -23,7 +23,7 @@ import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('FunctionScanner', () => {
   const testFilesDir = path.resolve(__dirname, '../static/namespaces/');
-  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 
   async function getNamespaceFunctions(filename: string) {

--- a/src/test/javascript/function-scanner_test.ts
+++ b/src/test/javascript/function-scanner_test.ts
@@ -16,30 +16,26 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
-import {Visitor} from '../../javascript/estree-visitor';
+import {Analyzer} from '../../core/analyzer';
 import {ScannedFunction} from '../../javascript/function';
 import {FunctionScanner} from '../../javascript/function-scanner';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('FunctionScanner', () => {
   const testFilesDir = path.resolve(__dirname, '../static/namespaces/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const underliner = new CodeUnderliner(urlLoader);
+  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const underliner = new CodeUnderliner(analyzer);
 
-  async function getNamespaceFunctions(filename: string):
-      Promise<ScannedFunction[]> {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new FunctionScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-    const {features} = await scanner.scan(document, visit);
-    return <ScannedFunction[]>features.filter(
-        (e) => e instanceof ScannedFunction);
+  async function getNamespaceFunctions(filename: string) {
+    const {features} =
+        await runScanner(analyzer, new FunctionScanner(), filename);
+    const scannedFunctions = [];
+    for (const feature of features) {
+      if (feature instanceof ScannedFunction) {
+        scannedFunctions.push(feature);
+      }
+    }
+    return scannedFunctions;
   };
 
 

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -14,69 +14,48 @@
 
 
 import {assert} from 'chai';
-import * as fs from 'fs';
 import * as path from 'path';
 
-import {Visitor} from '../../javascript/estree-visitor';
+import {Analyzer} from '../../core/analyzer';
 import {JavaScriptImportScanner} from '../../javascript/javascript-import-scanner';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
+import {runScanner} from '../test-utils';
 
 suite('JavaScriptImportScanner', () => {
-  const parser = new JavaScriptParser();
-  const scanner = new JavaScriptImportScanner();
+  const analyzer = Analyzer.forDirectory(path.resolve(__dirname, '../static'));
 
   test('finds imports', async () => {
-    const file = fs.readFileSync(
-        path.resolve(__dirname, '../static/javascript/module.js'), 'utf8');
-    const document =
-        parser.parse(file, '/static/javascript/module.js' as ResolvedUrl);
-
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
+    const {features} = await runScanner(
+        analyzer, new JavaScriptImportScanner(), 'javascript/module.js');
     assert.containSubset(features, [
       {
         type: 'js-import',
-        url: '/static/javascript/submodule.js',
+        url: 'javascript/submodule.js',
         lazy: false,
       },
     ]);
   });
 
   test('finds dynamic imports', async () => {
-    const file = fs.readFileSync(
-        path.resolve(__dirname, '../static/javascript/dynamic-import.js'),
-        'utf8');
-    const document = parser.parse(
-        file, '/static/javascript/dynamic-import.js' as ResolvedUrl);
+    const {features} = await runScanner(
+        analyzer,
+        new JavaScriptImportScanner(),
+        'javascript/dynamic-import.js');
 
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
     assert.containSubset(features, [
       {
         type: 'js-import',
-        url: '/static/javascript/submodule.js',
+        url: 'javascript/submodule.js',
         lazy: true,
       },
     ]);
   });
 
   test('skips non-path imports', async () => {
-    const file = fs.readFileSync(
-        path.resolve(
-            __dirname, '../static/javascript/module-with-named-import.js'),
-        'utf8');
-    const document = parser.parse(
-        file, '/static/javascript/module-with-named-import.js' as ResolvedUrl);
+    const {features} = await runScanner(
+        analyzer,
+        new JavaScriptImportScanner(),
+        'javascript/module-with-named-import.js');
 
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
     assert.equal(features.length, 0);
   });
 });

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -21,7 +21,7 @@ import {JavaScriptImportScanner} from '../../javascript/javascript-import-scanne
 import {runScanner} from '../test-utils';
 
 suite('JavaScriptImportScanner', () => {
-  const analyzer = Analyzer.forDirectory(path.resolve(__dirname, '../static'));
+  const analyzer = Analyzer.createForDirectory(path.resolve(__dirname, '../static'));
 
   test('finds imports', async () => {
     const {features} = await runScanner(

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -16,29 +16,26 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
+import {Analyzer} from '../../core/analyzer';
 import {ScannedNamespace} from '../../javascript/namespace';
 import {NamespaceScanner} from '../../javascript/namespace-scanner';
-import {ResolvedUrl} from '../../model/url';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('NamespaceScanner', () => {
   const testFilesDir = path.resolve(__dirname, '../static/namespaces/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const underliner = new CodeUnderliner(urlLoader);
+  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const underliner = new CodeUnderliner(analyzer);
 
-  async function getNamespaces(filename: string): Promise<any[]> {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new NamespaceScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-    const {features} = await scanner.scan(document, visit);
-    return <ScannedNamespace[]>features.filter(
-        (e) => e instanceof ScannedNamespace);
+  async function getNamespaces(filename: string) {
+    const {features} =
+        await runScanner(analyzer, new NamespaceScanner(), filename);
+    const scannedNamespaces = [];
+    for (const feature of features) {
+      if (feature instanceof ScannedNamespace) {
+        scannedNamespaces.push(feature);
+      }
+    }
+    return scannedNamespaces;
   };
 
   test('scans named namespaces', async () => {

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -23,7 +23,7 @@ import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('NamespaceScanner', () => {
   const testFilesDir = path.resolve(__dirname, '../static/namespaces/');
-  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 
   async function getNamespaces(filename: string) {

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -27,7 +27,7 @@ suite('BehaviorScanner', () => {
 
   suiteSetup(async () => {
     const {features} = await runScanner(
-        Analyzer.forDirectory(path.resolve(__dirname, '../static')),
+        Analyzer.createForDirectory(path.resolve(__dirname, '../static')),
         new BehaviorScanner(),
         'js-behaviors.js');
     behaviors = new Map();

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -14,31 +14,22 @@
 
 
 import {assert} from 'chai';
-import * as fs from 'fs';
 import * as path from 'path';
 
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptDocument} from '../../javascript/javascript-document';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
+import {Analyzer} from '../../core/analyzer';
 import {ScannedBehavior, ScannedBehaviorAssignment} from '../../polymer/behavior';
 import {BehaviorScanner} from '../../polymer/behavior-scanner';
+import {runScanner} from '../test-utils';
 
 suite('BehaviorScanner', () => {
-  let document: JavaScriptDocument;
   let behaviors: Map<string, ScannedBehavior>;
   let behaviorsList: ScannedBehavior[];
 
   suiteSetup(async () => {
-    const parser = new JavaScriptParser();
-    const file = fs.readFileSync(
-        path.resolve(__dirname, '../static/js-behaviors.js'), 'utf8');
-    document = parser.parse(file, '/static/js-behaviors.js' as ResolvedUrl);
-    const scanner = new BehaviorScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
+    const {features} = await runScanner(
+        Analyzer.forDirectory(path.resolve(__dirname, '../static')),
+        new BehaviorScanner(),
+        'js-behaviors.js');
     behaviors = new Map();
     behaviorsList =
         <ScannedBehavior[]>features.filter((e) => e instanceof ScannedBehavior);

--- a/src/test/polymer/polymer-core-feature_test.ts
+++ b/src/test/polymer/polymer-core-feature_test.ts
@@ -16,11 +16,9 @@ import {assert} from 'chai';
 import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
+import {ScannedPolymerCoreFeature} from '../../polymer/polymer-core-feature';
 import {PolymerCoreFeatureScanner} from '../../polymer/polymer-core-feature-scanner';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
+import {runScannerOnContents} from '../test-utils';
 
 suite('PolymerCoreFeatureScanner', () => {
   test('scans _addFeature calls and the Polymer.Base assignment', async () => {
@@ -53,11 +51,9 @@ suite('PolymerCoreFeatureScanner', () => {
       });
     `;
 
-    const parser = new JavaScriptParser();
-    const scanner = new PolymerCoreFeatureScanner();
-    const doc = parser.parse(js, 'features.js' as ResolvedUrl);
-    const visit = (visitor: Visitor) => Promise.resolve(doc.visit([visitor]));
-    const {features} = await scanner.scan(doc, visit);
+    const {features: untypedFeatures} = await runScannerOnContents(
+        new PolymerCoreFeatureScanner(), 'features.js', js);
+    const features = untypedFeatures as ScannedPolymerCoreFeature[];
 
     assert.lengthOf(features, 4);
     const [a, b, base, invalid] = features;
@@ -116,11 +112,9 @@ suite('PolymerCoreFeatureScanner', () => {
   });
 
   test('resolves the Polymer.Base class', async () => {
-    const analyzer = new Analyzer({
-      urlLoader: new FSUrlLoader(
-          // This directory contains files copied from Polymer 1.x core.
-          path.resolve(__dirname, '../static/polymer-core-feature/')),
-    });
+    // This directory contains files copied from Polymer 1.x core.
+    const analyzer = Analyzer.forDirectory(
+        path.resolve(__dirname, '../static/polymer-core-feature/'));
 
     const analysis = await analyzer.analyzePackage();
     const features = analysis.getFeatures({id: 'Polymer.Base', kind: 'class'});

--- a/src/test/polymer/polymer-core-feature_test.ts
+++ b/src/test/polymer/polymer-core-feature_test.ts
@@ -113,7 +113,7 @@ suite('PolymerCoreFeatureScanner', () => {
 
   test('resolves the Polymer.Base class', async () => {
     // This directory contains files copied from Polymer 1.x core.
-    const analyzer = Analyzer.forDirectory(
+    const analyzer = Analyzer.createForDirectory(
         path.resolve(__dirname, '../static/polymer-core-feature/'));
 
     const analysis = await analyzer.analyzePackage();

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -16,22 +16,13 @@
 
 import {assert} from 'chai';
 
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
+import {ScannedPolymerElement} from '../../polymer/polymer-element';
 import {PolymerElementScanner} from '../../polymer/polymer-element-scanner';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScannerOnContents} from '../test-utils';
 
 suite('PolymerElementScanner', () => {
-  suite('scan()', () => {
-    let scanner: PolymerElementScanner;
-
-    setup(() => {
-      scanner = new PolymerElementScanner();
-    });
-
-    test('finds polymer elements', async () => {
-      const contents = `Polymer({
+  test('finds polymer elements', async () => {
+    const contents = `Polymer({
         is: 'x-foo',
         properties: {
           a: {
@@ -101,160 +92,154 @@ suite('PolymerElementScanner', () => {
         listeners: []
       });`;
 
-      const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: Visitor) => document.visit([visitor]);
+    const {features: untypedFeatures} = await runScannerOnContents(
+        new PolymerElementScanner(), 'test-file.js', contents);
+    const features = untypedFeatures as ScannedPolymerElement[];
 
-      const {features} = await scanner.scan(document, visit);
+    assert.deepEqual(features.map((f) => f.tagName), ['x-foo', 'x-bar']);
 
-      assert.deepEqual(features.map((f) => f.tagName), ['x-foo', 'x-bar']);
+    assert.deepEqual(
+        features[0].observers.map((o) => o.expression),
+        ['_anObserver(foo, bar)', '_anotherObserver(foo)']);
+    assert.deepEqual(
+        features[0].observers.map(
+            (o) => o.parsedExpression!.properties.map((p) => p.name)),
+        [['_anObserver', 'foo', 'bar'], ['_anotherObserver', 'foo']]);
+    const properties = Array.from(features[0].properties.values());
+    assert.deepEqual(
+        properties.filter((p) => p.observerExpression)
+            .map(
+                (p) =>
+                    [p.name,
+                     p.observerExpression!.properties.map((sp) => sp.name)]),
+        [['f', ['_observeF']], ['all', ['_observeAll']]]);
 
-      assert.deepEqual(
-          features[0].observers.map((o) => o.expression),
-          ['_anObserver(foo, bar)', '_anotherObserver(foo)']);
-      assert.deepEqual(
-          features[0].observers.map(
-              (o) => o.parsedExpression!.properties.map((p) => p.name)),
-          [['_anObserver', 'foo', 'bar'], ['_anotherObserver', 'foo']]);
-      const properties = Array.from(features[0].properties.values());
-      assert.deepEqual(
-          properties.filter((p) => p.observerExpression)
-              .map(
-                  (p) =>
-                      [p.name,
-                       p.observerExpression!.properties.map((sp) => sp.name)]),
-          [['f', ['_observeF']], ['all', ['_observeAll']]]);
+    assert.deepEqual(
+        properties.filter((p) => p.computedExpression)
+            .map(
+                (p) =>
+                    [p.name,
+                     p.computedExpression!.properties.map((sp) => sp.name)]),
+        [['d', ['_computeD', 'c']], ['g', ['_computeG', 'a', 'b']]]);
 
-      assert.deepEqual(
-          properties.filter((p) => p.computedExpression)
-              .map(
-                  (p) =>
-                      [p.name,
-                       p.computedExpression!.properties.map((sp) => sp.name)]),
-          [['d', ['_computeD', 'c']], ['g', ['_computeG', 'a', 'b']]]);
+    assert.deepEqual(
+        Array.from(features[0].events.values()).map((e) => e.name),
+        ['e-changed', 'all-changed']);
 
-      assert.deepEqual(
-          Array.from(features[0].events.values()).map((e) => e.name),
-          ['e-changed', 'all-changed']);
+    assert.equal(properties.length, 9);
 
-      assert.equal(properties.length, 9);
-
-      assert.deepEqual(
-          properties.filter((p) => p.warnings.length > 0)
-              .map((p) => [p.name, p.warnings.map((w) => w.message)]),
-          [[
-            'g',
-            [
-              'Invalid type in property object.',
-              'Unable to determine type for property.'
-            ]
-          ]]);
-      const methods = Array.from(features[0].methods.values());
-      assert.deepEqual(methods.map((m) => m.name), [
-        'customPublicMethod',
-        '_customPrivateMethod',
-        'customPublicMethodWithJsDoc',
-        'customPublicMethodWithClassicFunction',
-        'shorthandMethod',
-      ]);
-
-      const jsDocMethod =
-          features[0].methods.get('customPublicMethodWithJsDoc')!;
-
-      assert.deepEqual(jsDocMethod.return !, {
-        type: 'boolean',
-        desc: 'The return.',
-      });
-
-      assert.deepEqual(
-          jsDocMethod.params!.map((p) => [p.name, p.type, p.description]), [
-            ['foo', 'string', 'The first argument.'],
-            ['bar', 'number', 'The second argument.'],
-          ]);
-
-      assert.deepEqual(properties.map((p) => [p.name, p.type]), [
-        ['a', 'boolean'],
-        ['b', 'string'],
-        ['c', 'number'],
-        ['d', 'number'],
-        ['e', 'string'],
-        ['f', 'Object'],
-        ['g', undefined],
-        ['h', 'string'],
-        ['all', 'Object']
-      ]);
-
-      assert.deepEqual(
-          Array.from(features[0].attributes.values())
-              .map((p) => [p.name, p.changeEvent]),
+    assert.deepEqual(
+        properties.filter((p) => p.warnings.length > 0)
+            .map((p) => [p.name, p.warnings.map((w) => w.message)]),
+        [[
+          'g',
           [
-            ['a', undefined],
-            ['b', undefined],
-            ['c', undefined],
-            ['d', undefined],
-            ['e', 'e-changed'],
-            ['f', undefined],
-            ['g', undefined],
-            ['h', undefined],
-            ['all', 'all-changed']
-          ]);
+            'Invalid type in property object.',
+            'Unable to determine type for property.'
+          ]
+        ]]);
+    const methods = Array.from(features[0].methods.values());
+    assert.deepEqual(methods.map((m) => m.name), [
+      'customPublicMethod',
+      '_customPrivateMethod',
+      'customPublicMethodWithJsDoc',
+      'customPublicMethodWithClassicFunction',
+      'shorthandMethod',
+    ]);
 
-      assert.deepEqual(
-          properties.filter((p) => p.readOnly).map((p) => p.name),
-          ['c', 'd', 'g']);
+    const jsDocMethod = features[0].methods.get('customPublicMethodWithJsDoc')!;
 
-      assert.deepEqual(
-          properties.filter((p) => p.default).map((p) => [p.name, p.default]),
-          [['a', '5'], ['b', '"test"']]);
-
-      assert.deepEqual(
-          properties.filter((p) => p.notify).map((p) => p.name), ['e', 'all']);
-
-      assert.deepEqual(features[0].listeners, [
-        {event: 'event-a', handler: '_handleA'},
-        {event: 'eventb', handler: '_handleB'}
-      ]);
-
-      // Skip not statically analizable entries without emitting a warning
-      assert.equal(
-          features[0]
-              .warnings
-              .filter((w) => w.code === 'invalid-listeners-declaration')
-              .length,
-          0);
-      // Emit warning for non-object `listeners` literal
-      assert.equal(
-          features[1]
-              .warnings
-              .filter((w) => w.code === 'invalid-listeners-declaration')
-              .length,
-          1);
+    assert.deepEqual(jsDocMethod.return !, {
+      type: 'boolean',
+      desc: 'The return.',
     });
 
-    test('finds declared and assigned call expressions', async () => {
-      const contents = `
+    assert.deepEqual(
+        jsDocMethod.params!.map((p) => [p.name, p.type, p.description]), [
+          ['foo', 'string', 'The first argument.'],
+          ['bar', 'number', 'The second argument.'],
+        ]);
+
+    assert.deepEqual(properties.map((p) => [p.name, p.type]), [
+      ['a', 'boolean'],
+      ['b', 'string'],
+      ['c', 'number'],
+      ['d', 'number'],
+      ['e', 'string'],
+      ['f', 'Object'],
+      ['g', undefined],
+      ['h', 'string'],
+      ['all', 'Object']
+    ]);
+
+    assert.deepEqual(
+        Array.from(features[0].attributes.values())
+            .map((p) => [p.name, p.changeEvent]),
+        [
+          ['a', undefined],
+          ['b', undefined],
+          ['c', undefined],
+          ['d', undefined],
+          ['e', 'e-changed'],
+          ['f', undefined],
+          ['g', undefined],
+          ['h', undefined],
+          ['all', 'all-changed']
+        ]);
+
+    assert.deepEqual(
+        properties.filter((p) => p.readOnly).map((p) => p.name),
+        ['c', 'd', 'g']);
+
+    assert.deepEqual(
+        properties.filter((p) => p.default).map((p) => [p.name, p.default]),
+        [['a', '5'], ['b', '"test"']]);
+
+    assert.deepEqual(
+        properties.filter((p) => p.notify).map((p) => p.name), ['e', 'all']);
+
+    assert.deepEqual(features[0].listeners, [
+      {event: 'event-a', handler: '_handleA'},
+      {event: 'eventb', handler: '_handleB'}
+    ]);
+
+    // Skip not statically analizable entries without emitting a warning
+    assert.equal(
+        features[0]
+            .warnings.filter((w) => w.code === 'invalid-listeners-declaration')
+            .length,
+        0);
+    // Emit warning for non-object `listeners` literal
+    assert.equal(
+        features[1]
+            .warnings.filter((w) => w.code === 'invalid-listeners-declaration')
+            .length,
+        1);
+  });
+
+  test('finds declared and assigned call expressions', async () => {
+    const contents = `
           const MyOtherElement = Polymer({
             is: 'my-other-element'
           });
 
           window.MyElement = Polymer({is: 'my-element'});
       `;
-      const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: Visitor) => document.visit([visitor]);
+    const {features: untypedFeatures} = await runScannerOnContents(
+        new PolymerElementScanner(), 'test-file.js', contents);
+    const features = untypedFeatures as ScannedPolymerElement[];
 
-      const {features} = await scanner.scan(document, visit);
-      assert.deepEqual(
-          features.map((f) => f.tagName), ['my-other-element', 'my-element']);
-      assert.deepEqual(
-          features.map((f) => f.className),
-          ['MyOtherElement', 'window.MyElement']);
-    });
+    assert.deepEqual(
+        features.map((f) => f.tagName), ['my-other-element', 'my-element']);
+    assert.deepEqual(
+        features.map((f) => f.className),
+        ['MyOtherElement', 'window.MyElement']);
+  });
 
-    const testName =
-        'Produces correct warnings for bad observers and computed properties';
-    test(testName, async () => {
-      const contents = `
+  const testName =
+      'Produces correct warnings for bad observers and computed properties';
+  test(testName, async () => {
+    const contents = `
       Polymer({
         is: 'x-foo',
         properties: {
@@ -281,65 +266,59 @@ suite('PolymerElementScanner', () => {
         }
       });`;
 
-      const underliner =
-          CodeUnderliner.withMapping('test-document.html', contents);
-      const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: Visitor) => document.visit([visitor]);
+    const {features: untypedFeatures, analyzer} = await runScannerOnContents(
+        new PolymerElementScanner(), 'test-file.js', contents);
+    const features = untypedFeatures as ScannedPolymerElement[];
+    const underliner = new CodeUnderliner(analyzer);
 
-      const {features} = await scanner.scan(document, visit);
-      assert.deepEqual(features.length, 1);
-      const element = features[0]!;
-      assert.deepEqual(
-          Array.from(element.properties.keys()),
-          ['parseError', 'badKindOfExpression']);
+    assert.deepEqual(features.length, 1);
+    const element = features[0]!;
+    assert.deepEqual(
+        Array.from(element.properties.keys()),
+        ['parseError', 'badKindOfExpression']);
 
-      assert.deepEqual(
-          await Promise.all(Array.from(element.properties.values())
-                                .map((p) => underliner.underline(p.warnings))),
+    assert.deepEqual(
+        await Promise.all(Array.from(element.properties.values())
+                              .map((p) => underliner.underline(p.warnings))),
+        [
           [
-            [
-              `
+            `
             computed: 'let let let',
                            ~`,
-              `
+            `
             observer: 'let let let',
                            ~`
-            ],
-            [
-              `
+          ],
+          [
+            `
             computed: 'foo',
                        ~~~`,
-              `
+            `
             observer: 'foo(bar, baz)'
                        ~~~~~~~~~~~~~`
-            ]
-          ]);
-      assert.deepEqual(await underliner.underline(element.warnings), [
-        `
+          ]
+        ]);
+    assert.deepEqual(await underliner.underline(element.warnings), [
+      `
           'let let let parseError',
                ~`,
-        `
+      `
           'foo'
            ~~~`
-      ]);
-    });
+    ]);
+  });
 
-    test('Polymer 2 class observers crash', async () => {
-      // When Polymer 2 adopted a static getter for observers, it crashed
-      // the Polymer 1 element scanner.
-      const contents = `class TestElement extends Polymer.Element {
+  test('Polymer 2 class observers crash', async () => {
+    // When Polymer 2 adopted a static getter for observers, it crashed
+    // the Polymer 1 element scanner.
+    const contents = `class TestElement extends Polymer.Element {
         static get observers() {
           return foo.bar;
         }
       }`;
 
-      const document = new JavaScriptParser().parse(
-          contents, 'test-document.html' as ResolvedUrl);
-      const visit = async (visitor: Visitor) => document.visit([visitor]);
-
-      // Scanning should not throw
-      await scanner.scan(document, visit);
-    });
+    // Scanning should not throw
+    await runScannerOnContents(
+        new PolymerElementScanner(), 'test-file.js', contents);
   });
 });

--- a/src/test/polymer/polymer-element_test.ts
+++ b/src/test/polymer/polymer-element_test.ts
@@ -22,7 +22,7 @@ import {PolymerElement} from '../../polymer/polymer-element';
 
 suite('PolymerElement', () => {
   const analyzer =
-      Analyzer.forDirectory(path.resolve(__dirname, '../static/polymer2/'));
+      Analyzer.createForDirectory(path.resolve(__dirname, '../static/polymer2/'));
 
   async function getElements(filename: string): Promise<Set<PolymerElement>> {
     const document =

--- a/src/test/polymer/polymer-element_test.ts
+++ b/src/test/polymer/polymer-element_test.ts
@@ -19,14 +19,10 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {Document, Severity, Warning} from '../../model/model';
 import {PolymerElement} from '../../polymer/polymer-element';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 
 suite('PolymerElement', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/polymer2/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const analyzer = new Analyzer({
-    urlLoader: urlLoader,
-  });
+  const analyzer =
+      Analyzer.forDirectory(path.resolve(__dirname, '../static/polymer2/'));
 
   async function getElements(filename: string): Promise<Set<PolymerElement>> {
     const document =

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -16,31 +16,21 @@
 import {assert, use as chaiUse} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner with old jsdoc annotations', () => {
   const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const underliner = new CodeUnderliner(urlLoader);
+  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const underliner = new CodeUnderliner(analyzer);
 
   async function getElements(filename: string):
       Promise<ScannedPolymerElement[]> {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new ClassScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
+    const {features} = await runScanner(analyzer, new ClassScanner(), filename);
     return features.filter((e) => e instanceof ScannedPolymerElement) as
         ScannedPolymerElement[];
   };

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -25,7 +25,7 @@ chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner with old jsdoc annotations', () => {
   const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
-  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 
   async function getElements(filename: string):

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -25,7 +25,7 @@ chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner', () => {
   const analyzer =
-      Analyzer.forDirectory(path.resolve(__dirname, '../static/polymer2/'));
+      Analyzer.createForDirectory(path.resolve(__dirname, '../static/polymer2/'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getElements(filename: string):

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -16,31 +16,22 @@
 import {assert, use as chaiUse} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/polymer2/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const underliner = new CodeUnderliner(urlLoader);
+  const analyzer =
+      Analyzer.forDirectory(path.resolve(__dirname, '../static/polymer2/'));
+  const underliner = new CodeUnderliner(analyzer);
 
   async function getElements(filename: string):
       Promise<ScannedPolymerElement[]> {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new ClassScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
+    const {features} = await runScanner(analyzer, new ClassScanner(), filename);
 
-    const {features} = await scanner.scan(document, visit);
     return features.filter((e) => e instanceof ScannedPolymerElement) as
         ScannedPolymerElement[];
   };

--- a/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -39,7 +39,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
   let elementsList: ScannedPolymerElement[];
 
   suiteSetup(async () => {
-    const analyzer = Analyzer.forDirectory(path.resolve(__dirname, '../'));
+    const analyzer = Analyzer.createForDirectory(path.resolve(__dirname, '../'));
     const {features} = await runScanner(
         analyzer, new ClassScanner(), 'static/vanilla-elements.js');
 

--- a/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -15,19 +15,16 @@
 
 import * as chai from 'chai';
 import {assert} from 'chai';
-import * as fs from 'fs';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptDocument} from '../../javascript/javascript-document';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
+import {runScanner} from '../test-utils';
 
 
 //
-// NOTE: THis test was copied from
+// NOTE: This test was copied from
 // /src/test/vanilla-custom-elements/element-scanner_test.js
 // to ensure that Polymer2ElementScanner can scan vanilla elements while we
 // disable the vanilla element scanner for a short time.
@@ -39,19 +36,12 @@ chai.use(require('chai-subset'));
 
 suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
   const elements = new Map<string|undefined, ScannedPolymerElement>();
-  let document: JavaScriptDocument;
   let elementsList: ScannedPolymerElement[];
 
   suiteSetup(async () => {
-    const parser = new JavaScriptParser();
-    const file = fs.readFileSync(
-        path.resolve(__dirname, '../static/vanilla-elements.js'), 'utf8');
-    document = parser.parse(file, '/static/vanilla-elements.js' as ResolvedUrl);
-    const scanner = new ClassScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-
-    const {features} = await scanner.scan(document, visit);
+    const analyzer = Analyzer.forDirectory(path.resolve(__dirname, '../'));
+    const {features} = await runScanner(
+        analyzer, new ClassScanner(), 'static/vanilla-elements.js');
 
     elementsList = features.filter((e) => e instanceof ScannedPolymerElement) as
         ScannedPolymerElement[];
@@ -97,7 +87,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
         name: 'disabled',
         type: 'boolean',
         sourceRange: {
-          file: '/static/vanilla-elements.js',
+          file: 'static/vanilla-elements.js',
           start: {column: 6, line: 25},
           end: {column: 16, line: 25}
         }
@@ -107,7 +97,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
         name: 'open',
         type: 'boolean',
         sourceRange: {
-          file: '/static/vanilla-elements.js',
+          file: 'static/vanilla-elements.js',
           start: {column: 6, line: 27},
           end: {column: 12, line: 27}
         }
@@ -116,7 +106,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
         description: '',
         name: 'foo',
         sourceRange: {
-          file: '/static/vanilla-elements.js',
+          file: 'static/vanilla-elements.js',
           start: {column: 14, line: 27},
           end: {column: 19, line: 27}
         },
@@ -125,7 +115,7 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
         description: '',
         name: 'bar',
         sourceRange: {
-          file: '/static/vanilla-elements.js',
+          file: 'static/vanilla-elements.js',
           start: {column: 21, line: 27},
           end: {column: 26, line: 27}
         },

--- a/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -18,27 +18,16 @@ import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner with old jsdoc annotations', () => {
   const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const underliner = new CodeUnderliner(urlLoader);
-  const analyzer = new Analyzer({urlLoader});
+  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedMixins(filename: string) {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new ClassScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-    const {features} = await scanner.scan(document, visit);
+    const {features} = await runScanner(analyzer, new ClassScanner(), filename);
     return <ScannedPolymerElementMixin[]>features.filter(
         (e) => e instanceof ScannedPolymerElementMixin);
   };

--- a/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -23,7 +23,7 @@ import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner with old jsdoc annotations', () => {
   const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
-  const analyzer = Analyzer.forDirectory(testFilesDir);
+  const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedMixins(filename: string) {

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -23,7 +23,7 @@ import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner', () => {
   const analyzer =
-      Analyzer.forDirectory(path.resolve(__dirname, '../static/polymer2/'));
+      Analyzer.createForDirectory(path.resolve(__dirname, '../static/polymer2/'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedMixins(filename: string) {

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -18,27 +18,16 @@ import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
-import {Visitor} from '../../javascript/estree-visitor';
-import {JavaScriptParser} from '../../javascript/javascript-parser';
-import {ResolvedUrl} from '../../model/url';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
-import {FSUrlLoader} from '../../url-loader/fs-url-loader';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/polymer2/');
-  const urlLoader = new FSUrlLoader(testFilesDir);
-  const underliner = new CodeUnderliner(urlLoader);
-  const analyzer = new Analyzer({urlLoader});
+  const analyzer =
+      Analyzer.forDirectory(path.resolve(__dirname, '../static/polymer2/'));
+  const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedMixins(filename: string) {
-    const file = await urlLoader.load(filename);
-    const parser = new JavaScriptParser();
-    const document = parser.parse(file, filename as ResolvedUrl);
-    const scanner = new ClassScanner();
-    const visit = (visitor: Visitor) =>
-        Promise.resolve(document.visit([visitor]));
-    const {features} = await scanner.scan(document, visit);
+    const {features} = await runScanner(analyzer, new ClassScanner(), filename);
     return <ScannedPolymerElementMixin[]>features.filter(
         (e) => e instanceof ScannedPolymerElementMixin);
   };

--- a/src/test/polymer/pseudo-element-scanner_test.ts
+++ b/src/test/polymer/pseudo-element-scanner_test.ts
@@ -14,22 +14,14 @@
 
 import {assert} from 'chai';
 
-import {HtmlVisitor} from '../../html/html-document';
-import {HtmlParser} from '../../html/html-parser';
-import {ResolvedUrl} from '../../model/url';
+import {ScannedPolymerElement} from '../../polymer/polymer-element';
 import {PseudoElementScanner} from '../../polymer/pseudo-element-scanner';
+import {runScannerOnContents} from '../test-utils';
 
 suite('PseudoElementScanner', () => {
-  suite('scan()', () => {
-    let scanner: PseudoElementScanner;
-
-    setup(() => {
-      scanner = new PseudoElementScanner();
-    });
-
-    test('finds pseudo elements in html comments ', async () => {
-      const desc = `This is a pseudo element`;
-      const contents = `<html><head></head><body>
+  test('finds pseudo elements in html comments ', async () => {
+    const desc = `This is a pseudo element`;
+    const contents = `<html><head></head><body>
           <!--
           ${desc}
           @pseudoElement x-foo
@@ -37,17 +29,12 @@ suite('PseudoElementScanner', () => {
           -->
         </body>
         </html>`;
-      const document =
-          new HtmlParser().parse(contents, 'test.html' as ResolvedUrl);
-      const visit = async (visitor: HtmlVisitor) => document.visit([visitor]);
-
-      const {features} = await scanner.scan(document, visit);
-      assert.equal(features.length, 1);
-      assert.equal(features[0].tagName, 'x-foo');
-      assert(features[0].pseudo);
-      assert.equal(features[0].description.trim(), desc);
-      assert.deepEqual(
-          features[0].demos, [{desc: 'demo', path: 'demo/index.html'}]);
-    });
+    const {features} = await runScannerOnContents(
+        new PseudoElementScanner(), 'test-doc.html', contents);
+    assert.deepEqual(
+        features.map(
+            (f: ScannedPolymerElement) =>
+                [f.tagName, f.pseudo, f.description.trim(), f.demos]),
+        [['x-foo', true, desc, [{desc: 'demo', path: 'demo/index.html'}]]]);
   });
 });

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -104,6 +104,11 @@ function isWarning(wOrS: Warning|SourceRange): wOrS is Warning {
   return 'code' in wOrS;
 }
 
+/**
+ * Run the given scanner on the given package relative url.
+ *
+ * The url must be loadable with the given analyzer.
+ */
 export async function runScanner(
     analyzer: Analyzer,
     scanner: Scanner<ParsedDocument, any, any>,
@@ -114,6 +119,12 @@ export async function runScanner(
   return scan(parsedDocument, [scanner]);
 }
 
+/**
+ * Run the given scanner on some file contents as a string.
+ *
+ * Note that the url's file extension is relevant, because it will affect how
+ * the file is parsed.
+ */
 export async function runScannerOnContents(
     scanner: Scanner<ParsedDocument, any, any>, url: string, contents: string) {
   const overlayLoader = new InMemoryOverlayUrlLoader();

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -13,8 +13,10 @@
  */
 
 import {Analyzer} from '../core/analyzer';
-import {Document, ParsedDocument} from '../index';
+import {Document, ParsedDocument, ScannedFeature} from '../index';
 import {SourceRange, Warning} from '../model/model';
+import {scan} from '../scanning/scan';
+import {Scanner} from '../scanning/scanner';
 import {InMemoryOverlayUrlLoader} from '../url-loader/overlay-loader';
 import {UrlLoader} from '../url-loader/url-loader';
 import {underlineCode} from '../warning/code-printer';
@@ -100,4 +102,23 @@ function isReadonlyArray(maybeArr: any): maybeArr is ReadonlyArray<any> {
 
 function isWarning(wOrS: Warning|SourceRange): wOrS is Warning {
   return 'code' in wOrS;
+}
+
+export async function runScanner(
+    analyzer: Analyzer,
+    scanner: Scanner<ParsedDocument, any, any>,
+    url: string): Promise<{features: ScannedFeature[], warnings: Warning[]}> {
+  const context = await analyzer['_analysisComplete'];
+  const resolvedUrl = analyzer.resolveUrl(url);
+  const parsedDocument = await context['_parse'](resolvedUrl);
+  return scan(parsedDocument, [scanner]);
+}
+
+export async function runScannerOnContents(
+    scanner: Scanner<ParsedDocument, any, any>, url: string, contents: string) {
+  const overlayLoader = new InMemoryOverlayUrlLoader();
+  const analyzer = new Analyzer({urlLoader: overlayLoader});
+  overlayLoader.urlContentsMap.set(analyzer.resolveUrl(url), contents);
+  const {features, warnings} = await runScanner(analyzer, scanner, url);
+  return {features, warnings, analyzer};
 }


### PR DESCRIPTION
Two things here:
  * Add a method `Analyzer.forDirectory` which encapsulates the process of getting a well configured analyzer rooted at a given directory. This is nice to land here because it's about to change, as the package url resolver is going to want to know about the root dir too.
  * Modified way that we write most of our tests to depend less on internals, and to the degree that we do depend on internals, use a single test method to do so.

This is a piece pulled out the url resolution PR.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
