### PR TITLE
UrlResolver#resolve(baseUrl, fileRelativeUrl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* [BREAKING]: `UrlResolver#resolve()` argument order swapped so that the
+  optional `baseUrl` argument comes first instead of second.  This makes
+  resolve more similar to `url.resolve`.
 * `UrlResolver#resolve()` returns urls containing querystring and fragment
   components where they were previously stripped out.
 * Add FSUrlLoader#getFilePath which will return the file path that would

--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -312,7 +312,7 @@ export class AnalysisContext {
 
             // Update dependency graph
             const importUrls = filterOutUndefineds(imports.map(
-                (i) => this.resolver.resolve(i.url, parsedDoc.baseUrl, i)));
+                (i) => this.resolver.resolve(parsedDoc.baseUrl, i.url, i)));
             this._cache.dependencyGraph.addDocument(resolvedUrl, importUrls);
 
             return scannedDocument;
@@ -337,8 +337,8 @@ export class AnalysisContext {
           // Scan imports
           for (const scannedImport of imports) {
             const importUrl = this.resolver.resolve(
-                scannedImport.url,
                 scannedDocument.document.baseUrl,
+                scannedImport.url,
                 scannedImport);
             if (importUrl === undefined) {
               continue;

--- a/src/html/html-parser.ts
+++ b/src/html/html-parser.ts
@@ -45,7 +45,7 @@ export class HtmlParser implements Parser<ParsedHtmlDocument> {
     let baseUrl;
     if (baseTag) {
       const baseHref = getAttribute(baseTag, 'href')! as FileRelativeUrl;
-      baseUrl = urlResolver.resolve(baseHref, url, undefined);
+      baseUrl = urlResolver.resolve(url, baseHref, undefined);
     } else {
       baseUrl = url;
     }

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -34,7 +34,7 @@ export class ScriptTagBackReferenceImport extends Import {
 export class ScannedScriptTagImport extends ScannedImport {
   resolve(document: Document): ScriptTagImport|undefined {
     const resolvedUrl = document._analysisContext.resolver.resolve(
-        this.url, document.parsedDocument.baseUrl, this);
+        document.parsedDocument.baseUrl, this.url, this);
     if (resolvedUrl === undefined) {
       return;
     }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -67,7 +67,7 @@ export class ScannedImport implements Resolvable {
 
   resolve(document: Document): Import|undefined {
     const resolvedUrl = document._analysisContext.resolver.resolve(
-        this.url, document.parsedDocument.baseUrl, this);
+        document.parsedDocument.baseUrl, this.url, this);
     if (resolvedUrl === undefined) {
       return;
     }

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -60,8 +60,10 @@ export class CodeUnderliner {
     const urlLoader = new InMemoryOverlayUrlLoader();
     urlLoader.urlContentsMap.set(url, contents);
     return new CodeUnderliner(urlLoader, new class extends UrlResolver {
-      resolve(url: FileRelativeUrl|PackageRelativeUrl) {
-        return this.brandAsResolved(url);
+      resolve(
+          firstUrl: ResolvedUrl|PackageRelativeUrl,
+          secondUrl?: FileRelativeUrl) {
+        return this.brandAsResolved(secondUrl || firstUrl);
       }
 
       relative(): FileRelativeUrl {
@@ -143,6 +145,11 @@ export const noOpTag =
 export function fileRelativeUrl(
     strings: TemplateStringsArray, ...values: any[]): FileRelativeUrl {
   return noOpTag(strings, ...values) as FileRelativeUrl;
+}
+
+export function packageRelativeUrl(
+    strings: TemplateStringsArray, ...values: any[]): PackageRelativeUrl {
+  return noOpTag(strings, ...values) as PackageRelativeUrl;
 }
 
 export function resolvedUrl(

--- a/src/test/typescript/typescript-analyzer_test.ts
+++ b/src/test/typescript/typescript-analyzer_test.ts
@@ -28,7 +28,7 @@ async function getTypeScriptAnalyzer(files: Map<PackageRelativeUrl, string>) {
   const urlResolver = new PackageUrlResolver();
   for (const [url, contents] of files) {
     urlLoader.urlContentsMap.set(
-        urlResolver.resolve(url as any, '' as any)!, contents);
+        urlResolver.resolve('' as any, url as any)!, contents);
   }
   const analysisContext = new AnalysisContext({
     parsers: new Map([['ts', new TypeScriptPreparser()]]),

--- a/src/test/url-loader/multi-url-resolver_test.ts
+++ b/src/test/url-loader/multi-url-resolver_test.ts
@@ -52,7 +52,7 @@ suite('MultiUrlResolver', function() {
           ['resolved.html', 'resolved2.html', 'resolved3.html']);
       const resolver = new MultiUrlResolver(resolvers);
       assert.equal(
-          resolver.resolve(fileRelativeUrl`test.html`, resolvedUrl``),
+          resolver.resolve(resolvedUrl``, fileRelativeUrl`test.html`),
           resolvedUrl`resolved.html`);
       // Verify only the first resolver is called
       assert.equal(resolvers[0].resolveCount, 1);
@@ -64,7 +64,7 @@ suite('MultiUrlResolver', function() {
       const resolvers = mockResolverArray([null, null, 'resolved.html']);
       const resolver = new MultiUrlResolver(resolvers);
       assert.equal(
-          resolver.resolve(fileRelativeUrl`test.html`, resolvedUrl``),
+          resolver.resolve(resolvedUrl``, fileRelativeUrl`test.html`),
           resolvedUrl`resolved.html`);
       // Verify all resolvers are called
       assert.equal(resolvers[0].resolveCount, 1);
@@ -77,7 +77,7 @@ suite('MultiUrlResolver', function() {
           ['resolved.html', 'resolved2.html', 'resolved3.html']);
       const resolver = new MultiUrlResolver(resolvers);
       assert.equal(
-          resolver.resolve(fileRelativeUrl`test.html`, resolvedUrl``),
+          resolver.resolve(resolvedUrl``, fileRelativeUrl`test.html`),
           resolvedUrl`resolved.html`);
       // Verify only the first resolver is called
       assert.equal(resolvers[0].resolveCount, 1);
@@ -89,7 +89,7 @@ suite('MultiUrlResolver', function() {
       const resolvers = mockResolverArray([null, null, null]);
       const resolver = new MultiUrlResolver(resolvers);
       assert.equal(
-          resolver.resolve(fileRelativeUrl`test.html`, resolvedUrl``),
+          resolver.resolve(resolvedUrl``, fileRelativeUrl`test.html`),
           undefined);
       // Verify only the first resolver is called
       assert.equal(resolvers[0].resolveCount, 1);

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -25,12 +25,12 @@ suite('RedirectResolver', function() {
           new RedirectResolver(resolvedUrl``, 'proto://site/', 'some/path/');
       assert.equal(
           resolver.resolve(
-              fileRelativeUrl`proto://site/something.html`, resolvedUrl``),
+              resolvedUrl``, fileRelativeUrl`proto://site/something.html`),
           resolvedUrl`some/path/something.html`);
       resolver = new RedirectResolver(resolvedUrl``, '/site/', 'some/path/');
       assert.equal(
           resolver.resolve(
-              fileRelativeUrl`/site/something.html`, resolvedUrl``),
+              resolvedUrl``, fileRelativeUrl`/site/something.html`),
           resolvedUrl`some/path/something.html`);
     });
 
@@ -39,7 +39,7 @@ suite('RedirectResolver', function() {
           new RedirectResolver(resolvedUrl``, 'proto://site/', 'some/path/');
       assert.equal(
           resolver.resolve(
-              fileRelativeUrl`protoz://site/something.html`, resolvedUrl``),
+              resolvedUrl``, fileRelativeUrl`protoz://site/something.html`),
           undefined);
     });
   });

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -15,7 +15,7 @@
 import {assert} from 'chai';
 
 import {RedirectResolver} from '../../url-loader/redirect-resolver';
-import {fileRelativeUrl, resolvedUrl} from '../test-utils';
+import {packageRelativeUrl, resolvedUrl} from '../test-utils';
 
 
 suite('RedirectResolver', function() {
@@ -24,13 +24,11 @@ suite('RedirectResolver', function() {
       let resolver =
           new RedirectResolver(resolvedUrl``, 'proto://site/', 'some/path/');
       assert.equal(
-          resolver.resolve(
-              resolvedUrl``, fileRelativeUrl`proto://site/something.html`),
+          resolver.resolve(packageRelativeUrl`proto://site/something.html`),
           resolvedUrl`some/path/something.html`);
       resolver = new RedirectResolver(resolvedUrl``, '/site/', 'some/path/');
       assert.equal(
-          resolver.resolve(
-              resolvedUrl``, fileRelativeUrl`/site/something.html`),
+          resolver.resolve(packageRelativeUrl`/site/something.html`),
           resolvedUrl`some/path/something.html`);
     });
 
@@ -38,8 +36,7 @@ suite('RedirectResolver', function() {
       const resolver =
           new RedirectResolver(resolvedUrl``, 'proto://site/', 'some/path/');
       assert.equal(
-          resolver.resolve(
-              resolvedUrl``, fileRelativeUrl`protoz://site/something.html`),
+          resolver.resolve(packageRelativeUrl`protoz://site/something.html`),
           undefined);
     });
   });

--- a/src/test/url-loader/url-resolver_test.ts
+++ b/src/test/url-loader/url-resolver_test.ts
@@ -19,9 +19,11 @@ import {UrlResolver} from '../../url-loader/url-resolver';
 
 class SimplestUrlResolver extends UrlResolver {
   resolve(
-      url: FileRelativeUrl|PackageRelativeUrl,
-      baseUrl: ResolvedUrl = '/test/' as ResolvedUrl) {
-    return this.simpleUrlResolve(url, baseUrl);
+      firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl) {
+    const [baseUrl, url] = typeof secondUrl === 'undefined' ?
+        [this.brandAsResolved('/test/'), firstUrl as PackageRelativeUrl] :
+        [this.brandAsResolved(firstUrl), secondUrl];
+    return this.simpleUrlResolve(baseUrl, url);
   }
 
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):
@@ -41,24 +43,25 @@ class SimplestUrlResolver extends UrlResolver {
 suite('UrlResolver', () => {
   suite('resolve', () => {
     const resolver = new SimplestUrlResolver();
-    function resolve(url: string, baseUrl: string) {
-      return resolver.resolve(url as FileRelativeUrl, baseUrl as ResolvedUrl);
+    function resolve(baseUrl: string, unresolvedUrl: string) {
+      return resolver.resolve(
+          baseUrl as ResolvedUrl, unresolvedUrl as FileRelativeUrl);
     }
     test('can resolve a url when relative url contains no pathname', () => {
-      assert.equal(resolve('', '/foo.html?fiz#buz'), '/foo.html?fiz');
-      assert.equal(resolve('#fiz', '/foo.html'), '/foo.html#fiz');
-      assert.equal(resolve('#fiz', '/foo.html#buz'), '/foo.html#fiz');
-      assert.equal(resolve('?fiz', '/foo.html'), '/foo.html?fiz');
-      assert.equal(resolve('?fiz', '/foo.html?buz'), '/foo.html?fiz');
-      assert.equal(resolve(`?fiz`, `/foo.html?bar#buz`), `/foo.html?fiz`);
+      assert.equal(resolve('/foo.html?fiz#buz', ''), '/foo.html?fiz');
+      assert.equal(resolve('/foo.html', '#fiz'), '/foo.html#fiz');
+      assert.equal(resolve('/foo.html#buz', '#fiz'), '/foo.html#fiz');
+      assert.equal(resolve('/foo.html', '?fiz'), '/foo.html?fiz');
+      assert.equal(resolve('/foo.html?buz', '?fiz'), '/foo.html?fiz');
+      assert.equal(resolve('/foo.html?bar#buz', '?fiz'), `/foo.html?fiz`);
     });
   });
 
   suite('relative', () => {
     const resolver = new SimplestUrlResolver();
     function relative(from: string, to: string) {
-      const fromResolved = resolver.resolve(from as FileRelativeUrl);
-      const toResolved = resolver.resolve(to as FileRelativeUrl);
+      const fromResolved = resolver.resolve(from as PackageRelativeUrl);
+      const toResolved = resolver.resolve(to as PackageRelativeUrl);
       return resolver.relative(fromResolved, toResolved);
     }
 

--- a/src/test/url-loader/url-resolver_test.ts
+++ b/src/test/url-loader/url-resolver_test.ts
@@ -20,9 +20,8 @@ import {UrlResolver} from '../../url-loader/url-resolver';
 class SimplestUrlResolver extends UrlResolver {
   resolve(
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl) {
-    const [baseUrl, url] = secondUrl === undefined ?
-        [this.brandAsResolved('/test/'), firstUrl as PackageRelativeUrl] :
-        [this.brandAsResolved(firstUrl), secondUrl];
+    const [baseUrl = '/test/' as ResolvedUrl, url] =
+        this.getBaseAndUnresolved(firstUrl, secondUrl);
     return this.simpleUrlResolve(baseUrl, url);
   }
 

--- a/src/test/url-loader/url-resolver_test.ts
+++ b/src/test/url-loader/url-resolver_test.ts
@@ -20,7 +20,7 @@ import {UrlResolver} from '../../url-loader/url-resolver';
 class SimplestUrlResolver extends UrlResolver {
   resolve(
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl) {
-    const [baseUrl, url] = typeof secondUrl === 'undefined' ?
+    const [baseUrl, url] = secondUrl === undefined ?
         [this.brandAsResolved('/test/'), firstUrl as PackageRelativeUrl] :
         [this.brandAsResolved(firstUrl), secondUrl];
     return this.simpleUrlResolve(baseUrl, url);

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -26,12 +26,13 @@ export class MultiUrlResolver extends UrlResolver {
   }
 
   resolve(
-      url: FileRelativeUrl|PackageRelativeUrl, baseUrl?: ResolvedUrl,
+      firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl,
       import_?: ScannedImport): ResolvedUrl|undefined {
     for (const resolver of this._resolvers) {
-      const resolved = baseUrl === undefined ?
-          resolver.resolve(url as PackageRelativeUrl) :
-          resolver.resolve(url as FileRelativeUrl, baseUrl, import_);
+      const resolved = typeof secondUrl === 'undefined' ?
+          resolver.resolve(firstUrl as PackageRelativeUrl) :
+          resolver.resolve(
+              firstUrl as ResolvedUrl, secondUrl as FileRelativeUrl, import_);
       if (resolved !== undefined) {
         return resolved;
       }

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -29,7 +29,7 @@ export class MultiUrlResolver extends UrlResolver {
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl,
       import_?: ScannedImport): ResolvedUrl|undefined {
     for (const resolver of this._resolvers) {
-      const resolved = typeof secondUrl === 'undefined' ?
+      const resolved = secondUrl === undefined ?
           resolver.resolve(firstUrl as PackageRelativeUrl) :
           resolver.resolve(
               firstUrl as ResolvedUrl, secondUrl as FileRelativeUrl, import_);

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -59,7 +59,7 @@ export class PackageUrlResolver extends UrlResolver {
   resolve(
       firstHref: ResolvedUrl|PackageRelativeUrl, secondHref?: FileRelativeUrl,
       _import?: ScannedImport): ResolvedUrl|undefined {
-    const [baseUrl, unresolvedHref] = typeof secondHref === 'undefined' ?
+    const [baseUrl, unresolvedHref] = secondHref === undefined ?
         [this.packageUrl, firstHref as PackageRelativeUrl] :
         [this.brandAsResolved(firstHref), secondHref];
     const resolvedHref = this.simpleUrlResolve(baseUrl, unresolvedHref);

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -59,9 +59,8 @@ export class PackageUrlResolver extends UrlResolver {
   resolve(
       firstHref: ResolvedUrl|PackageRelativeUrl, secondHref?: FileRelativeUrl,
       _import?: ScannedImport): ResolvedUrl|undefined {
-    const [baseUrl, unresolvedHref] = secondHref === undefined ?
-        [this.packageUrl, firstHref as PackageRelativeUrl] :
-        [this.brandAsResolved(firstHref), secondHref];
+    const [baseUrl = this.packageUrl, unresolvedHref] =
+        this.getBaseAndUnresolved(firstHref, secondHref);
     const resolvedHref = this.simpleUrlResolve(baseUrl, unresolvedHref);
     if (resolvedHref === undefined) {
       return undefined;

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -57,10 +57,12 @@ export class PackageUrlResolver extends UrlResolver {
   }
 
   resolve(
-      unresolvedHref: FileRelativeUrl|PackageRelativeUrl,
-      baseUrl: ResolvedUrl = this.packageUrl,
+      firstHref: ResolvedUrl|PackageRelativeUrl, secondHref?: FileRelativeUrl,
       _import?: ScannedImport): ResolvedUrl|undefined {
-    const resolvedHref = this.simpleUrlResolve(unresolvedHref, baseUrl);
+    const [baseUrl, unresolvedHref] = typeof secondHref === 'undefined' ?
+        [this.packageUrl, firstHref as PackageRelativeUrl] :
+        [this.brandAsResolved(firstHref), secondHref];
+    const resolvedHref = this.simpleUrlResolve(baseUrl, unresolvedHref);
     if (resolvedHref === undefined) {
       return undefined;
     }
@@ -145,7 +147,7 @@ export class PackageUrlResolver extends UrlResolver {
         const componentDirPath =
             pathnameInComponentDir.slice(this.resolvedComponentDir.length);
         const reresolved = this.simpleUrlResolve(
-            ('../' + componentDirPath) as FileRelativeUrl, this.packageUrl);
+            this.packageUrl, ('../' + componentDirPath) as FileRelativeUrl);
         if (reresolved !== undefined) {
           const reresolvedUrl = parseUrl(reresolved);
           const toUrl = parseUrl(to);

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -33,11 +33,10 @@ export class RedirectResolver extends UrlResolver {
   resolve(
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl,
       _import?: ScannedImport): ResolvedUrl|undefined {
-    const [baseUrl, fileRelativeUrl] = secondUrl === undefined ?
-        [this.packageUrl, firstUrl as PackageRelativeUrl] :
-        [firstUrl as ResolvedUrl, secondUrl];
+    const [baseUrl = this.packageUrl, unresolvedUrl] =
+        this.getBaseAndUnresolved(firstUrl, secondUrl);
     const packageRelativeUrl =
-        this.brandAsResolved(urlLibResolver(baseUrl, fileRelativeUrl));
+        this.brandAsResolved(urlLibResolver(baseUrl, unresolvedUrl));
     if (packageRelativeUrl === undefined ||
         !packageRelativeUrl.startsWith(this._redirectFrom)) {
       return undefined;

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -33,7 +33,7 @@ export class RedirectResolver extends UrlResolver {
   resolve(
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl,
       _import?: ScannedImport): ResolvedUrl|undefined {
-    const [baseUrl, fileRelativeUrl] = typeof secondUrl === 'undefined' ?
+    const [baseUrl, fileRelativeUrl] = secondUrl === undefined ?
         [this.packageUrl, firstUrl as PackageRelativeUrl] :
         [firstUrl as ResolvedUrl, secondUrl];
     const packageRelativeUrl =

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -31,9 +31,11 @@ export class RedirectResolver extends UrlResolver {
   }
 
   resolve(
-      fileRelativeUrl: FileRelativeUrl|PackageRelativeUrl,
-      baseUrl: ResolvedUrl = this.packageUrl,
+      firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl,
       _import?: ScannedImport): ResolvedUrl|undefined {
+    const [baseUrl, fileRelativeUrl] = typeof secondUrl === 'undefined' ?
+        [this.packageUrl, firstUrl as PackageRelativeUrl] :
+        [firstUrl as ResolvedUrl, secondUrl];
     const packageRelativeUrl =
         this.brandAsResolved(urlLibResolver(baseUrl, fileRelativeUrl));
     if (packageRelativeUrl === undefined ||

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -41,6 +41,14 @@ export abstract class UrlResolver {
   abstract relative(from: ResolvedUrl, to?: ResolvedUrl, kind?: string):
       FileRelativeUrl;
 
+  protected getBaseAndUnresolved(
+      url1: PackageRelativeUrl|ResolvedUrl, url2?: FileRelativeUrl):
+      [ResolvedUrl|undefined, FileRelativeUrl|PackageRelativeUrl] {
+    return url2 === undefined ?
+        [undefined, url1 as PackageRelativeUrl] :
+        [this.brandAsResolved(url1), this.brandAsRelative(url2)];
+  }
+
   protected simpleUrlResolve(
       baseUrl: ResolvedUrl,
       url: FileRelativeUrl|PackageRelativeUrl): ResolvedUrl {

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -35,16 +35,15 @@ export abstract class UrlResolver {
    */
   abstract resolve(url: PackageRelativeUrl): ResolvedUrl|undefined;
   abstract resolve(
-      url: FileRelativeUrl, baseUrl: ResolvedUrl,
+      baseUrl: ResolvedUrl, url: FileRelativeUrl,
       scannedImport?: ScannedImport): ResolvedUrl|undefined;
 
-  abstract relative(to: ResolvedUrl): FileRelativeUrl;
   abstract relative(from: ResolvedUrl, to?: ResolvedUrl, kind?: string):
       FileRelativeUrl;
 
   protected simpleUrlResolve(
-      url: FileRelativeUrl|PackageRelativeUrl,
-      baseUrl: ResolvedUrl): ResolvedUrl {
+      baseUrl: ResolvedUrl,
+      url: FileRelativeUrl|PackageRelativeUrl): ResolvedUrl {
     return this.brandAsResolved(urlLibResolver(baseUrl, url));
   }
 


### PR DESCRIPTION
We talked about reversing `UrlResolver#relative()` to make it `(to, from)` but I thought I'd apply the straw-man gambit and take a stab at flipping around `UrlResolver#resolve(baseUrl, url)` instead.

One nice side effect of this is that the type of the unresolvedUrl is known based on whether optional baseUrl is provided, since the typings of the two method forms are:

1. `UrlResolver#resolve(baseUrl: ResolvedUrl, unresolvedUrl: FileRelativeUrl)`
2. `UrlResolver#resolve(unresolvedUrl: PackageRelativeUrl)`


* [BREAKING]: `UrlResolver#resolve()` argument order swapped so that the optional `baseUrl` argument comes first instead of second.  This makes resolve more similar to `url.resolve`.
* [x] CHANGELOG.md has been updated
