### PR TITLE
Assume Polymer properties are possibly null|undefined; add attributeType.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Add `Import#originalUrl` which has the original url of the import as it was
   encountered in the document, before it was resolved relative to the base url
   of its containing document.
+* [BREAKING] Polymer property types are now assumed to be possibly
+  `null|undefined` unless an explicit `@type` annotation says otherwise.
+* Added `attributeType` field to Polymer property, which contains the name
+  of the Polymer property declaration `type` field Constructor.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.4] - 2017-12-14

--- a/src/polymer/polymer-element-mixin.ts
+++ b/src/polymer/polymer-element-mixin.ts
@@ -112,16 +112,14 @@ export class PolymerElementMixin extends ElementMixin implements
   }
 
   emitPropertyMetadata(property: PolymerProperty) {
-    const polymerMetadata:
-        {notify?: boolean, observer?: string, readOnly?: boolean} = {};
-    const polymerMetadataFields: Array<keyof typeof polymerMetadata> =
-        ['notify', 'observer', 'readOnly'];
-    for (const field of polymerMetadataFields) {
-      if (field in property) {
-        polymerMetadata[field] = property[field];
+    return {
+      polymer: {
+        notify: property.notify,
+        observer: property.observer,
+        readOnly: property.readOnly,
+        attributeType: property.attributeType,
       }
-    }
-    return {polymer: polymerMetadata};
+    };
   }
 
   protected _getSuperclassAndMixins(

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -34,12 +34,18 @@ export interface BasePolymerProperty {
   observerExpression?: JavascriptDatabindingExpression;
   reflectToAttribute?: boolean;
   computedExpression?: JavascriptDatabindingExpression;
+
   /**
    * True if the property is part of Polymer's element configuration syntax.
    *
    * e.g. 'properties', 'is', 'extends', etc
    */
   isConfiguration?: boolean;
+
+  /**
+   * Constructor used when deserializing this property from an attribute.
+   */
+  attributeType?: string;
 }
 
 export interface ScannedPolymerProperty extends ScannedProperty,
@@ -336,16 +342,14 @@ export class PolymerElement extends Element implements PolymerExtension {
   }
 
   emitPropertyMetadata(property: PolymerProperty) {
-    const polymerMetadata:
-        {notify?: boolean, observer?: string, readOnly?: boolean} = {};
-    const polymerMetadataFields: Array<keyof typeof polymerMetadata> =
-        ['notify', 'observer', 'readOnly'];
-    for (const field of polymerMetadataFields) {
-      if (field in property) {
-        polymerMetadata[field] = property[field];
+    return {
+      polymer: {
+        notify: property.notify,
+        observer: property.observer,
+        readOnly: property.readOnly,
+        attributeType: property.attributeType,
       }
-    }
-    return {polymer: polymerMetadata};
+    };
   }
 
   protected _getSuperclassAndMixins(

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -161,15 +161,15 @@ suite('PolymerElementScanner', () => {
         ]);
 
     assert.deepEqual(properties.map((p) => [p.name, p.type]), [
-      ['a', 'boolean'],
-      ['b', 'string'],
-      ['c', 'number'],
-      ['d', 'number'],
-      ['e', 'string'],
-      ['f', 'Object'],
+      ['a', 'boolean | null | undefined'],
+      ['b', 'string | null | undefined'],
+      ['c', 'number | null | undefined'],
+      ['d', 'number | null | undefined'],
+      ['e', 'string | null | undefined'],
+      ['f', 'Object | null | undefined'],
       ['g', undefined],
-      ['h', 'string'],
-      ['all', 'Object']
+      ['h', 'string | null | undefined'],
+      ['all', 'Object | null | undefined']
     ]);
 
     assert.deepEqual(

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -114,8 +114,11 @@ suite('Polymer2ElementScanner with old jsdoc annotations', () => {
         superClass: 'Polymer.Element',
         description: 'A very basic element',
         summary: 'A basic element',
-        properties:
-            [{name: 'foo', description: 'A base foo element.', type: 'string'}],
+        properties: [{
+          name: 'foo',
+          description: 'A base foo element.',
+          type: 'string | null | undefined',
+        }],
         attributes: [{
           name: 'foo',
         }],
@@ -242,7 +245,7 @@ class BaseElement extends Polymer.Element {
         properties: [{
           name: 'foo',
           description: '',
-          type: 'string',
+          type: 'string | null | undefined',
         }],
         attributes: [
           {
@@ -273,7 +276,7 @@ namespaced name.`,
         properties: [{
           name: 'foo',
           description: '',
-          type: 'string',
+          type: 'string | null | undefined',
         }],
         attributes: [{
           name: 'foo',
@@ -292,7 +295,7 @@ namespaced name.`,
         properties: [{
           name: 'foo',
           description: '',
-          type: 'string',
+          type: 'string | null | undefined',
         }],
         attributes: [{
           name: 'foo',
@@ -393,7 +396,7 @@ namespaced name.`,
             properties: [{
               name: 'foo',
               description: '',
-              type: 'string',
+              type: 'string | null | undefined',
             }],
             attributes: [{
               name: 'foo',
@@ -500,7 +503,7 @@ namespaced name.`,
           properties: [
             {
               name: 'parseError',
-              type: 'string',
+              type: 'string | null | undefined',
               description: '',
               warningUnderlines: [
                 `
@@ -513,7 +516,7 @@ namespaced name.`,
             },
             {
               name: 'badKindOfExpression',
-              type: 'string',
+              type: 'string | null | undefined',
               description: '',
               propertiesInComputed: ['foo'],
               propertiesInObserver: ['foo', 'bar', 'baz'],
@@ -556,7 +559,8 @@ namespaced name.`,
           className: 'MyElement',
           description: '',
           methods: [],
-          properties: [{name: 'prop1', description: '', type: 'string'}],
+          properties:
+              [{name: 'prop1', description: '', type: 'string | null | undefined'}],
           summary: '',
           superClass: 'Polymer.Element',
           tagName: 'my-app',

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -24,8 +24,8 @@ import {CodeUnderliner, runScanner} from '../test-utils';
 chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner', () => {
-  const analyzer =
-      Analyzer.createForDirectory(path.resolve(__dirname, '../static/polymer2/'));
+  const analyzer = Analyzer.createForDirectory(
+      path.resolve(__dirname, '../static/polymer2/'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getElements(filename: string):
@@ -115,8 +115,11 @@ suite('Polymer2ElementScanner', () => {
         superClass: 'Polymer.Element',
         description: 'A very basic element',
         summary: 'A basic element',
-        properties:
-            [{name: 'foo', description: 'A base foo element.', type: 'string'}],
+        properties: [{
+          name: 'foo',
+          description: 'A base foo element.',
+          type: 'string | null | undefined'
+        }],
         attributes: [{
           name: 'foo',
         }],
@@ -243,7 +246,7 @@ class BaseElement extends Polymer.Element {
         properties: [{
           name: 'foo',
           description: '',
-          type: 'string',
+          type: 'string | null | undefined',
         }],
         attributes: [
           {
@@ -274,7 +277,7 @@ namespaced name.`,
         properties: [{
           name: 'foo',
           description: '',
-          type: 'string',
+          type: 'string | null | undefined',
         }],
         attributes: [{
           name: 'foo',
@@ -293,7 +296,7 @@ namespaced name.`,
         properties: [{
           name: 'foo',
           description: '',
-          type: 'string',
+          type: 'string | null | undefined',
         }],
         attributes: [{
           name: 'foo',
@@ -394,7 +397,7 @@ namespaced name.`,
             properties: [{
               name: 'foo',
               description: '',
-              type: 'string',
+              type: 'string | null | undefined',
             }],
             attributes: [{
               name: 'foo',
@@ -501,7 +504,7 @@ namespaced name.`,
           properties: [
             {
               name: 'parseError',
-              type: 'string',
+              type: 'string | null | undefined',
               description: '',
               warningUnderlines: [
                 `
@@ -514,7 +517,7 @@ namespaced name.`,
             },
             {
               name: 'badKindOfExpression',
-              type: 'string',
+              type: 'string | null | undefined',
               description: '',
               propertiesInComputed: ['foo'],
               propertiesInObserver: ['foo', 'bar', 'baz'],
@@ -557,7 +560,8 @@ namespaced name.`,
           className: 'MyElement',
           description: '',
           methods: [],
-          properties: [{name: 'prop1', description: '', type: 'string'}],
+          properties:
+              [{name: 'prop1', description: '', type: 'string | null | undefined'}],
           summary: '',
           superClass: 'Polymer.Element',
           tagName: 'my-app',
@@ -581,7 +585,7 @@ namespaced name.`,
           {
             name: 'foo',
             description: 'This description lives in the constructor.',
-            type: 'string'
+            type: 'string | null | undefined'
           },
           {
             name: 'constructorOnly_',
@@ -599,7 +603,7 @@ namespaced name.`,
         name: 'foo',
         privacy: 'protected',
         description: 'This description lives in the constructor.',
-        type: 'string',
+        type: 'string | null | undefined',
         default: `'bar'`,
         published: true,
         notify: true,

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -22,8 +22,8 @@ import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/pol
 import {CodeUnderliner, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner', () => {
-  const analyzer =
-      Analyzer.createForDirectory(path.resolve(__dirname, '../static/polymer2/'));
+  const analyzer = Analyzer.createForDirectory(
+      path.resolve(__dirname, '../static/polymer2/'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedMixins(filename: string) {
@@ -451,7 +451,7 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
         name: 'foo',
         privacy: 'public',
         description: 'This description is in the constructor.',
-        type: 'string',
+        type: 'string | null | undefined',
         published: true,
         notify: true,
         warnings: [],

--- a/src/test/static/analysis/behaviors/analysis.json
+++ b/src/test/static/analysis/behaviors/analysis.json
@@ -21,7 +21,7 @@
             }
           },
           "metadata": {},
-          "type": "Array",
+          "type": "Array | null | undefined",
           "inheritedFrom": "MyNamespace.SubBehavior"
         },
         {
@@ -39,7 +39,7 @@
             }
           },
           "metadata": {},
-          "type": "number",
+          "type": "number | null | undefined",
           "inheritedFrom": "MyNamespace.SimpleBehavior"
         },
         {
@@ -56,13 +56,13 @@
             }
           },
           "metadata": {},
-          "type": "boolean"
+          "type": "boolean | null | undefined"
         }
       ],
       "properties": [
         {
           "name": "deeplyInheritedProperty",
-          "type": "Array",
+          "type": "Array | null | undefined",
           "description": "This is a deeply inherited property.",
           "privacy": "public",
           "sourceRange": {
@@ -78,7 +78,8 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "Array"
             }
           },
           "defaultValue": "[]",
@@ -86,7 +87,7 @@
         },
         {
           "name": "inheritPlease",
-          "type": "number",
+          "type": "number | null | undefined",
           "description": "A property provided by SimpleBehavior.",
           "privacy": "public",
           "sourceRange": {
@@ -102,7 +103,8 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "Number"
             }
           },
           "defaultValue": "10",
@@ -110,7 +112,7 @@
         },
         {
           "name": "localProperty",
-          "type": "boolean",
+          "type": "boolean | null | undefined",
           "description": "A property defined directly on behavior-test-elem.",
           "privacy": "public",
           "sourceRange": {
@@ -125,14 +127,15 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "Boolean"
             }
           },
           "defaultValue": "true"
         },
         {
           "name": "_protectedProperty",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "This can only be used directly by code that mixes in this behavior.",
           "privacy": "protected",
           "sourceRange": {
@@ -146,13 +149,15 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"do cool stuff with me!\""
         },
         {
           "name": "__privateProperty",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "This is used entirely for internal purposes ok.",
           "privacy": "private",
           "sourceRange": {
@@ -166,7 +171,9 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           },
           "defaultValue": "\"don't look!\""
         }
@@ -257,13 +264,13 @@
                 }
               },
               "metadata": {},
-              "type": "Array"
+              "type": "Array | null | undefined"
             }
           ],
           "properties": [
             {
               "name": "deeplyInheritedProperty",
-              "type": "Array",
+              "type": "Array | null | undefined",
               "description": "This is a deeply inherited property.",
               "privacy": "public",
               "sourceRange": {
@@ -278,7 +285,8 @@
               },
               "metadata": {
                 "polymer": {
-                  "notify": true
+                  "notify": true,
+                  "attributeType": "Array"
                 }
               },
               "defaultValue": "[]"
@@ -334,7 +342,7 @@
                 }
               },
               "metadata": {},
-              "type": "Array",
+              "type": "Array | null | undefined",
               "inheritedFrom": "MyNamespace.SubBehavior"
             },
             {
@@ -351,13 +359,13 @@
                 }
               },
               "metadata": {},
-              "type": "number"
+              "type": "number | null | undefined"
             }
           ],
           "properties": [
             {
               "name": "deeplyInheritedProperty",
-              "type": "Array",
+              "type": "Array | null | undefined",
               "description": "This is a deeply inherited property.",
               "privacy": "public",
               "sourceRange": {
@@ -373,7 +381,8 @@
               },
               "metadata": {
                 "polymer": {
-                  "notify": true
+                  "notify": true,
+                  "attributeType": "Array"
                 }
               },
               "defaultValue": "[]",
@@ -381,7 +390,7 @@
             },
             {
               "name": "inheritPlease",
-              "type": "number",
+              "type": "number | null | undefined",
               "description": "A property provided by SimpleBehavior.",
               "privacy": "public",
               "sourceRange": {
@@ -396,7 +405,8 @@
               },
               "metadata": {
                 "polymer": {
-                  "notify": true
+                  "notify": true,
+                  "attributeType": "Number"
                 }
               },
               "defaultValue": "10"

--- a/src/test/static/analysis/mixins-old-jsdoc/analysis.json
+++ b/src/test/static/analysis/mixins-old-jsdoc/analysis.json
@@ -5,28 +5,10 @@
       "description": "",
       "summary": "",
       "path": "mixins.js",
-      "attributes": [
-        {
-          "name": "foo",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 8,
-              "column": 8
-            },
-            "end": {
-              "line": 11,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        }
-      ],
       "properties": [
         {
           "name": "foo",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -41,20 +23,15 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         }
       ],
       "methods": [],
       "staticMethods": [],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
       "demos": [],
-      "slots": [],
-      "events": [],
       "metadata": {},
       "sourceRange": {
         "start": {
@@ -67,12 +44,76 @@
         }
       },
       "privacy": "public",
-      "name": "Polymer.TestMixin"
+      "name": "Polymer.TestMixin",
+      "attributes": [
+        {
+          "name": "foo",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 8,
+              "column": 8
+            },
+            "end": {
+              "line": 11,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": []
     },
     {
       "description": "",
       "summary": "",
       "path": "mixins.js",
+      "properties": [
+        {
+          "name": "foo",
+          "type": "string | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 25,
+              "column": 8
+            },
+            "end": {
+              "line": 28,
+              "column": 9
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "attributeType": "String"
+            }
+          }
+        }
+      ],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 21,
+          "column": 0
+        },
+        "end": {
+          "line": 32,
+          "column": 1
+        }
+      },
+      "privacy": "protected",
+      "name": "Polymer._ProtectedMixin",
       "attributes": [
         {
           "name": "foo",
@@ -88,60 +129,20 @@
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         }
       ],
-      "properties": [
-        {
-          "name": "foo",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 25,
-              "column": 8
-            },
-            "end": {
-              "line": 28,
-              "column": 9
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "notify": true
-            }
-          }
-        }
-      ],
-      "methods": [],
-      "staticMethods": [],
+      "events": [],
       "styling": {
         "cssVariables": [],
         "selectors": []
       },
-      "demos": [],
-      "slots": [],
-      "events": [],
-      "metadata": {},
-      "sourceRange": {
-        "start": {
-          "line": 21,
-          "column": 0
-        },
-        "end": {
-          "line": 32,
-          "column": 1
-        }
-      },
-      "privacy": "protected",
-      "name": "Polymer._ProtectedMixin"
+      "slots": []
     },
     {
       "description": "",
       "summary": "",
       "path": "mixins.js",
-      "attributes": [],
       "properties": [],
       "methods": [
         {
@@ -171,30 +172,24 @@
       ],
       "staticMethods": [
         {
-          "description": "",
-          "metadata": {},
           "name": "glob",
-          "params": [],
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "end": {
-              "column": 5,
-              "line": 46
-            },
             "start": {
-              "column": 4,
-              "line": 45
+              "line": 45,
+              "column": 4
+            },
+            "end": {
+              "line": 46,
+              "column": 5
             }
-          }
+          },
+          "metadata": {},
+          "params": []
         }
       ],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
       "demos": [],
-      "slots": [],
-      "events": [],
       "metadata": {},
       "sourceRange": {
         "start": {
@@ -207,34 +202,23 @@
         }
       },
       "privacy": "private",
-      "name": "Polymer.InternalMixin"
+      "name": "Polymer.InternalMixin",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": []
     },
     {
       "description": "",
       "summary": "",
       "path": "mixins.js",
-      "attributes": [
-        {
-          "name": "meta",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 59,
-              "column": 8
-            },
-            "end": {
-              "line": 61,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        }
-      ],
       "properties": [
         {
           "name": "meta",
-          "type": "boolean",
+          "type": "boolean | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -248,7 +232,9 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "Boolean"
+            }
           }
         }
       ],
@@ -281,31 +267,25 @@
       ],
       "staticMethods": [
         {
-          "description": "",
-          "inheritedFrom": "Polymer.InternalMixin",
-          "metadata": {},
           "name": "glob",
-          "params": [],
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "end": {
-              "column": 5,
-              "line": 46
-            },
             "start": {
-              "column": 4,
-              "line": 45
+              "line": 45,
+              "column": 4
+            },
+            "end": {
+              "line": 46,
+              "column": 5
             }
-          }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.InternalMixin"
         }
       ],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
       "demos": [],
