### PR TITLE
Make FSUrlLoader#canLoad honestly report that it can't load files outside its root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* `FSUrlLoader#canLoad` reports false for local urls outside the loader's
+  own root; enables fall-thru support needed for racking in `MultiUrlLoader`.
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
 * Use event annotation descriptions over their tag description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 * `FSUrlLoader#canLoad` reports false for local urls outside the loader's
-  own root; enables fall-thru support needed for racking in `MultiUrlLoader`.
+  own root; enables fall-thru support needed for use with `MultiUrlLoader`.
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
 * Use event annotation descriptions over their tag description

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -41,6 +41,7 @@ import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
 import {AnalysisContext} from '../../core/analysis-context';
 import {HtmlScanner} from '../../html/html-scanner';
 import {ScannedFeature} from '../../index';
+import Uri from 'vscode-uri';
 
 use(chaiSubset);
 use(chaiAsPromised);
@@ -79,8 +80,11 @@ suite('Analyzer', () => {
   });
 
   test('canLoad delegates to the urlLoader canLoad method', () => {
-    assert.isTrue(analyzer.canLoad(resolvedUrl`file:///`));
-    assert.isTrue(analyzer.canLoad(resolvedUrl`file:////path`));
+    assert.isTrue(
+        analyzer.canLoad(Uri.file(testDir).toString() as ResolvedUrl));
+    assert.isFalse(analyzer.canLoad(
+        Uri.file(path.resolve(testDir, '../outside')).toString() as
+        ResolvedUrl));
     assert.isFalse(analyzer.canLoad(resolvedUrl`file://hostname/path`));
     assert.isFalse(analyzer.canLoad(resolvedUrl`http://host/`));
     assert.isFalse(analyzer.canLoad(resolvedUrl`http://host/path`));

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -13,20 +13,22 @@
  */
 
 import {assert} from 'chai';
+import Uri from 'vscode-uri';
 
+import {ResolvedUrl} from '../../model/url';
 import {FSUrlLoader} from '../../url-loader/fs-url-loader';
 import {resolvedUrl} from '../test-utils';
 
 suite('FSUrlLoader', function() {
   suite('canLoad', () => {
     test('canLoad is true for a local file URL inside root', () => {
-      assert.isTrue(new FSUrlLoader('/a/').canLoad(resolvedUrl
-                                                      `file:///a/foo.html`));
+      assert.isTrue(new FSUrlLoader('/a/').canLoad(
+          Uri.file('/a/foo.html').toString() as ResolvedUrl));
     });
 
     test('canLoad is false for a local file URL outside root', () => {
-      assert.isFalse(new FSUrlLoader('/a/').canLoad(resolvedUrl
-                                                      `file:///b/foo.html`));
+      assert.isFalse(new FSUrlLoader('/a/').canLoad(
+          Uri.file('/b/foo.html').toString() as ResolvedUrl));
     });
     test('canLoad is false for a file url with a host', () => {
       assert.isFalse(new FSUrlLoader('/foo/').canLoad(
@@ -35,12 +37,12 @@ suite('FSUrlLoader', function() {
 
     test('canLoad is false for a relative path URL', () => {
       assert.isFalse(
-          new FSUrlLoader('/').canLoad(resolvedUrl`../../foo/foo.html`));
+          new FSUrlLoader().canLoad(resolvedUrl`../../foo/foo.html`));
     });
 
     test('canLoad is false for an http URL', () => {
       assert.isFalse(
-          new FSUrlLoader('/').canLoad(resolvedUrl`http://abc.xyz/foo.html`));
+          new FSUrlLoader().canLoad(resolvedUrl`http://abc.xyz/foo.html`));
     });
   });
 });

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -19,23 +19,28 @@ import {resolvedUrl} from '../test-utils';
 
 suite('FSUrlLoader', function() {
   suite('canLoad', () => {
-    test('canLoad is true a local file URL', () => {
-      assert.isTrue(new FSUrlLoader().canLoad(resolvedUrl`file:///foo.html`));
+    test('canLoad is true for a local file URL inside root', () => {
+      assert.isTrue(new FSUrlLoader('/a/').canLoad(resolvedUrl
+                                                      `file:///a/foo.html`));
     });
 
+    test('canLoad is false for a local file URL outside root', () => {
+      assert.isFalse(new FSUrlLoader('/a/').canLoad(resolvedUrl
+                                                      `file:///b/foo.html`));
+    });
     test('canLoad is false for a file url with a host', () => {
-      assert.isFalse(
-          new FSUrlLoader().canLoad(resolvedUrl`file://foo/foo/foo.html`));
+      assert.isFalse(new FSUrlLoader('/foo/').canLoad(
+          resolvedUrl`file://foo/foo/foo.html`));
     });
 
     test('canLoad is false for a relative path URL', () => {
       assert.isFalse(
-          new FSUrlLoader().canLoad(resolvedUrl`../../foo/foo.html`));
+          new FSUrlLoader('/').canLoad(resolvedUrl`../../foo/foo.html`));
     });
 
     test('canLoad is false for an http URL', () => {
       assert.isFalse(
-          new FSUrlLoader().canLoad(resolvedUrl`http://abc.xyz/foo.html`));
+          new FSUrlLoader('/').canLoad(resolvedUrl`http://abc.xyz/foo.html`));
     });
   });
 });

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -13,6 +13,7 @@
  */
 
 import {assert} from 'chai';
+import * as path from 'path';
 import Uri from 'vscode-uri';
 
 import {ResolvedUrl} from '../../model/url';
@@ -23,12 +24,12 @@ suite('FSUrlLoader', function() {
   suite('canLoad', () => {
     test('canLoad is true for a local file URL inside root', () => {
       assert.isTrue(new FSUrlLoader('/a/').canLoad(
-          Uri.file('/a/foo.html').toString() as ResolvedUrl));
+          Uri.file(path.resolve('/a/foo.html')).toString() as ResolvedUrl));
     });
 
     test('canLoad is false for a local file URL outside root', () => {
       assert.isFalse(new FSUrlLoader('/a/').canLoad(
-          Uri.file('/b/foo.html').toString() as ResolvedUrl));
+          Uri.file(path.resolve('/b/foo.html')).toString() as ResolvedUrl));
     });
     test('canLoad is false for a file url with a host', () => {
       assert.isFalse(new FSUrlLoader('/foo/').canLoad(

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -37,7 +37,7 @@ export class FSUrlLoader implements UrlLoader {
   }
 
   canLoad(url: ResolvedUrl): boolean {
-    return url.startsWith('file:///');
+    return url.startsWith(Uri.file(this.root).toString());
   }
 
   load(url: ResolvedUrl): Promise<string> {


### PR DESCRIPTION
* `FSUrlLoader#canLoad` *now* reports _false_ for local urls outside the loader's own root; enables fall-thru support needed for racking in `MultiUrlLoader`.
* [x] CHANGELOG.md has been updated
