### PR TITLE
Speed up `npm run test:watch`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,9 +19,9 @@
           "relative",
           "${workspaceRoot}/src"
         ],
-        "watching": {
-          "beginsPattern": "\\[npm\\] INFO Spawning\\.\\.\\.",
-          "endsPattern": "\\[npm\\] (ERROR Exited with code \\d+|SUCCESS Exited cleanly|INFO Killed with SIGTERM)"
+        "background": {
+          "beginsPattern": "tsc-then: Running",
+          "endsPattern": "tsc-then: command finished"
         },
         "pattern": [
           {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,19 +1,21 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=733558
-  // for the documentation about the tasks.json format
-  "version": "0.1.0",
-  "command": "npm",
-  "isShellCommand": true,
-  "showOutput": "always",
-  "suppressTaskName": true,
+  "version": "2.0.0",
   "tasks": [
     {
-      "taskName": "test",
-      "args": [
-        "run",
-        "test:watch"
-      ],
-      "isTestCommand": true,
+      "type": "npm",
+      "script": "test:watch",
+      "isBackground": true,
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated"
+      },
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "promptOnClose": false,
       "problemMatcher": {
         "fileLocation": [
           "relative",
@@ -31,9 +33,10 @@
             "line": 1,
             "column": 1
           }
-        ]
-      },
-      "isBackground": true
+        ],
+        "applyTo": "allDocuments",
+        "severity": "error"
+      }
     }
   ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,8 +86,7 @@ task('compile', function() {
   // const srcs = tsProject.src();
   return mergeStream(
              tsResult.js.pipe(sourcemaps.write('../lib')),
-             tsResult.dts,
-             gulp.src(['src/**/*', '!src/**/*.ts']))
+             tsResult.dts)
       .pipe(gulp.dest('lib'));
 });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bin/"
   ],
   "scripts": {
-    "clean": "mkdir -p lib/ && rm -rf lib/",
+    "clean": "touch lib && rm -rf lib && mkdir lib",
     "build": "gulp build --silent",
     "release": "npm run compile",
     "lint": "gulp lint",
@@ -26,7 +26,7 @@
     "quicktest": "export QUICK_TESTS=true; npm run build && mocha",
     "initBench": "if [ ! -d bower_components ]; then bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi",
     "benchmark": "npm run build && npm run initBench && node --expose-gc lib/perf/parse-all-benchmark.js",
-    "test:watch": "watchy -w src/ -- npm run quicktest --loglevel=silent",
+    "test:watch": "tsc-then -- mocha",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
     "prepublishOnly": "tsc && npm test"
   },

--- a/src/test/analysis-format/generate-analysis_test.ts
+++ b/src/test/analysis-format/generate-analysis_test.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import {Analysis} from '../../analysis-format/analysis-format';
 import {generateAnalysis, validateAnalysis, ValidationError} from '../../analysis-format/generate-analysis';
 import {Analyzer} from '../../core/analyzer';
-import {fileRelativeUrl} from '../test-utils';
+import {fileRelativeUrl, fixtureDir} from '../test-utils';
 
 const onlyTests = new Set<string>([]);  // Should be empty when not debugging.
 
@@ -28,12 +28,10 @@ const onlyTests = new Set<string>([]);  // Should be empty when not debugging.
 const skipTests = new Set<string>(['bower_packages', 'nested-packages']);
 
 