-      "slots": [],
-      "events": [],
       "metadata": {},
       "sourceRange": {
         "start": {
@@ -319,6 +299,30 @@
       },
       "privacy": "public",
       "name": "Polymer.MetaMixin",
+      "attributes": [
+        {
+          "name": "meta",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 59,
+              "column": 8
+            },
+            "end": {
+              "line": 61,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "type": "boolean | null | undefined"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
       "mixins": [
         "Polymer.InternalMixin"
       ]

--- a/src/test/static/analysis/mixins/analysis.json
+++ b/src/test/static/analysis/mixins/analysis.json
@@ -20,13 +20,13 @@
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         }
       ],
       "properties": [
         {
           "name": "foo",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -41,7 +41,8 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         }
@@ -88,13 +89,13 @@
             }
           },
           "metadata": {},
-          "type": "string"
+          "type": "string | null | undefined"
         }
       ],
       "properties": [
         {
           "name": "foo",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -109,7 +110,8 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         }
@@ -228,13 +230,13 @@
             }
           },
           "metadata": {},
-          "type": "boolean"
+          "type": "boolean | null | undefined"
         }
       ],
       "properties": [
         {
           "name": "meta",
-          "type": "boolean",
+          "type": "boolean | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -248,7 +250,9 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "Boolean"
+            }
           }
         }
       ],

