### PR TITLE
Updated CHANGELOG for 3.0.0-pre.8 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+<!-- Add new, unreleased changes here. -->
+
+## [3.0.0-pre.8] - 2017-01-18
 * `FSUrlLoader#canLoad` reports false for local urls outside the loader's
   own root; enables fall-thru support needed for use with `MultiUrlLoader`.
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
 * Use event annotation descriptions over their tag description.
 * `RedirectResolver` resolves URLs which start with its redirect-to.
-<!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.7] - 2017-01-01
 * [BREAKING]: `UrlResolver#resolve()` argument order swapped so that the


### PR DESCRIPTION
## [3.0.0-pre.8] - 2017-01-18
 * `FSUrlLoader#canLoad` reports false for local urls outside the loader's
   own root; enables fall-thru support needed for use with `MultiUrlLoader`.
 * Add `Element#template` for getting the template of an element.
 * In MultiUrlLoader, proxy the first implementation of readDirectory, if any.
 * Use event annotation descriptions over their tag description.
 * `RedirectResolver` resolves URLs which start with its redirect-to.
 * [x] CHANGELOG.md has been updated