-const fixturesDir = path.join(__dirname, '..', 'static');
-
 suite('generate-analysis', () => {
   suite('generateAnalysisMetadata', () => {
     suite('generates for Document array from fixtures', () => {
-      const basedir = path.join(fixturesDir, 'analysis');
+      const basedir = path.join(fixtureDir, 'analysis');
       const analysisFixtureDirs =
           fs.readdirSync(basedir)
               .map((p) => path.join(basedir, p))
@@ -74,7 +72,7 @@ suite('generate-analysis', () => {
                 JSON.parse(fs.readFileSync(pathToGolden, 'utf-8'));
 
             try {
-              const shortPath = path.relative(fixturesDir, pathToGolden);
+              const shortPath = path.relative(fixtureDir, pathToGolden);
               assert.deepEqual(
                   analysis,
                   golden,
@@ -93,7 +91,7 @@ suite('generate-analysis', () => {
 
     suite('generates from package', () => {
       test('does not include external features', async () => {
-        const basedir = path.resolve(fixturesDir, 'analysis/bower_packages');
+        const basedir = path.resolve(fixtureDir, 'analysis/bower_packages');
         const analyzer = Analyzer.createForDirectory(basedir);
         const _package = await analyzer.analyzePackage();
         const metadata = generateAnalysis(_package, analyzer.urlResolver);
@@ -102,7 +100,7 @@ suite('generate-analysis', () => {
       });
 
       test('includes package features', async () => {
-        const basedir = path.resolve(fixturesDir, 'analysis/simple');
+        const basedir = path.resolve(fixtureDir, 'analysis/simple');
         const analyzer = Analyzer.createForDirectory(basedir);
         const _package = await analyzer.analyzePackage();
         const metadata = generateAnalysis(_package, analyzer.urlResolver);

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -31,7 +31,7 @@ import {Document, ScannedImport, ScannedInlineDocument, Severity, Warning} from 
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {InMemoryOverlayUrlLoader} from '../../url-loader/overlay-loader';
 import {UrlLoader} from '../../url-loader/url-loader';
-import {CodeUnderliner, invertPromise, resolvedUrl} from '../test-utils';
+import {CodeUnderliner, fixtureDir, invertPromise, resolvedUrl} from '../test-utils';
 
 import chaiAsPromised = require('chai-as-promised');
 import chaiSubset = require('chai-subset');
@@ -48,7 +48,7 @@ function getOnly<V>(iter: Iterable<V>): V {
   return arr[0]!;
 }
 
-const testDir = path.join(__dirname, '..');
+const testDir = path.join(fixtureDir, '..');
 
 suite('Analyzer', () => {
   let analyzer: Analyzer;
@@ -712,7 +712,7 @@ var DuplicateNamespace = {};
   suite('analyzePackage', () => {
     test('produces a package with the right documents', async () => {
       const analyzer =
-          Analyzer.createForDirectory(path.join(testDir, 'static', 'project'));
+          Analyzer.createForDirectory(path.join(fixtureDir, 'project'));
       const pckage = await analyzer.analyzePackage();
 
       // The root documents of the package are a minimal set of documents whose
@@ -789,7 +789,7 @@ var DuplicateNamespace = {};
 
     test('can get warnings from within and without the package', async () => {
       const analyzer = Analyzer.createForDirectory(
-          path.join(testDir, 'static', 'project-with-errors'));
+          path.join(fixtureDir, 'project-with-errors'));
       const pckage = await analyzer.analyzePackage();
       assert.deepEqual(
           Array.from(pckage['_searchRoots']).map((d) => d.url),

--- a/src/test/core/dependency-graph_test.ts
+++ b/src/test/core/dependency-graph_test.ts
@@ -15,14 +15,13 @@
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 
 import {assert, use} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {DependencyGraph} from '../../core/dependency-graph';
 
 import chaiAsPromised = require('chai-as-promised');
 import {ResolvedUrl} from '../../model/url';
-import {resolvedUrl} from '../test-utils';
+import {resolvedUrl, fixtureDir} from '../test-utils';
 use(chaiAsPromised);
 
 suite('DependencyGraph', () => {
@@ -37,22 +36,27 @@ suite('DependencyGraph', () => {
     // base.html -> a.html -> common.html
     // base.html -> b.html -> common.html
     let graph = new DependencyGraph();
-    assertStringSetsEqual(graph.getAllDependantsOf(resolvedUrl`common.html`), []);
+    assertStringSetsEqual(
+        graph.getAllDependantsOf(resolvedUrl`common.html`), []);
     graph.addDocument(resolvedUrl`a.html`, [resolvedUrl`common.html`]);
     assertStringSetsEqual(
         graph.getAllDependantsOf(resolvedUrl`common.html`), ['a.html']);
     graph.addDocument(resolvedUrl`b.html`, [resolvedUrl`common.html`]);
     assertStringSetsEqual(
-        graph.getAllDependantsOf(resolvedUrl`common.html`), ['a.html', 'b.html']);
-    graph.addDocument(resolvedUrl`base.html`, ['a.html', 'b.html'] as ResolvedUrl[]);
+        graph.getAllDependantsOf(resolvedUrl`common.html`),
+        ['a.html', 'b.html']);
+    graph.addDocument(
+        resolvedUrl`base.html`, ['a.html', 'b.html'] as ResolvedUrl[]);
     assertStringSetsEqual(
         graph.getAllDependantsOf(resolvedUrl`common.html`),
         ['a.html', 'b.html', 'base.html']);
     graph = graph.invalidatePaths([resolvedUrl`a.html`]);
     assertStringSetsEqual(
-        graph.getAllDependantsOf(resolvedUrl`common.html`), ['b.html', 'base.html']);
+        graph.getAllDependantsOf(resolvedUrl`common.html`),
+        ['b.html', 'base.html']);
     graph = graph.invalidatePaths([resolvedUrl`b.html`]);
-    assertStringSetsEqual(graph.getAllDependantsOf(resolvedUrl`common.html`), []);
+    assertStringSetsEqual(
+        graph.getAllDependantsOf(resolvedUrl`common.html`), []);
     assertIsValidGraph(graph);
   });
 
@@ -64,7 +68,7 @@ suite('DependencyGraph', () => {
   suite('as used in the Analyzer', () => {
     let analyzer: Analyzer;
     setup(() => {
-      analyzer = Analyzer.createForDirectory(path.join(__dirname, '..', 'static'));
+      analyzer = Analyzer.createForDirectory(fixtureDir);
     });
 
     async function assertImportersOf(
@@ -141,7 +145,8 @@ suite('DependencyGraph', () => {
 
     test('resolves for a simple cycle', async () => {
       const graph = new DependencyGraph();
-      const promises = [graph.whenReady(resolvedUrl`a`), graph.whenReady(resolvedUrl`b`)];
+      const promises =
+          [graph.whenReady(resolvedUrl`a`), graph.whenReady(resolvedUrl`b`)];
       graph.addDocument(resolvedUrl`a`, ['b'] as ResolvedUrl[]);
       graph.addDocument(resolvedUrl`b`, ['a'] as ResolvedUrl[]);
       await Promise.all(promises);

--- a/src/test/css/css-custom-property-scanner_test.ts
+++ b/src/test/css/css-custom-property-scanner_test.ts
@@ -13,20 +13,17 @@
  */
 
 import {assert} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 
-import {CodeUnderliner} from '../test-utils';
-
-const testDir = path.join(__dirname, '..', 'static');
+import {CodeUnderliner, fixtureDir} from '../test-utils';
 
 suite('CssCustomPropertyScanner', () => {
   let analyzer: Analyzer;
   let underliner: CodeUnderliner;
 
   setup(() => {
-    analyzer = Analyzer.createForDirectory(testDir);
+    analyzer = Analyzer.createForDirectory(fixtureDir);
     underliner = new CodeUnderliner(analyzer);
   });
 

--- a/src/test/css/css-parser_test.ts
+++ b/src/test/css/css-parser_test.ts
@@ -19,12 +19,12 @@ import * as path from 'path';
 import {ParsedCssDocument} from '../../css/css-document';
 import {CssParser} from '../../css/css-parser';
 import {PackageUrlResolver} from '../../index';
-import {resolvedUrl} from '../test-utils';
+import {fixtureDir, resolvedUrl} from '../test-utils';
 
 suite('CssParser', () => {
   suite('parse()', () => {
-    const fileContents = fs.readFileSync(
-        path.resolve(__dirname, '../static/stylesheet.css'), 'utf8');
+    const fileContents =
+        fs.readFileSync(path.join(fixtureDir, 'stylesheet.css'), 'utf8');
 
     let parser: CssParser;
 

--- a/src/test/html/html-document_test.ts
+++ b/src/test/html/html-document_test.ts
@@ -22,14 +22,13 @@ import {Analyzer} from '../../core/analyzer';
 import {ParsedHtmlDocument} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
-import {CodeUnderliner} from '../test-utils';
+import {CodeUnderliner, fixtureDir} from '../test-utils';
 
 suite('ParsedHtmlDocument', () => {
   const parser: HtmlParser = new HtmlParser();
   const url = `./source-ranges/html-complicated.html`;
-  const basedir = path.join(__dirname, '../static/');
-  const file = fs.readFileSync(path.join(basedir, url), 'utf8');
-  const analyzer = Analyzer.createForDirectory(basedir);
+  const file = fs.readFileSync(path.join(fixtureDir, url), 'utf8');
+  const analyzer = Analyzer.createForDirectory(fixtureDir);
   const document: ParsedHtmlDocument =
       parser.parse(file, analyzer.resolveUrl(url)!, new PackageUrlResolver({}));
   const underliner = new CodeUnderliner(analyzer);

--- a/src/test/html/html-parser_test.ts
+++ b/src/test/html/html-parser_test.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import {HtmlParser} from '../../html/html-parser';
 import {Analyzer} from '../../index';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
-import {resolvedUrl} from '../test-utils';
+import {fixtureDir, resolvedUrl} from '../test-utils';
 
 suite('HtmlParser', () => {
   suite('parse()', () => {
@@ -31,7 +31,7 @@ suite('HtmlParser', () => {
 
     suite('on a well-formed document', () => {
       const file = fs.readFileSync(
-          path.resolve(__dirname, '../static/html-parse-target.html'), 'utf8');
+          path.resolve(fixtureDir, 'html-parse-target.html'), 'utf8');
 
       test('parses a well-formed document', () => {
         const document = parser.parse(
@@ -52,7 +52,7 @@ suite('HtmlParser', () => {
 
     test('can properly determine the base url of a document', async () => {
       const analyzer =
-          Analyzer.createForDirectory(path.resolve(__dirname, '../'));
+          Analyzer.createForDirectory(path.resolve(fixtureDir, '../'));
       const resolvedPath =
           analyzer.resolveUrl(`static/base-href/doc-with-base.html`)!;
       const file = await analyzer.load(resolvedPath);

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -13,16 +13,14 @@
  */
 
 import {assert} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {HtmlScriptScanner} from '../../html/html-script-scanner';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {Analysis} from '../../model/analysis';
 import {ScannedImport, ScannedInlineDocument} from '../../model/model';
-import {runScannerOnContents} from '../test-utils';
+import {fixtureDir, runScannerOnContents} from '../test-utils';
 
-const fixturesDir = path.resolve(__dirname, '../static');
 suite('HtmlScriptScanner', () => {
   test('finds external and inline scripts', async () => {
     const contents = `<html><head>
@@ -57,7 +55,7 @@ suite('HtmlScriptScanner', () => {
   });
 
   suite('modules', () => {
-    const analyzer = Analyzer.createForDirectory(fixturesDir);
+    const analyzer = Analyzer.createForDirectory(fixtureDir);
     let analysis: Analysis;
 
     before(async () => {

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -14,15 +14,14 @@
 
 
 import {assert} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {Class, Element, ElementMixin, Method, ScannedClass} from '../../model/model';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 suite('Class', () => {
-  const analyzer = Analyzer.createForDirectory(path.resolve(__dirname, '../static'));
+  const analyzer = Analyzer.createForDirectory(fixtureDir);
   const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedFeatures(filename: string) {

--- a/src/test/javascript/function-scanner_test.ts
+++ b/src/test/javascript/function-scanner_test.ts
@@ -19,10 +19,10 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ScannedFunction} from '../../javascript/function';
 import {FunctionScanner} from '../../javascript/function-scanner';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 suite('FunctionScanner', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/namespaces/');
+  const testFilesDir = path.resolve(fixtureDir, 'namespaces/');
   const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -14,14 +14,13 @@
 
 
 import {assert} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {JavaScriptImportScanner} from '../../javascript/javascript-import-scanner';
-import {runScanner} from '../test-utils';
+import {fixtureDir, runScanner} from '../test-utils';
 
 suite('JavaScriptImportScanner', () => {
-  const analyzer = Analyzer.createForDirectory(path.resolve(__dirname, '../static'));
+  const analyzer = Analyzer.createForDirectory(fixtureDir);
 
   test('finds imports', async () => {
     const {features} = await runScanner(

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -23,7 +23,7 @@ import * as esutil from '../../javascript/esutil';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {JavaScriptParser, JavaScriptModuleParser, JavaScriptScriptParser} from '../../javascript/javascript-parser';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
-import {resolvedUrl} from '../test-utils';
+import {resolvedUrl, fixtureDir} from '../test-utils';
 
 suite('JavaScriptParser', () => {
   let parser: JavaScriptParser;
@@ -82,7 +82,7 @@ suite('JavaScriptParser', () => {
 
     test('throws syntax errors', () => {
       const file = fs.readFileSync(
-          path.resolve(__dirname, '../static/js-parse-error.js'), 'utf8');
+          path.resolve(fixtureDir, 'js-parse-error.js'), 'utf8');
       assert.throws(
           () => parser.parse(
               file,
@@ -91,8 +91,8 @@ suite('JavaScriptParser', () => {
     });
 
     test('attaches comments', () => {
-      const file = fs.readFileSync(
-          path.resolve(__dirname, '../static/js-elements.js'), 'utf8');
+      const file =
+          fs.readFileSync(path.resolve(fixtureDir, 'js-elements.js'), 'utf8');
       const document = parser.parse(
           file, resolvedUrl`/static/js-elements.js`, new PackageUrlResolver());
       const ast = document.ast;

--- a/src/test/javascript/namespace-scanner_test.ts
+++ b/src/test/javascript/namespace-scanner_test.ts
@@ -19,10 +19,10 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ScannedNamespace} from '../../javascript/namespace';
 import {NamespaceScanner} from '../../javascript/namespace-scanner';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 suite('NamespaceScanner', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/namespaces/');
+  const testFilesDir = path.resolve(fixtureDir, 'namespaces/');
   const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -14,12 +14,11 @@
 
 
 import {assert} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {ScannedBehavior, ScannedBehaviorAssignment} from '../../polymer/behavior';
 import {BehaviorScanner} from '../../polymer/behavior-scanner';
-import {runScanner} from '../test-utils';
+import {fixtureDir, runScanner} from '../test-utils';
 
 suite('BehaviorScanner', () => {
   let behaviors: Map<string, ScannedBehavior>;
@@ -27,7 +26,7 @@ suite('BehaviorScanner', () => {
 
   suiteSetup(async () => {
     const {features} = await runScanner(
-        Analyzer.createForDirectory(path.resolve(__dirname, '../static')),
+        Analyzer.createForDirectory(fixtureDir),
         new BehaviorScanner(),
         'js-behaviors.js');
     behaviors = new Map();

--- a/src/test/polymer/polymer-core-feature_test.ts
+++ b/src/test/polymer/polymer-core-feature_test.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ScannedPolymerCoreFeature} from '../../polymer/polymer-core-feature';
 import {PolymerCoreFeatureScanner} from '../../polymer/polymer-core-feature-scanner';
-import {runScannerOnContents} from '../test-utils';
+import {fixtureDir, runScannerOnContents} from '../test-utils';
 
 suite('PolymerCoreFeatureScanner', () => {
   test('scans _addFeature calls and the Polymer.Base assignment', async () => {
@@ -114,7 +114,7 @@ suite('PolymerCoreFeatureScanner', () => {
   test('resolves the Polymer.Base class', async () => {
     // This directory contains files copied from Polymer 1.x core.
     const analyzer = Analyzer.createForDirectory(
-        path.resolve(__dirname, '../static/polymer-core-feature/'));
+        path.resolve(fixtureDir, 'polymer-core-feature/'));
 
     const analysis = await analyzer.analyzePackage();
     const features = analysis.getFeatures({id: 'Polymer.Base', kind: 'class'});

--- a/src/test/polymer/polymer-element-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer-element-old-jsdoc_test.ts
@@ -21,9 +21,10 @@ import {ClassScanner} from '../../javascript/class-scanner';
 import {PolymerElement} from '../../polymer/polymer-element';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
+import {fixtureDir} from '../test-utils';
 
 suite('PolymerElement with old jsdoc annotations', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
+  const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
   const urlLoader = new FSUrlLoader(testFilesDir);
   const analyzer = new Analyzer({
     urlLoader: urlLoader,

--- a/src/test/polymer/polymer-element_test.ts
+++ b/src/test/polymer/polymer-element_test.ts
@@ -19,10 +19,11 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {Severity, Warning} from '../../model/model';
 import {PolymerElement} from '../../polymer/polymer-element';
+import {fixtureDir} from '../test-utils';
 
 suite('PolymerElement', () => {
-  const analyzer = Analyzer.createForDirectory(
-      path.resolve(__dirname, '../static/polymer2/'));
+  const analyzer =
+      Analyzer.createForDirectory(path.resolve(fixtureDir, 'polymer2/'));
 
   async function getElements(filename: string): Promise<Set<PolymerElement>> {
     const result = (await analyzer.analyze([filename])).getDocument(filename);

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -19,12 +19,12 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner with old jsdoc annotations', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
+  const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
   const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -19,13 +19,13 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
 
 suite('Polymer2ElementScanner', () => {
-  const analyzer = Analyzer.createForDirectory(
-      path.resolve(__dirname, '../static/polymer2/'));
+  const analyzer =
+      Analyzer.createForDirectory(path.resolve(fixtureDir, 'polymer2/'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getElements(filename: string):
@@ -554,19 +554,21 @@ namespaced name.`,
   test('can identify elements registered with ClassName.is', async () => {
     const elements = await getElements('test-element-11.js');
     const elementData = await Promise.all(elements.map(getTestProps));
-    assert.deepEqual(
-        elementData, [{
-          attributes: [{name: 'prop1'}],
-          className: 'MyElement',
-          description: '',
-          methods: [],
-          properties:
-              [{name: 'prop1', description: '', type: 'string | null | undefined'}],
-          summary: '',
-          superClass: 'Polymer.Element',
-          tagName: 'my-app',
-          warningUnderlines: [],
-        }]);
+    assert.deepEqual(elementData, [
+      {
+        attributes: [{name: 'prop1'}],
+        className: 'MyElement',
+        description: '',
+        methods: [],
+        properties: [
+          {name: 'prop1', description: '', type: 'string | null | undefined'}
+        ],
+        summary: '',
+        superClass: 'Polymer.Element',
+        tagName: 'my-app',
+        warningUnderlines: [],
+      }
+    ]);
   });
 
   test('can infer properties assigned to in the constructor', async () => {

--- a/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -15,12 +15,11 @@
 
 import * as chai from 'chai';
 import {assert} from 'chai';
-import * as path from 'path';
 
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
-import {runScanner} from '../test-utils';
+import {fixtureDir, runScanner} from '../test-utils';
 
 
 //
@@ -39,9 +38,9 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
   let elementsList: ScannedPolymerElement[];
 
   suiteSetup(async () => {
-    const analyzer = Analyzer.createForDirectory(path.resolve(__dirname, '../'));
-    const {features} = await runScanner(
-        analyzer, new ClassScanner(), 'static/vanilla-elements.js');
+    const analyzer = Analyzer.createForDirectory(fixtureDir);
+    const {features} =
+        await runScanner(analyzer, new ClassScanner(), 'vanilla-elements.js');
 
     elementsList = features.filter((e) => e instanceof ScannedPolymerElement) as
         ScannedPolymerElement[];

--- a/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -19,10 +19,10 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner with old jsdoc annotations', () => {
-  const testFilesDir = path.resolve(__dirname, '../static/polymer2-old-jsdoc/');
+  const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
   const analyzer = Analyzer.createForDirectory(testFilesDir);
   const underliner = new CodeUnderliner(analyzer);
 

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -19,11 +19,11 @@ import * as path from 'path';
 import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
-import {CodeUnderliner, runScanner} from '../test-utils';
+import {CodeUnderliner, fixtureDir, runScanner} from '../test-utils';
 
 suite('Polymer2MixinScanner', () => {
-  const analyzer = Analyzer.createForDirectory(
-      path.resolve(__dirname, '../static/polymer2/'));
+  const analyzer =
+      Analyzer.createForDirectory(path.resolve(fixtureDir, 'polymer2/'));
   const underliner = new CodeUnderliner(analyzer);
 
   async function getScannedMixins(filename: string) {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as path from 'path';
 import {Analyzer} from '../core/analyzer';
 import {FileRelativeUrl, ParsedDocument, ResolvedUrl, ScannedFeature, UrlResolver} from '../index';
 import {makeParseLoader, SourceRange, Warning} from '../model/model';
@@ -148,3 +149,5 @@ export function resolvedUrl(
     strings: TemplateStringsArray, ...values: any[]): ResolvedUrl {
   return noOpTag(strings, ...values) as ResolvedUrl;
 }
+
+export const fixtureDir = path.join(__dirname, '../../src/test/static');

--- a/src/test/url-loader/fetch-url-loader_test.html
+++ b/src/test/url-loader/fetch-url-loader_test.html
@@ -1,43 +1,46 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8">
-    <script src="../../../web-component-tester/browser.js"></script>
-    <script src="../../hydrolysis.js"></script>
-  </head>
-  <body>
-    <script>
-      'use strict';
 
-      const FetchUrlLoader = require('hydrolysis').FetchUrlLoader;
+<head>
+  <meta charset="UTF-8">
+  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../hydrolysis.js"></script>
+</head>
 
-      suite('FetchUrlLoader', () => {
+<body>
+  <script>
+    'use strict';
 
-        let loader;
+    const FetchUrlLoader = require('hydrolysis').FetchUrlLoader;
 
-        setup(() => {
-          loader = new FetchUrlLoader();
-        })
+    suite('FetchUrlLoader', () => {
 
-        test('load() returns a Promise that resolves an existing document', () => {
-          let url = new URL('../static/xhr-text.txt', document.baseURI).href;
-          return loader.load(url)
-            .then((content) => {
-              assert.equal(content.trim(), 'Hello!');
-            });
-        });
+      let loader;
 
-        test('load() returns a Promise that rejects ', () => {
-          var url = new URL('../static/not-found', document.baseURI).href;
-          return loader.load(url)
-            .then((content) => {
-              throw new Error(`resolve not expected: ${content}`);
-            }, (error) => {
-              // pass
-            });
-        });
+      setup(() => {
+        loader = new FetchUrlLoader();
+      })
 
+      test('load() returns a Promise that resolves an existing document', () => {
+        let url = new URL('../static/xhr-text.txt', document.baseURI).href;
+        return loader.load(url)
+          .then((content) => {
+            assert.equal(content.trim(), 'Hello!');
+          });
       });
-    </script>
-  </body>
+
+      test('load() returns a Promise that rejects ', () => {
+        var url = new URL('../static/not-found', document.baseURI).href;
+        return loader.load(url)
+          .then((content) => {
+            throw new Error(`resolve not expected: ${content}`);
+          }, (error) => {
+            // pass
+          });
+      });
+
+    });
+  </script>
+</body>
+
 </html>

--- a/src/test/warning/warning-printer_test.ts
+++ b/src/test/warning/warning-printer_test.ts
@@ -22,13 +22,12 @@ import {JavaScriptParser} from '../../javascript/javascript-parser';
 import {Severity, Warning} from '../../model/model';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {WarningPrinter} from '../../warning/warning-printer';
-import {resolvedUrl} from '../test-utils';
+import {fixtureDir, resolvedUrl} from '../test-utils';
 
 const parser = new JavaScriptParser();
-const staticTestDir = path.join(__dirname, '../static');
 const url = resolvedUrl`vanilla-elements.js`;
 const vanillaSources =
-    fs.readFileSync(path.join(staticTestDir, 'vanilla-elements.js'), 'utf-8');
+    fs.readFileSync(path.join(fixtureDir, 'vanilla-elements.js'), 'utf-8');
 const parsedDocument =
     parser.parse(vanillaSources, url, new PackageUrlResolver());
 


### PR DESCRIPTION
We're now mostly limited by the speed at which our tests run.

There's two parts of this change:
  * use `tsc-then` to keep the typescript compiler warm
  * read our fixtures out of src/, never copy them over into lib/

 - [x] CHANGELOG.md not updated, internal change