--- a/src/test/static/analysis/simple/analysis.json
+++ b/src/test/static/analysis/simple/analysis.json
@@ -2,34 +2,13 @@
   "schema_version": "1.0.0",
   "elements": [
     {
-      "tagname": "simple-element",
       "description": "This is a description of the element.",
       "summary": "",
-      "superclass": "HTMLElement",
       "path": "simple-element.html",
-      "privacy": "public",
-      "attributes": [
-        {
-          "name": "the-value",
-          "description": "This is a simple test property named theValue.",
-          "sourceRange": {
-            "start": {
-              "line": 9,
-              "column": 6
-            },
-            "end": {
-              "line": 12,
-              "column": 7
-            }
-          },
-          "type": "string",
-          "metadata": {}
-        }
-      ],
       "properties": [
         {
           "name": "theValue",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "This is a simple test property named theValue.",
           "privacy": "public",
           "sourceRange": {
@@ -44,13 +23,14 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         },
         {
           "name": "_protectedValue",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -64,12 +44,14 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           }
         },
         {
           "name": "__privateValue",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "private",
           "sourceRange": {
@@ -83,12 +65,14 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           }
         },
         {
           "name": "closureStyleTrailingUnderscoresArePrivate_",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "private",
           "sourceRange": {
@@ -102,12 +86,14 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           }
         },
         {
           "name": "_looksProtectedButActuallyPublic",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -121,12 +107,14 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           }
         },
         {
           "name": "looksPublicButActuallyProtected",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -140,12 +128,14 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           }
         },
         {
           "name": "looksPublicButActuallyPrivate",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "private",
           "sourceRange": {
@@ -159,7 +149,9 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "attributeType": "String"
+            }
           }
         }
       ],
