### PR TITLE
detect return type of methods when not annotated

### DIFF
--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -205,6 +205,34 @@ suite('Class', () => {
             {
               name: 'customInstanceFunction',
               description: '',
+              return: {
+                type: 'number'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithNoReturn',
+              description: '',
+              return: {
+                type: 'void'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithInferredReturn',
+              description: '',
+              return: {
+                type: 'number'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithInferredMultipleReturn',
+              description: '',
+              return: {
+                type: '(number | boolean)'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithUninferrableReturn',
+              description: ''
             },
             {
               name: 'customInstanceFunctionWithJSDoc',
@@ -219,6 +247,9 @@ suite('Class', () => {
               name: 'customInstanceFunctionWithParams',
               description: '',
               params: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
+              return: {
+                type: 'number'
+              }
             },
             {
               name: 'customInstanceFunctionWithParamsAndJSDoc',
@@ -249,6 +280,9 @@ suite('Class', () => {
               name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
               description: 'This is the description for\n' +
                   'customInstanceFunctionWithParamsAndPrivateJSDoc.',
+              return: {
+                type: 'number'
+              }
             },
             {
               name: 'customInstanceFunctionWithRestParam',
@@ -312,10 +346,12 @@ suite('Class', () => {
             {
               description: 'This is a base method.',
               name: 'baseMethod',
+              return: { type: 'void' },
             },
             {
               description: 'Will be overriden by Subclass.',
               name: 'overriddenMethod',
+              return: { type: 'void' },
             }
           ]
         },
@@ -328,10 +364,12 @@ suite('Class', () => {
             {
               description: 'Overrides the method on Base.',
               name: 'overriddenMethod',
+              return: { type: 'void' },
             },
             {
               description: 'This method only exists on Subclass.',
               name: 'subMethod',
+              return: { type: 'void' },
             }
           ]
         }
@@ -420,6 +458,34 @@ suite('Class', () => {
             {
               name: 'customInstanceFunction',
               description: '',
+              return: {
+                type: 'number'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithNoReturn',
+              description: '',
+              return: {
+                type: 'void'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithInferredReturn',
+              description: '',
+              return: {
+                type: 'number'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithInferredMultipleReturn',
+              description: '',
+              return: {
+                type: '(number | boolean)'
+              }
+            },
+            {
+              name: 'customInstanceFunctionWithUninferrableReturn',
+              description: ''
             },
             {
               name: 'customInstanceFunctionWithJSDoc',
@@ -434,7 +500,7 @@ suite('Class', () => {
               name: 'customInstanceFunctionWithParams',
               description: '',
               params: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
-
+              return: { type: 'number' },
             },
             {
               name: 'customInstanceFunctionWithParamsAndJSDoc',
@@ -465,6 +531,9 @@ suite('Class', () => {
               name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
               description: 'This is the description for\n' +
                   'customInstanceFunctionWithParamsAndPrivateJSDoc.',
+              return: {
+                type: 'number'
+              }
             },
             {
               name: 'customInstanceFunctionWithRestParam',
@@ -528,10 +597,12 @@ suite('Class', () => {
             {
               description: 'This is a base method.',
               name: 'baseMethod',
+              return: { type: 'void' },
             },
             {
               description: 'Will be overriden by Subclass.',
               name: 'overriddenMethod',
+              return: { type: 'void' },
             }
           ]
         },
@@ -544,15 +615,18 @@ suite('Class', () => {
             {
               description: 'This is a base method.',
               name: 'baseMethod',
+              return: { type: 'void' },
               inheritedFrom: 'Base'
             },
             {
               description: 'Overrides the method on Base.',
               name: 'overriddenMethod',
+              return: { type: 'void' },
             },
             {
               description: 'This method only exists on Subclass.',
               name: 'subMethod',
+              return: { type: 'void' },
             },
           ]
         }

--- a/src/test/polymer/polymer-element-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer-element-old-jsdoc_test.ts
@@ -142,7 +142,7 @@ suite('PolymerElement with old jsdoc annotations', () => {
         methods: [{
           name: 'customMethodOnBaseElement',
           params: [],
-          return: undefined,
+          return: { type: 'string' },
           inheritedFrom: undefined
         }],
       },
@@ -194,19 +194,19 @@ suite('PolymerElement with old jsdoc annotations', () => {
           {
             name: 'customMethodOnBaseElement',
             params: [],
-            return: undefined,
+            return: { type: 'string' },
             inheritedFrom: 'BaseElement'
           },
           {
             name: 'customMethodOnMixin',
             params: [],
-            return: undefined,
+            return: { type: 'string' },
             inheritedFrom: 'Mixin'
           },
           {
             name: 'customMethodOnSubElement',
             params: [],
-            return: undefined,
+            return: { type: 'string' },
             inheritedFrom: undefined
           },
         ],

--- a/src/test/polymer/polymer-element_test.ts
+++ b/src/test/polymer/polymer-element_test.ts
@@ -186,7 +186,7 @@ suite('PolymerElement', () => {
         methods: [{
           name: 'customMethodOnBaseElement',
           params: [],
-          return: undefined,
+          return: { type: 'string' },
           inheritedFrom: undefined
         }],
       },
@@ -238,19 +238,19 @@ suite('PolymerElement', () => {
           {
             name: 'customMethodOnBaseElement',
             params: [],
-            return: undefined,
+            return: { type: 'string' },
             inheritedFrom: 'BaseElement'
           },
           {
             name: 'customMethodOnMixin',
             params: [],
-            return: undefined,
+            return: { type: 'string' },
             inheritedFrom: 'Mixin'
           },
           {
             name: 'customMethodOnSubElement',
             params: [],
-            return: undefined,
+            return: { type: 'string' },
             inheritedFrom: undefined
           },
         ],

--- a/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -412,7 +412,7 @@ namespaced name.`,
                 name: 'customInstanceFunction',
                 description: '',
                 params: [],
-                return: undefined
+                return: { type: 'number' },
               },
               {
                 name: 'customInstanceFunctionWithJSDoc',
@@ -450,7 +450,7 @@ namespaced name.`,
                     description: undefined
                   }
                 ],
-                return: undefined,
+                return: { type: 'number' },
               },
               {
                 name: 'customInstanceFunctionWithParamsAndJSDoc',
@@ -489,7 +489,7 @@ namespaced name.`,
                 description: 'This is the description for\n' +
                     'customInstanceFunctionWithParamsAndPrivateJSDoc.',
                 params: [],
-                return: undefined,
+                return: { type: 'number' },
               },
             ],
             warningUnderlines: [],

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -413,7 +413,7 @@ namespaced name.`,
                 name: 'customInstanceFunction',
                 description: '',
                 params: [],
-                return: undefined
+                return: { type: 'number' },
               },
               {
                 name: 'customInstanceFunctionWithJSDoc',
@@ -451,7 +451,7 @@ namespaced name.`,
                     description: undefined
                   }
                 ],
-                return: undefined,
+                return: { type: 'number' },
               },
               {
                 name: 'customInstanceFunctionWithParamsAndJSDoc',
@@ -490,7 +490,7 @@ namespaced name.`,
                 description: 'This is the description for\n' +
                     'customInstanceFunctionWithParamsAndPrivateJSDoc.',
                 params: [],
-                return: undefined,
+                return: { type: 'number' },
               },
             ],
             warningUnderlines: [],

--- a/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -339,7 +339,11 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
             name: 'foo',
           }],
           methods: [
-            {name: 'customInstanceFunction', params: [], return: undefined},
+            {
+              name: 'customInstanceFunction',
+              params: [],
+              return: { type: 'number' },
+            },
             {
               name: 'customInstanceFunctionWithJSDoc',
               params: [],
@@ -351,7 +355,7 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
             {
               name: 'customInstanceFunctionWithParams',
               params: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
-              return: undefined,
+              return: { type: 'number' },
             },
             {
               name: 'customInstanceFunctionWithParamsAndJSDoc',
@@ -379,7 +383,7 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
             {
               name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
               params: [],
-              return: undefined,
+              return: { type: 'number' },
             },
           ],
           underlinedWarnings: [],
@@ -396,10 +400,26 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
         summary: '',
         attributes: [{name: 'foo'}],
         methods: [
-          {name: 'baseMethod', params: [], return: undefined},
-          {name: 'privateMethod', params: [], return: undefined},
-          {name: 'privateOverriddenMethod', params: [], return: undefined},
-          {name: 'overrideMethod', params: [], return: undefined},
+          {
+            name: 'baseMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateOverriddenMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'overrideMethod',
+            params: [],
+            return: { type: 'void' },
+          },
         ],
         properties: [{name: 'foo'}],
         underlinedWarnings: [],
@@ -409,11 +429,31 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
         attributes: [{name: 'foo'}],
         description: '',
         methods: [
-          {name: 'baseMethod', params: [], return: undefined},
-          {name: 'privateMethod', params: [], return: undefined},
-          {name: 'privateOverriddenMethod', params: [], return: undefined},
-          {name: 'overrideMethod', params: [], return: undefined},
-          {name: 'middleMethod', params: [], return: undefined},
+          {
+            name: 'baseMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateOverriddenMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'overrideMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'middleMethod',
+            params: [],
+            return: { type: 'void' },
+          },
         ],
         properties: [{name: 'foo'}],
         summary: '',

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -341,7 +341,11 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
             name: 'foo',
           }],
           methods: [
-            {name: 'customInstanceFunction', params: [], return: undefined},
+            {
+              name: 'customInstanceFunction',
+              params: [],
+              return: { type: 'number' },
+            },
             {
               name: 'customInstanceFunctionWithJSDoc',
               params: [],
@@ -353,7 +357,7 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
             {
               name: 'customInstanceFunctionWithParams',
               params: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
-              return: undefined,
+              return: { type: 'number' },
             },
             {
               name: 'customInstanceFunctionWithParamsAndJSDoc',
@@ -381,7 +385,7 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
             {
               name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',
               params: [],
-              return: undefined,
+              return: { type: 'number' },
             },
           ],
           underlinedWarnings: [],
@@ -398,10 +402,26 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
         summary: '',
         attributes: [{name: 'foo'}],
         methods: [
-          {name: 'baseMethod', params: [], return: undefined},
-          {name: 'privateMethod', params: [], return: undefined},
-          {name: 'privateOverriddenMethod', params: [], return: undefined},
-          {name: 'overrideMethod', params: [], return: undefined},
+          {
+            name: 'baseMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateOverriddenMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'overrideMethod',
+            params: [],
+            return: { type: 'void' },
+          },
         ],
         properties: [{name: 'foo'}],
         underlinedWarnings: [],
@@ -411,11 +431,31 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
         attributes: [{name: 'foo'}],
         description: '',
         methods: [
-          {name: 'baseMethod', params: [], return: undefined},
-          {name: 'privateMethod', params: [], return: undefined},
-          {name: 'privateOverriddenMethod', params: [], return: undefined},
-          {name: 'overrideMethod', params: [], return: undefined},
-          {name: 'middleMethod', params: [], return: undefined},
+          {
+            name: 'baseMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'privateOverriddenMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'overrideMethod',
+            params: [],
+            return: { type: 'void' },
+          },
+          {
+            name: 'middleMethod',
+            params: [],
+            return: { type: 'void' },
+          },
         ],
         properties: [{name: 'foo'}],
         summary: '',

--- a/src/test/static/analysis/behaviors/analysis.json
+++ b/src/test/static/analysis/behaviors/analysis.json
@@ -183,6 +183,9 @@
           "name": "created",
           "description": "",
           "privacy": "protected",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 26,

--- a/src/test/static/analysis/class/analysis.json
+++ b/src/test/static/analysis/class/analysis.json
@@ -136,6 +136,9 @@
           "name": "baseMethod",
           "description": "This is a base method.",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 32,
@@ -153,6 +156,9 @@
           "name": "overriddenMethod",
           "description": "Will be overriden by Subclass.",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 35,
@@ -172,6 +178,9 @@
           "name": "baseStaticMethod",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 38,
@@ -189,6 +198,9 @@
           "name": "overriddenStaticMethod",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 41,
@@ -229,6 +241,9 @@
           "name": "baseMethod",
           "description": "This is a base method.",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 32,
@@ -247,6 +262,9 @@
           "name": "overriddenMethod",
           "description": "Overrides the method on Base.",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 47,
@@ -264,6 +282,9 @@
           "name": "subMethod",
           "description": "This method only exists on Subclass.",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 52,
@@ -283,6 +304,9 @@
           "name": "baseStaticMethod",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 38,
@@ -301,6 +325,9 @@
           "name": "overriddenStaticMethod",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 55,
@@ -318,6 +345,9 @@
           "name": "staticSubMethod",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 58,

--- a/src/test/static/analysis/mixins-old-jsdoc/analysis.json
+++ b/src/test/static/analysis/mixins-old-jsdoc/analysis.json
@@ -149,6 +149,9 @@
           "name": "frob",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 42,
@@ -175,6 +178,9 @@
           "name": "glob",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 45,
@@ -243,6 +249,9 @@
           "name": "frob",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 42,
@@ -270,6 +279,9 @@
           "name": "glob",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 45,

--- a/src/test/static/analysis/mixins/analysis.json
+++ b/src/test/static/analysis/mixins/analysis.json
@@ -150,6 +150,9 @@
           "name": "frob",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 45,
@@ -178,6 +181,9 @@
           "name": "glob",
           "params": [],
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "end": {
               "column": 5,
@@ -261,6 +267,9 @@
           "name": "frob",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 45,
@@ -291,6 +300,9 @@
           "name": "glob",
           "params": [],
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "end": {
               "column": 5,

--- a/src/test/static/analysis/simple/analysis.json
+++ b/src/test/static/analysis/simple/analysis.json
@@ -160,6 +160,9 @@
           "name": "customFunction",
           "description": "",
           "privacy": "public",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 24,
@@ -184,6 +187,9 @@
           "name": "_customProtectedFunction",
           "description": "",
           "privacy": "protected",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 25,
@@ -208,6 +214,9 @@
           "name": "__customPrivateFunction",
           "description": "",
           "privacy": "private",
+          "return": {
+            "type": "void"
+          },
           "sourceRange": {
             "start": {
               "line": 26,

--- a/src/test/static/class/class-methods.js
+++ b/src/test/static/class/class-methods.js
@@ -15,6 +15,29 @@ class Class {
     return 4;
   }
 
+  customInstanceFunctionWithNoReturn() {
+  }
+
+  customInstanceFunctionWithInferredReturn() {
+    return 4.1;
+  }
+
+  customInstanceFunctionWithInferredMultipleReturn() {
+    if (window.foo) {
+      return 4.2;
+    } else {
+      return true;
+    }
+  }
+
+  customInstanceFunctionWithUninferrableReturn() {
+    if (window.foo) {
+      return 4.3;
+    } else {
+      return (window.bar ? new Set() : new Map());
+    }
+  }
+
   /**
    * This is the description for customInstanceFunctionWithJSDoc.
    * @return {Number} - The number 5, always.


### PR DESCRIPTION
Fixes #753.

This is just something I figured i'd do while i was in there. If we don't want it then this can be closed.

## Work in progress

At the min it doesn't pass tests because it no longer detects `Polymer.Base` methods in the polymer-core tests... I can't seem to track down why adding `return` to some methods causes that failure. Commenting out my changes in `esutil` makes the test pass, confusingly.

Also what do we do about inheritance? what if we detect a method as `void` but the one it is overriding in the base class is typed as something else?

---

What it does:

* If there is no `@return`, it tries to infer it
* If there is no return statement, it is inferred as `void`
* If there is a return statement, or multiple, it tries to get the type (via `closureType`) and joins them
* If one or more of the `closureType` calls create warnings, we don't add a return type at all because its better to not have one than to get it wrong i think