### PR TITLE
MultiUrlResolver#relative() fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* `MultiUrlResolver` now delegates the `relative()` method to the first
+  `UrlResolver` in its `_resolvers` array that can `resolve()` the
+  destination URL.  Makes it possible now to rely on the Analyzer's
+  resolver to return a valid `PackageRelativeUrl` from a resolved URL.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.8] - 2017-01-18

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -25,6 +25,9 @@ export class MultiUrlResolver extends UrlResolver {
     super();
   }
 
+  /**
+   * Returns the first resolved URL (which is not undefined.)
+   */
   resolve(
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl,
       import_?: ScannedImport): ResolvedUrl|undefined {
@@ -40,10 +43,16 @@ export class MultiUrlResolver extends UrlResolver {
     return undefined;
   }
 
+  /**
+   * Delegates to relative method on the first resolver which can resolve the
+   * destination URL.
+   */
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, kind?: string):
       FileRelativeUrl {
     for (const resolver of this._resolvers) {
-      return resolver.relative(fromOrTo, maybeTo, kind);
+      if (resolver.resolve((maybeTo || fromOrTo) as any)) {
+        return resolver.relative(fromOrTo, maybeTo, kind);
+      }
     }
     throw new Error(
         `Could not get relative url, with no configured url resolvers`);


### PR DESCRIPTION
- `MultiUrlResolver` now delegates the `relative()` method to the first
  `UrlResolver` in its `_resolvers` array that can `resolve()` the
  destination URL.  Makes it possible now to rely on the Analyzer's
  resolver to return a valid `PackageRelativeUrl` from a resolved URL.
 - [x] CHANGELOG.md has been updated