@@ -178,6 +170,7 @@
               "column": 39
             }
           },
+          "metadata": {},
           "params": [
             {
               "name": "a"
@@ -185,8 +178,7 @@
             {
               "name": "b"
             }
-          ],
-          "metadata": {}
+          ]
         },
         {
           "name": "_customProtectedFunction",
@@ -202,6 +194,7 @@
               "column": 49
             }
           },
+          "metadata": {},
           "params": [
             {
               "name": "a"
@@ -209,8 +202,7 @@
             {
               "name": "b"
             }
-          ],
-          "metadata": {}
+          ]
         },
         {
           "name": "__customPrivateFunction",
@@ -226,6 +218,7 @@
               "column": 48
             }
           },
+          "metadata": {},
           "params": [
             {
               "name": "a"
@@ -233,8 +226,7 @@
             {
               "name": "b"
             }
-          ],
-          "metadata": {}
+          ]
         },
         {
           "name": "customFunctionWithJsDoc",
@@ -250,6 +242,7 @@
               "column": 61
             }
           },
+          "metadata": {},
           "params": [
             {
               "name": "a",
@@ -262,8 +255,7 @@
           ],
           "return": {
             "type": "boolean"
-          },
-          "metadata": {}
+          }
         },
         {
           "name": "_customProtectedFunctionWithJsDoc",
@@ -279,6 +271,7 @@
               "column": 71
             }
           },
