### PR TITLE
Updated CHANGELOG for 3.0.0-pre.9 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+<!-- Add new, unreleased changes here. -->
+
+## [3.0.0-pre.9] - 2017-01-25
 * [BREAKING] Document#astNode and ParsedDocument#astNode are now an
   `AstNodeWithLanguage`, because we support inline documents in more than just
   HTML, as we've added an HTML-in-JS scanner.
@@ -13,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `UrlResolver` in its `_resolvers` array that can `resolve()` the
   destination URL.  Makes it possible now to rely on the Analyzer's
   resolver to return a valid `PackageRelativeUrl` from a resolved URL.
-<!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.8] - 2017-01-18
 * `FSUrlLoader#canLoad` reports false for local urls outside the loader's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.9] - 2018-01-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
 
-## [3.0.0-pre.9] - 2018-01-25
+## [3.0.0-pre.9] - 2018-01-26
 * [BREAKING] Document#astNode and ParsedDocument#astNode are now an
   `AstNodeWithLanguage`, because we support inline documents in more than just
   HTML, as we've added an HTML-in-JS scanner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
 
-## [3.0.0-pre.9] - 2017-01-25
+## [3.0.0-pre.9] - 2018-01-25
 * [BREAKING] Document#astNode and ParsedDocument#astNode are now an
   `AstNodeWithLanguage`, because we support inline documents in more than just
   HTML, as we've added an HTML-in-JS scanner.
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   destination URL.  Makes it possible now to rely on the Analyzer's
   resolver to return a valid `PackageRelativeUrl` from a resolved URL.
 
-## [3.0.0-pre.8] - 2017-01-18
+## [3.0.0-pre.8] - 2018-01-18
 * `FSUrlLoader#canLoad` reports false for local urls outside the loader's
   own root; enables fall-thru support needed for use with `MultiUrlLoader`.
 * Add `Element#template` for getting the template of an element.
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Use event annotation descriptions over their tag description.
 * `RedirectResolver` resolves URLs which start with its redirect-to.
 
-## [3.0.0-pre.7] - 2017-01-01
+## [3.0.0-pre.7] - 2018-01-01
 * [BREAKING]: `UrlResolver#resolve()` argument order swapped so that the
   optional `baseUrl` argument comes first instead of second.  This makes
   resolve more similar to `url.resolve`.


### PR DESCRIPTION
## [3.0.0-pre.9] - 2017-01-25
 * [BREAKING] Document#astNode and ParsedDocument#astNode are now an
   `AstNodeWithLanguage`, because we support inline documents in more than just
   HTML, as we've added an HTML-in-JS scanner.
 * `MultiUrlResolver` now delegates the `relative()` method to the first
   `UrlResolver` in its `_resolvers` array that can `resolve()` the
   destination URL.  Makes it possible now to rely on the Analyzer's
   resolver to return a valid `PackageRelativeUrl` from a resolved URL.
* [x] CHANGELOG.md has been updated
