### PR TITLE
Inline Documents inherit Container Document base href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Analyzer#urlResolver is a property that exposes the analyzer's url resolver,
   for cases where more direct access to url resolution is desired.
 * Fix a situation where a warning would be reported as `[Object object]`.
+* Fix issue where inline JavaScript module import statements did not honor
+  their containing document's baseUrl; inline documents now inherit baseUrl
+  from their containing documents.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.3] - 2017-12-08

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -404,6 +404,8 @@ export class AnalysisContext {
             feature.contents,
             containingDocument.url,
             {locationOffset, astNode: feature.astNode});
+        // Inline documents inherit the base url of their containers.
+        parsedDoc.baseUrl = containingDocument.document.baseUrl;
         const scannedDoc = await this._scanDocument(
             parsedDoc, feature.attachedComment, containingDocument.document);
 

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -16,7 +16,7 @@ import {Document, Import, ScannedImport, Severity, Warning} from '../model/model
 
 /**
  * <script> tags are represented in two different ways: as inline documents,
- * or as imports, dependeng on whether the tag has a `src` attribute. This class
+ * or as imports, depending on whether the tag has a `src` attribute. This class
  * represents a script tag with a `src` attribute as an import, so that the
  * analyzer loads and parses the referenced document.
  */

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -48,7 +48,8 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
         }
         imports.push(new ScannedImport(
             'js-import',
-            ScannedImport.resolveUrl(document.url, source as FileRelativeUrl),
+            ScannedImport.resolveUrl(
+                document.baseUrl, source as FileRelativeUrl),
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.callee)!,
             node,
@@ -63,7 +64,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
         }
         imports.push(new ScannedImport(
             'js-import',
-            ScannedImport.resolveUrl(document.url, source),
+            ScannedImport.resolveUrl(document.baseUrl, source),
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.source)!,
             node,

--- a/src/test/static/base-href/imports-js-module-with-base.html
+++ b/src/test/static/base-href/imports-js-module-with-base.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <base href="../">
+  </head>
+  <body>
+    <script type="module">
+      import {someValue} from './javascript/module-with-export.js';
+      console.log(someValue);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- Fixes https://github.com/Polymer/polymer-analyzer/issues/795 where inline JavaScript module import statements did not honor their containing document's baseUrl.
- Inline documents now inherit baseUrl from their containing documents.
- Thanks @justinfagnani for showing me where scanned inline documents are born.
- [x] CHANGELOG.md has been updated
