### PR TITLE
Add type parmeter to Document.

### DIFF
--- a/src/model/analysis.ts
+++ b/src/model/analysis.ts
@@ -159,7 +159,8 @@ export class Analysis implements Queryable {
    *
    * @param sourceRange Source range to search for in a document
    */
-  getDocumentContaining(sourceRange: SourceRange|undefined) {
+  getDocumentContaining(sourceRange: SourceRange|undefined): Document
+      |undefined {
     if (!sourceRange) {
       return undefined;
     }

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -14,7 +14,12 @@
 import * as dom5 from 'dom5';
 
 import {AnalysisContext} from '../core/analysis-context';
+import {ParsedCssDocument} from '../css/css-document';
+import {ParsedHtmlDocument} from '../html/html-document';
+import {JavaScriptDocument} from '../javascript/javascript-document';
+import {ParsedJsonDocument} from '../json/json-document';
 import {ParsedDocument} from '../parser/document';
+import {ParsedTypeScriptDocument} from '../typescript/typescript-document';
 
 import {Analysis} from './analysis';
 import {Feature, ScannedFeature} from './feature';
@@ -85,13 +90,15 @@ declare module './queryable' {
     'document': Document;
 
     // Document specializations.
-    'html-document': Document;
-    'js-document': Document;
-    'json-document': Document;
-    'css-document': Document;
+    'html-document': Document<ParsedHtmlDocument>;
+    'js-document': Document<JavaScriptDocument>;
+    'json-document': Document<ParsedJsonDocument>;
+    'css-document': Document<ParsedCssDocument>;
+    'typescript-document': Document<ParsedTypeScriptDocument>;
   }
 }
-export class Document implements Feature, Queryable {
+export class Document<ParsedType extends ParsedDocument = ParsedDocument>
+    implements Feature, Queryable {
   readonly kinds: ImmutableSet<string> = new Set(['document']);
   readonly identifiers: ImmutableSet<string> = new Set();
 
@@ -155,8 +162,8 @@ export class Document implements Feature, Queryable {
     return this._scannedDocument.astNode;
   }
 
-  get parsedDocument(): ParsedDocument {
-    return this._scannedDocument.document;
+  get parsedDocument(): ParsedType {
+    return this._scannedDocument.document as ParsedType;
   }
 
   get resolved(): boolean {


### PR DESCRIPTION
This is optional and backwards compatible, but it's useful sometimes when we know the type of a Document's parsed document.

See discussion at https://github.com/Polymer/polymer-editor-service/pull/113 which spawned this

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
