### PR TITLE
Give ranges for css custom property declarations only on the name.

### DIFF
--- a/src/css/css-custom-property-scanner.ts
+++ b/src/css/css-custom-property-scanner.ts
@@ -90,7 +90,7 @@ class CssCustomPropertyVisitor implements Visitor {
     if (node.type === shady.nodeType.declaration &&
         node.name.startsWith('--')) {
       this.features.push(new CssCustomPropertyAssignment(
-          node.name, this.document.sourceRangeForNode(node)));
+          node.name, this.document.sourceRangeForShadyRange(node.nameRange)));
     } else if (node.type === shady.nodeType.expression) {
       this.getCustomPropertiesIn(node.text, node.range);
     } else if (node.type === shady.nodeType.atRule && node.parametersRange) {

--- a/src/css/css-document.ts
+++ b/src/css/css-document.ts
@@ -40,6 +40,10 @@ export class ParsedCssDocument extends ParsedDocument<shady.Node, Visitor> {
     return this.sourceRangeForShadyRange(node.range);
   }
 
+  /**
+   * Takes a range from a shadycss node directly, rather than a shadycss node.
+   * Useful when there are multiple ranges for a given node.
+   */
   sourceRangeForShadyRange(range: shady.Range): SourceRange {
     return this.offsetsToSourceRange(range.start, range.end);
   }

--- a/src/test/css/css-custom-property-scanner_test.ts
+++ b/src/test/css/css-custom-property-scanner_test.ts
@@ -40,13 +40,13 @@ suite('CssCustomPropertyScanner', () => {
         [
           `
       --primary-text-color: var(--light-theme-text-color);
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      ~~~~~~~~~~~~~~~~~~~~`,
           `
       --primary-background-color: var(--light-theme-background-color, --orange);
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~`,
           `
       --light-theme-background-color: #ffffff;
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
 
         ]);
     assert.deepEqual(assignments.map((a) => a.name), [


### PR DESCRIPTION
This aligns us with the vscode css languageserver, so that users don't see duplicate definitions when they find references/jump to definition. Related: https://github.com/Microsoft/vscode/issues/39890

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not updated, mostly internal change
