### PR TITLE
Detect event descriptions correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
+* Use event annotation descriptions over their tag description
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.7] - 2017-01-01

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -87,7 +87,7 @@ export function annotateEvent(annotation: jsdoc.Annotation): ScannedEvent {
   }
   const scannedEvent: ScannedEvent = {
     name: name,
-    description: (eventTag && eventTag.description) || annotation.description,
+    description: annotation.description || (eventTag && eventTag.description) || undefined,
     jsdoc: annotation,
     sourceRange: undefined,
     astNode: null,


### PR DESCRIPTION
* Use the annotation description before trying the tag description (Fixes #836)