+          "metadata": {},
           "params": [
             {
               "name": "a",
@@ -291,8 +284,7 @@
           ],
           "return": {
             "type": "boolean"
-          },
-          "metadata": {}
+          }
         },
         {
           "name": "__customPrivateFunctionWithJsDoc",
@@ -308,6 +300,7 @@
               "column": 70
             }
           },
+          "metadata": {},
           "params": [
             {
               "name": "a",
@@ -320,25 +313,11 @@
           ],
           "return": {
             "type": "boolean"
-          },
-          "metadata": {}
+          }
         }
       ],
       "staticMethods": [],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
       "demos": [],
-      "slots": [],
-      "events": [
-        {
-          "name": "the-value-changed",
-          "description": "Fired when the `theValue` property changes.",
-          "type": "CustomEvent",
-          "metadata": {}
-        }
-      ],
       "metadata": {},
       "sourceRange": {
         "start": {
@@ -349,7 +328,41 @@
           "line": 51,
           "column": 3
         }
-      }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "the-value",
+          "description": "This is a simple test property named theValue.",
+          "sourceRange": {
+            "start": {
+              "line": 9,
+              "column": 6
+            },
+            "end": {
+              "line": 12,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "the-value-changed",
+          "description": "Fired when the `theValue` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "simple-element"
     }
   ]
 }

