### PR TITLE
Scan multiple events in a single annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
 * Use event annotation descriptions over their tag description
+* Detect multiple `@event` annotations in a single comment
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.7] - 2017-01-01

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -23,7 +23,7 @@ import {Privacy} from '../model/model';
 import {ScannedEvent, Severity, SourceRange, Warning} from '../model/model';
 import {ParsedDocument} from '../parser/document';
 import * as docs from '../polymer/docs';
-import {annotateEvent} from '../polymer/docs';
+import {annotateEvents} from '../polymer/docs';
 
 import * as astValue from './ast-value';
 import * as estraverse from './estraverse-shim';
@@ -161,13 +161,15 @@ export function getEventComments(node: babel.Node): Map<string, ScannedEvent> {
           .forEach((comment) => eventComments.add(comment));
     }
   });
-  const events = [...eventComments]
+
+  const events = annotateEvents([...eventComments]
                      .map(
-                         (comment) => annotateEvent(jsdoc.parseJsdoc(
-                             jsdoc.removeLeadingAsterisks(comment).trim())))
-                     .filter((ev) => !!ev)
-                     .sort((ev1, ev2) => ev1.name.localeCompare(ev2.name));
-  return new Map(events.map((e) => [e.name, e] as [string, ScannedEvent]));
+                         (comment) => jsdoc.parseJsdoc(
+                             jsdoc.removeLeadingAsterisks(comment).trim())));
+
+  return new Map(events
+                 .sort((ev1, ev2) => ev1.name.localeCompare(ev2.name))
+                 .map((e) => [e.name, e] as [string, ScannedEvent]));
 }
 
 function getLeadingComments(node: babel.Node): string[]|undefined {

--- a/src/polymer/docs.ts
+++ b/src/polymer/docs.ts
@@ -77,36 +77,42 @@ export function annotateElementHeader(scannedElement: ScannedPolymerElement) {
 /**
  * Annotates event documentation
  */
-export function annotateEvent(annotation: jsdoc.Annotation): ScannedEvent {
-  const eventTag = jsdoc.getTag(annotation, 'event');
-  let name: string;
-  if (eventTag && eventTag.description) {
-    name = (eventTag.description || '').match(/^\S*/)![0];
-  } else {
-    name = 'N/A';
-  }
-  const scannedEvent: ScannedEvent = {
-    name: name,
-    description: annotation.description || (eventTag && eventTag.description) || undefined,
-    jsdoc: annotation,
-    sourceRange: undefined,
-    astNode: null,
-    warnings: [],
-    params: []
-  };
+export function annotateEvents(annotations: jsdoc.Annotation[]): ScannedEvent[] {
+  const events: ScannedEvent[] = [];
 
-  const tags = (annotation && annotation.tags || []);
-  // process @params
-  scannedEvent.params.push(
-      ...tags.filter((tag) => tag.title === 'param').map((param) => {
+  for (const annotation of annotations) {
+    const tags = annotation.tags || [];
+    const eventTags = tags.filter((tag) => tag.title === 'event');
+    const params = tags.filter((tag) => tag.title === 'param')
+      .map((tag) => {
         return {
-          type: param.type ? doctrine.type.stringify(param.type) : 'N/A',
-          desc: param.description || '',
-          name: param.name || 'N/A'
+          type: tag.type ? doctrine.type.stringify(tag.type) : 'N/A',
+          desc: tag.description || '',
+          name: tag.name || 'N/A'
         };
-      }));
-  // process @params
-  return scannedEvent;
+      });
+
+    for (const eventTag of eventTags) {
+      let name: string;
+      if (eventTag && eventTag.description) {
+        name = (eventTag.description || '').match(/^\S*/)![0];
+      } else {
+        name = 'N/A';
+      }
+
+      events.push({
+        name: name,
+        description: annotation.description || (eventTag && eventTag.description) || undefined,
+        jsdoc: annotation,
+        sourceRange: undefined,
+        astNode: null,
+        warnings: [],
+        params: params
+      });
+    }
+  }
+
+  return events;
 }
 
 /**

--- a/src/test/javascript/esutil_test.ts
+++ b/src/test/javascript/esutil_test.ts
@@ -22,6 +22,26 @@ import {objectKeyToString, getEventComments} from '../../javascript/esutil';
 // See analysis_test for tests of generateElementMetadata
 
 suite('getEventComments', () => {
+  test('returns multiple events from one comment', () => {
+    const node = parse(`
+        class Foo {
+          /**
+           * This is an event
+           *
+           * @event event-one
+           * @event event-two
+           * @param {Event} event
+           */
+           myMethod() { }
+        }`);
+    const events = [...getEventComments(node).values()];
+
+    assert.deepEqual(events.map((ev) => ev.name), [
+      'event-one',
+      'event-two'
+    ]);
+  });
+
   test('returns events from a comment', () => {
     const node = parse(`
         class Foo {


### PR DESCRIPTION
This allows multiple events to be scanned from a single annotation.

Btw it does depend on #838 (branched off that).

## Do not merge yet

cc @aomarks 

we can discuss here whether we want this or not. you may be right about just doing PRs at iron-ajax and what not instead, to fix up the annotations.