### PR TITLE
Redirect resolvers should resolve redirects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
-* Use event annotation descriptions over their tag description
+* Use event annotation descriptions over their tag description.
+* `RedirectResolver` resolves URLs which start with its redirect-to.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.7] - 2017-01-01

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -39,5 +39,14 @@ suite('RedirectResolver', function() {
           resolver.resolve(packageRelativeUrl`protoz://site/something.html`),
           undefined);
     });
+
+    test(`if url matches redirection target, returns url`, () => {
+      const resolver =
+          new RedirectResolver(resolvedUrl`/a/`, 'proto://site/', '/b/');
+      const resolved =
+          resolver.resolve(packageRelativeUrl`proto://site/page.html`)!;
+      assert.equal(resolved, resolvedUrl`/b/page.html`);
+      assert.equal(resolver.resolve(resolved), resolved);
+    });
   });
 });

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -37,12 +37,15 @@ export class RedirectResolver extends UrlResolver {
         this.getBaseAndUnresolved(firstUrl, secondUrl);
     const packageRelativeUrl =
         this.brandAsResolved(urlLibResolver(baseUrl, unresolvedUrl));
-    if (packageRelativeUrl === undefined ||
-        !packageRelativeUrl.startsWith(this._redirectFrom)) {
-      return undefined;
+    if (packageRelativeUrl.startsWith(this._redirectFrom)) {
+      return this.brandAsResolved(
+          this._redirectTo +
+          packageRelativeUrl.slice(this._redirectFrom.length));
     }
-    return this.brandAsResolved(
-        this._redirectTo + packageRelativeUrl.slice(this._redirectFrom.length));
+    if (packageRelativeUrl.startsWith(this._redirectTo)) {
+      return packageRelativeUrl;
+    }
+    return undefined;
   }
 
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):


### PR DESCRIPTION
 - `RedirectResolver` resolves URLs which start with its redirect-to.
 - [x] CHANGELOG.md has been updated

The problem is that redirect resolvers produce resolved urls which they later return `undefined` when asked to resolve again.  UrlResolvers should essentially be idempotent, in that once a URL is resolved, it should stay resolved.

This fix prevents a particularly awkward case where a `MultiUrlResolver` includes a `RedirectResolver` which produce a resolved URL which points to files outside the package root, which the subsequently racked `PackageUrlResolver` perceives to be a sibling directory and therefore reroutes to the component directory when the resolved url is subsequently given to `UrlResolver.resolve()`.

While it could be argued that resolved urls should never be asked to be resolved again, at this time we really can't guarantee this as there are many intermediate data-structures or serializations which occur that we can only assume are URLs of some form, relative, package-relative or resolved.