### PR TITLE
Make the prototype scanner pick up namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* Add namespace detection to the prototype scanner, such that members
+  annotated with `@memberof` are discovered with the correct class name
 * Add `Element#template` for getting the template of an element.
 <!-- Add new, unreleased changes here. -->
 

--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -385,21 +385,24 @@ class PrototypeMemberFinder implements Visitor {
     const leftExpr = node.left.object;
     const leftProperty = node.left.property;
     const cls = getIdentifierName(leftExpr.object);
+
     if (!cls || getIdentifierName(leftExpr.property) !== 'prototype') {
       return;
     }
+
+    const namespacedCls = getNamespacedIdentifier(cls, jsdocAnn);
 
     if (babel.isFunctionExpression(node.right)) {
       const prop = this._createMethodFromExpression(
           leftProperty.name, node.right, jsdocAnn);
       if (prop) {
-        this._addMethodToClass(cls, prop);
+        this._addMethodToClass(namespacedCls, prop);
       }
     } else {
       const method =
           this._createPropertyFromExpression(leftProperty.name, node, jsdocAnn);
       if (method) {
-        this._addPropertyToClass(cls, method);
+        this._addPropertyToClass(namespacedCls, method);
       }
     }
   }
@@ -430,17 +433,19 @@ class PrototypeMemberFinder implements Visitor {
       return;
     }
 
+    const namespacedCls = getNamespacedIdentifier(cls, jsdocAnn);
+
     if (jsdoc.hasTag(jsdocAnn, 'function')) {
       const prop =
           this._createMethodFromExpression(node.property.name, node, jsdocAnn);
       if (prop) {
-        this._addMethodToClass(cls, prop);
+        this._addMethodToClass(namespacedCls, prop);
       }
     } else {
       const method = this._createPropertyFromExpression(
           node.property.name, node, jsdocAnn);
       if (method) {
-        this._addPropertyToClass(cls, method);
+        this._addPropertyToClass(namespacedCls, method);
       }
     }
   }

--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -350,6 +350,42 @@ interface CustomElementDefinition {
   definition?: ElementDefineCall;
 }
 
+/**
+ * Finds any methods or properties added to a class' prototype after
+ * the class has been defined.
+ *
+ * Assignments are detected:
+ *
+ *    MyClass.prototype.MyMethod = function() { ... }
+ *
+ * And expressions without a body:
+ *
+ *    MyClass.prototype.MyMethod;
+ *
+ * For a member to be detected as a method, the `@function` annotation
+ * is required. Otherwise, the default is to treat it as a property.
+ *
+ * When attaching members to a class which has a `@memberof` annotation,
+ * the members should also be annotated identically:
+ *
+ *    @memberof MyNamespace
+ *    MyClass.prototype.MyMethod;
+ *
+ * One exception to this is when the member is not set directly on
+ * the prototype, such as a function which is attached at a later place
+ * in the file:
+ *
+ *    @memberof MyNamespace.MyClass
+ *    @instance
+ *    function MyMethod() {
+ *
+ * As you can see, we must specify `@instance` to define the function
+ * as an instance method, and `@memberof` to define the class along with
+ * its namespace.
+ *
+ * For more information, see [memberof](http://usejsdoc.org/tags-memberof.html)
+ * and [instance](http://usejsdoc.org/tags-instance.html).
+ */
 class PrototypeMemberFinder implements Visitor {
   readonly members = new MapWithDefault<string, {
     methods: Map<string, ScannedMethod>,

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -154,6 +154,28 @@ suite('Class', () => {
       ]);
     });
 
+    test('respects @memberof in prototype members', async () => {
+      const cls = (await getScannedClasses('class/class-memberof.js'))[0];
+
+      assert.deepEqual(await getTestProps(cls), {
+        name: 'MyNamespace.Class',
+        description: '',
+        privacy: 'public',
+        properties: [
+          { name: 'Property' }
+        ],
+        methods: [
+          {
+            description: undefined,
+            name: 'Method',
+            return: {
+              type: 'void'
+            }
+          }
+        ]
+      });
+    });
+
     test('finds properties', async () => {
       const cls = (await getScannedClasses('class/class-properties.js'))[0];
 

--- a/src/test/static/class/class-memberof.js
+++ b/src/test/static/class/class-memberof.js
@@ -6,13 +6,15 @@ class Class {
 
 /**
  * @function
- * @memberof MyNamespace
+ * @memberof MyNamespace.Class.prototype
+ * @alias Method
  * @return {void}
  */
 Class.prototype.Method;
 
 /**
- * @memberof MyNamespace
+ * @memberof MyNamespace.Class.prototype
+ * @alias Property
  * @type {string}
  */
 Class.prototype.Property;

--- a/src/test/static/class/class-memberof.js
+++ b/src/test/static/class/class-memberof.js
@@ -1,0 +1,18 @@
+/**
+ * @memberof MyNamespace
+ */
+class Class {
+}
+
+/**
+ * @function
+ * @memberof MyNamespace
+ * @return {void}
+ */
+Class.prototype.Method;
+
+/**
+ * @memberof MyNamespace
+ * @type {string}
+ */
+Class.prototype.Property;


### PR DESCRIPTION
This is an attempt at fixing the lack of `@memberof` understanding in the prototype scanner.

As usual, it'll help us finalise polymer/polymer#5000.

---

The problem was:

```ts
/**
 * @memberof Polymer
 */
class MyClass {}

/** @function */
MyClass.prototype.MyMethod;
```

This is currently scanned like so:

* The class is named `Polymer.MyClass`
* The method thinks its class is called `MyClass`
* During class finalisation, it therefore can't find `MyClass` in the scanned classes

So the fix i figure is to respect `@memberof` on methods/properties too.

If this doesn't seem semantically correct, do speak up.

cc @aomarks @rictic 
  