--- a/src/test/static/analysis/weird-property-names/analysis.json
+++ b/src/test/static/analysis/weird-property-names/analysis.json
@@ -2,50 +2,13 @@
   "schema_version": "1.0.0",
   "elements": [
     {
-      "tagname": "simple-element",
       "description": "",
       "summary": "",
-      "superclass": "HTMLElement",
       "path": "simple-element.html",
-      "privacy": "public",
-      "attributes": [
-        {
-          "name": "d-e-f",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 7,
-              "column": 6
-            },
-            "end": {
-              "line": 10,
-              "column": 7
-            }
-          },
-          "type": "string",
-          "metadata": {}
-        },
-        {
-          "name": "g--h--i",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 11,
-              "column": 6
-            },
-            "end": {
-              "line": 14,
-              "column": 7
-            }
-          },
-          "type": "string",
-          "metadata": {}
-        }
-      ],
       "properties": [
         {
           "name": "ABC",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -60,13 +23,14 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         },
         {
           "name": "dEF",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -81,13 +45,14 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         },
         {
           "name": "g-H--i",
-          "type": "string",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
@@ -102,33 +67,15 @@
           },
           "metadata": {
             "polymer": {
-              "notify": true
+              "notify": true,
+              "attributeType": "String"
             }
           }
         }
       ],
       "methods": [],
       "staticMethods": [],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
       "demos": [],
