### PR TITLE
detect static methods in polymer elements

### DIFF
--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -208,6 +208,11 @@ export function addMethod(
   target.methods.set(method.name, method);
 }
 
+export function addStaticMethod(
+    target: ScannedPolymerExtension, method: ScannedMethod) {
+  target.staticMethods.set(method.name, method);
+}
+
 /**
  * The metadata for a single polymer element
  */
@@ -215,6 +220,7 @@ export class ScannedPolymerElement extends ScannedElement implements
     ScannedPolymerExtension {
   properties = new Map<string, ScannedPolymerProperty>();
   methods = new Map<string, ScannedMethod>();
+  staticMethods = new Map<string, ScannedMethod>();
   observers: Observer[] = [];
   listeners: {event: string, handler: string}[] = [];
   behaviorAssignments: ScannedBehaviorAssignment[] = [];
@@ -247,6 +253,9 @@ export class ScannedPolymerElement extends ScannedElement implements
     if (options.methods) {
       options.methods.forEach((m) => this.addMethod(m));
     }
+    if (options.staticMethods) {
+      options.staticMethods.forEach((m) => this.addStaticMethod(m));
+    }
     const summaryTag = jsdoc.getTag(this.jsdoc, 'summary');
     this.summary =
         (summaryTag !== undefined && summaryTag.description != null) ?
@@ -260,6 +269,10 @@ export class ScannedPolymerElement extends ScannedElement implements
 
   addMethod(method: ScannedMethod) {
     addMethod(this, method);
+  }
+
+  addStaticMethod(method: ScannedMethod) {
+    addStaticMethod(this, method);
   }
 
   resolve(document: Document): PolymerElement {

--- a/src/test/static/analysis/class/analysis.json
+++ b/src/test/static/analysis/class/analysis.json
@@ -38,7 +38,25 @@
       "path": "classes.js",
       "properties": [],
       "methods": [],
-      "staticMethods": [],
+      "staticMethods": [
+        {
+          "description": "",
+          "metadata": {},
+          "name": "staticMeth",
+          "params": [],
+          "privacy": "public",
+          "sourceRange": {
+            "end": {
+              "column": 25,
+              "line": 12
+            },
+            "start": {
+              "column": 2,
+              "line": 12
+            }
+          }
+        }
+      ],
       "demos": [],
       "metadata": {},
       "sourceRange": {


### PR DESCRIPTION
This helps with polymer/polymer#5000.

We were not adding the static methods we detected on a polymer element to the scanned class.