### PR TITLE
Expose FSUrlLoader#getFilePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+* Add FSUrlLoader#getFilePath which will return the file path that would
+  be loaded for a given ResolvedUrl, or an error message explaining why
+  it can't be.
+
 ## [3.0.0-pre.6] - 2017-12-18
 * [BREAKING] `Analysis#getDocument` now returns a `Result` object. When
   `result.successful` is true, `result.value` is a Document. When

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,7 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
-
 export function parseUrl(url: string): Url {
   if (!url.startsWith('//')) {
     return parseUrl_(url);
@@ -20,9 +33,13 @@ export function trimLeft(str: string, char: string): string {
   return str.substring(leftEdge);
 }
 
+/**
+ * Returns whether the given file path points to a location inside the given
+ * directory.
+ */
 export function isPathInside(directory: string, filePath: string): boolean {
   if (process.platform === 'win32') {
-    return filePath.toLowerCase().startsWith(directory);
+    return filePath.toLowerCase().startsWith(directory.toLowerCase());
   }
   return filePath.startsWith(directory);
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,16 +1,3 @@
-/**
- * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
 import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
@@ -31,6 +18,13 @@ export function trimLeft(str: string, char: string): string {
     leftEdge++;
   }
   return str.substring(leftEdge);
+}
+
+export function isPathInside(directory: string, filePath: string): boolean {
+  if (process.platform === 'win32') {
+    return filePath.toLowerCase().startsWith(directory);
+  }
+  return filePath.startsWith(directory);
 }
 
 export class Deferred<T> {

--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -26,6 +26,13 @@ import {ResolvedUrl} from './url';
 import {Warning} from './warning';
 
 
+/**
+ * Represents the result of a computation that may fail.
+ *
+ * This lets us represent errors in a type-safe way, as well as
+ * in a way that makes it clear to the caller that the computation
+ * may fail.
+ */
 export type Result<T, E> = {
   successful: true,
   value: T,
@@ -152,26 +159,27 @@ export class Analysis implements Queryable {
    *
    * @param sourceRange Source range to search for in a document
    */
-   getDocumentContaining(sourceRange: SourceRange|undefined) {
-     if (!sourceRange) {
-       return undefined;
-     }
-     let mostSpecificDocument: undefined|Document = undefined;
-     const [outerDocument] = this.getFeatures({kind: 'document', id: sourceRange.file});
-     if (!outerDocument) {
-       return undefined;
-     }
-     for (const doc of outerDocument.getFeatures({kind: 'document'})) {
-       if (isPositionInsideRange(sourceRange.start, doc.sourceRange)) {
-         if (!mostSpecificDocument ||
-             isPositionInsideRange(
-                 doc.sourceRange!.start, mostSpecificDocument.sourceRange)) {
-           mostSpecificDocument = doc;
-         }
-       }
-     }
-     return mostSpecificDocument;
-   }
+  getDocumentContaining(sourceRange: SourceRange|undefined) {
+    if (!sourceRange) {
+      return undefined;
+    }
+    let mostSpecificDocument: undefined|Document = undefined;
+    const [outerDocument] =
+        this.getFeatures({kind: 'document', id: sourceRange.file});
+    if (!outerDocument) {
+      return undefined;
+    }
+    for (const doc of outerDocument.getFeatures({kind: 'document'})) {
+      if (isPositionInsideRange(sourceRange.start, doc.sourceRange)) {
+        if (!mostSpecificDocument ||
+            isPositionInsideRange(
+                doc.sourceRange!.start, mostSpecificDocument.sourceRange)) {
+          mostSpecificDocument = doc;
+        }
+      }
+    }
+    return mostSpecificDocument;
+  }
 
   private _getDocumentQuery(query: Query = {}): DocumentQuery {
     return {

--- a/src/model/warning.ts
+++ b/src/model/warning.ts
@@ -367,6 +367,10 @@ export function makeParseLoader(analyzer: Analyzer, analysis?: Analysis) {
     if (result.successful) {
       return result.value.parsedDocument;
     }
-    throw new Error(`Cannot load file at:  ${url}`);
+    let message = '';
+    if (result.error) {
+      message = result.error.message;
+    }
+    throw new Error(`Cannot load file at: ${JSON.stringify(url)}: ${message}`);
   };
 }


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

This method will be useful in the CLI, where we need to get these paths in order to write out files when fixing lint warnings.

This also fixes a bug whereby we weren't verifying that the loaded file contained within the root dir.