-      "slots": [],
-      "events": [
-        {
-          "name": "d-e-f-changed",
-          "description": "Fired when the `dEF` property changes.",
-          "type": "CustomEvent",
-          "metadata": {}
-        },
-        {
-          "name": "g--h--i-changed",
-          "description": "Fired when the `g-H--i` property changes.",
-          "type": "CustomEvent",
-          "metadata": {}
-        }
-      ],
       "metadata": {},
       "sourceRange": {
         "start": {
@@ -139,7 +86,63 @@
           "line": 17,
           "column": 3
         }
-      }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "d-e-f",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 7,
+              "column": 6
+            },
+            "end": {
+              "line": 10,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
+          "name": "g--h--i",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 11,
+              "column": 6
+            },
+            "end": {
+              "line": 14,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "d-e-f-changed",
+          "description": "Fired when the `dEF` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "g--h--i-changed",
+          "description": "Fired when the `g-H--i` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "simple-element"
     }
   ]
 }


### PR DESCRIPTION
Polymer property definitions include a `type` field. This is a reference to the constructor that will be used to deserialize attribute values.
    
In the absence of an explicit `@type` annotation, this deserializer is also used by Analyzer to infer the Closure syntax property type.
    
Previously, we emitted one of: `string|boolean|number|Object|Array|Date`. Note that in Closure syntax, some of these types are nullable, others aren't (all non-primitive types in Closure are nullable by default), and none can be `undefined`.
   
Now, we always emit a possibly `null|undefined` type when inferring the property type.
    
We also now store the original attribute deserializer constructor name in the `attributeType` field.

For context, see this comment on the generated Polymer TypeScript declarations: https://github.com/Polymer/polymer/pull/4928/files/c9be530d6450238a0ea64a06cf5fa1298a8f824c#r155947127, and some of the other properties there.

 - [x] CHANGELOG.md has been updated
