### PR TITLE
RedirectResolver#relative() now correctly represents relative-to-package-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* [BREAKING] The `UrlResolver#relative()` method now returns a
+  `PackageRelativeUrl` when called with only one argument, since the only
+  use of this call form is to reverse a resolved URL back into a simpler
+  package relative form.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.9] - 2018-01-26

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -66,7 +66,10 @@ export class CodeUnderliner {
         return this.brandAsResolved(secondUrl || firstUrl);
       }
 
-      relative(): FileRelativeUrl {
+      relative(to: ResolvedUrl): PackageRelativeUrl;
+      relative(
+          from: ResolvedUrl, to: ResolvedUrl, kind?: string): FileRelativeUrl;
+      relative(): FileRelativeUrl|PackageRelativeUrl {
         throw new Error('does not do relative');
       }
     }());

--- a/src/test/url-loader/multi-url-resolver_test.ts
+++ b/src/test/url-loader/multi-url-resolver_test.ts
@@ -38,12 +38,18 @@ class MockResolver extends UrlResolver {
     return undefined;
   }
 
+  relative(to: ResolvedUrl): PackageRelativeUrl;
+  relative(from: ResolvedUrl, to: ResolvedUrl, kind?: string): FileRelativeUrl;
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):
-      FileRelativeUrl {
+      FileRelativeUrl|PackageRelativeUrl {
     const [from, to] = (maybeTo !== undefined) ? [fromOrTo, maybeTo] :
                                                  [this.packageUrl, fromOrTo];
     ++this.relativeCount;
-    return this.simpleUrlRelative(from, to);
+    const result = this.simpleUrlRelative(from, to);
+    if (maybeTo === undefined) {
+      return this.brandAsPackageRelative(result);
+    }
+    return result;
   }
 }
 
@@ -101,7 +107,7 @@ suite('MultiUrlResolver', function() {
       const resolver = new MultiUrlResolver(resolvers);
       assert.equal(
           resolver.relative(resolvedUrl`file2.html`),
-          fileRelativeUrl`file2.html`);
+          packageRelativeUrl`file2.html`);
       // Verify the first two resolvers are called.
       assert.equal(resolvers[0].resolveCount, 1);
       assert.equal(resolvers[1].resolveCount, 1);

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -14,9 +14,8 @@
 
 import {assert} from 'chai';
 
-import {ResolvedUrl} from '../../model/url';
 import {RedirectResolver} from '../../url-loader/redirect-resolver';
-import {fileRelativeUrl, packageRelativeUrl, resolvedUrl} from '../test-utils';
+import {packageRelativeUrl, resolvedUrl} from '../test-utils';
 
 
 suite('RedirectResolver', function() {
@@ -56,7 +55,7 @@ suite('RedirectResolver', function() {
       const resolver =
           new RedirectResolver(resolvedUrl`/a/`, 'proto://site/', '/b/');
       const relative = resolver.relative(resolvedUrl`/b/page.html`)!;
-      assert.equal(relative, fileRelativeUrl`proto://site/page.html`);
+      assert.equal(relative, packageRelativeUrl`proto://site/page.html`);
       assert.equal(
           resolver.relative(resolvedUrl`proto://site/page.html`) as string,
           resolvedUrl`proto://site/page.html`);

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -51,7 +51,7 @@ suite('RedirectResolver', function() {
   });
 
   suite('relative', () => {
-    test('if `to` is no in redirect-to, return as-is', () => {
+    test('if `to` is not in redirect-to, return as-is', () => {
       const resolver = new RedirectResolver(
           resolvedUrl`file:///src/a/`,
           resolvedUrl`proto://site/`,

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -52,14 +52,14 @@ suite('RedirectResolver', function() {
   });
 
   suite('relative', () => {
-    test('if from not within _redirectTo but to is, reverse redirect', () => {
+    test('if `from` is not in redirect-to, un-redirect the `to`', () => {
       const resolver =
           new RedirectResolver(resolvedUrl`/a/`, 'proto://site/', '/b/');
       const relative = resolver.relative(resolvedUrl`/b/page.html`)!;
       assert.equal(relative, fileRelativeUrl`proto://site/page.html`);
       assert.equal(
-          resolver.relative(relative as string as ResolvedUrl) as string,
-          relative);
+          resolver.relative(resolvedUrl`proto://site/page.html`) as string,
+          resolvedUrl`proto://site/page.html`);
     });
   });
 });

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -14,8 +14,9 @@
 
 import {assert} from 'chai';
 
+import {ResolvedUrl} from '../../model/url';
 import {RedirectResolver} from '../../url-loader/redirect-resolver';
-import {packageRelativeUrl, resolvedUrl} from '../test-utils';
+import {fileRelativeUrl, packageRelativeUrl, resolvedUrl} from '../test-utils';
 
 
 suite('RedirectResolver', function() {
@@ -47,6 +48,18 @@ suite('RedirectResolver', function() {
           resolver.resolve(packageRelativeUrl`proto://site/page.html`)!;
       assert.equal(resolved, resolvedUrl`/b/page.html`);
       assert.equal(resolver.resolve(resolved), resolved);
+    });
+  });
+
+  suite('relative', () => {
+    test('if from not within _redirectTo but to is, reverse redirect', () => {
+      const resolver =
+          new RedirectResolver(resolvedUrl`/a/`, 'proto://site/', '/b/');
+      const relative = resolver.relative(resolvedUrl`/b/page.html`)!;
+      assert.equal(relative, fileRelativeUrl`proto://site/page.html`);
+      assert.equal(
+          resolver.relative(relative as string as ResolvedUrl) as string,
+          relative);
     });
   });
 });

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -50,7 +50,7 @@ suite('RedirectResolver', function() {
     });
   });
 
-  suite.only('relative', () => {
+  suite('relative', () => {
     test('if `to` is no in redirect-to, return as-is', () => {
       const resolver = new RedirectResolver(
           resolvedUrl`file:///src/a/`,

--- a/src/test/url-loader/redirect-resolver_test.ts
+++ b/src/test/url-loader/redirect-resolver_test.ts
@@ -50,15 +50,29 @@ suite('RedirectResolver', function() {
     });
   });
 
-  suite('relative', () => {
+  suite.only('relative', () => {
+    test('if `to` is no in redirect-to, return as-is', () => {
+      const resolver = new RedirectResolver(
+          resolvedUrl`file:///src/a/`,
+          resolvedUrl`proto://site/`,
+          resolvedUrl`file:///src/b/`);
+      const relative = resolver.relative(resolvedUrl`file:///src/a/page.html`)!;
+      assert.equal(relative, packageRelativeUrl`page.html`);
+      assert.equal(
+          resolver.relative(resolvedUrl`file:///src/a/page.html`),
+          packageRelativeUrl`page.html`);
+    });
+
     test('if `from` is not in redirect-to, un-redirect the `to`', () => {
-      const resolver =
-          new RedirectResolver(resolvedUrl`/a/`, 'proto://site/', '/b/');
-      const relative = resolver.relative(resolvedUrl`/b/page.html`)!;
+      const resolver = new RedirectResolver(
+          resolvedUrl`file:///src/a/`,
+          resolvedUrl`proto://site/`,
+          resolvedUrl`file:///src/b/`);
+      const relative = resolver.relative(resolvedUrl`file:///src/b/page.html`)!;
       assert.equal(relative, packageRelativeUrl`proto://site/page.html`);
       assert.equal(
-          resolver.relative(resolvedUrl`proto://site/page.html`) as string,
-          resolvedUrl`proto://site/page.html`);
+          resolver.relative(resolvedUrl`proto://site/page.html`),
+          packageRelativeUrl`proto://site/page.html`);
     });
   });
 });

--- a/src/test/url-loader/url-resolver_test.ts
+++ b/src/test/url-loader/url-resolver_test.ts
@@ -25,8 +25,10 @@ class SimplestUrlResolver extends UrlResolver {
     return this.simpleUrlResolve(baseUrl, url);
   }
 
+  relative(to: ResolvedUrl): PackageRelativeUrl;
+  relative(from: ResolvedUrl, to: ResolvedUrl, kind?: string): FileRelativeUrl;
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):
-      FileRelativeUrl {
+      FileRelativeUrl|PackageRelativeUrl {
     let from, to;
     if (maybeTo !== undefined) {
       from = fromOrTo;
@@ -35,7 +37,11 @@ class SimplestUrlResolver extends UrlResolver {
       throw new Error(
           'simplest url resolver.relative must be called with two arguments');
     }
-    return this.simpleUrlRelative(from, to);
+    const result = this.simpleUrlRelative(from, to);
+    if (maybeTo === undefined) {
+      return this.brandAsPackageRelative(result);
+    }
+    return result;
   }
 }
 

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -47,11 +47,20 @@ export class MultiUrlResolver extends UrlResolver {
    * Delegates to relative method on the first resolver which can resolve the
    * destination URL.
    */
+  relative(to: ResolvedUrl): PackageRelativeUrl;
+  relative(from: ResolvedUrl, to: ResolvedUrl, kind?: string): FileRelativeUrl;
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, kind?: string):
-      FileRelativeUrl {
+      FileRelativeUrl|PackageRelativeUrl {
+    const from = (maybeTo === undefined) ? undefined : fromOrTo;
+    const to = (maybeTo === undefined) ? fromOrTo : maybeTo;
     for (const resolver of this._resolvers) {
-      if (resolver.resolve((maybeTo || fromOrTo) as any)) {
-        return resolver.relative(fromOrTo, maybeTo, kind);
+      if (!resolver.resolve(this.brandAsPackageRelative(to))) {
+        continue;
+      }
+      if (from === undefined) {
+        return resolver.relative(to);
+      } else {
+        return resolver.relative(from, to, kind);
       }
     }
     throw new Error(

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -51,8 +51,8 @@ export class MultiUrlResolver extends UrlResolver {
   relative(from: ResolvedUrl, to: ResolvedUrl, kind?: string): FileRelativeUrl;
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, kind?: string):
       FileRelativeUrl|PackageRelativeUrl {
-    const from = (maybeTo === undefined) ? undefined : fromOrTo;
-    const to = (maybeTo === undefined) ? fromOrTo : maybeTo;
+    const [from, to] =
+        (maybeTo === undefined) ? [undefined, fromOrTo] : [fromOrTo, maybeTo];
     for (const resolver of this._resolvers) {
       if (!resolver.resolve(this.brandAsPackageRelative(to))) {
         continue;

--- a/src/url-loader/multi-url-resolver.ts
+++ b/src/url-loader/multi-url-resolver.ts
@@ -54,7 +54,7 @@ export class MultiUrlResolver extends UrlResolver {
     const [from, to] =
         (maybeTo === undefined) ? [undefined, fromOrTo] : [fromOrTo, maybeTo];
     for (const resolver of this._resolvers) {
-      if (!resolver.resolve(this.brandAsPackageRelative(to))) {
+      if (resolver.resolve(this.brandAsPackageRelative(to)) === undefined) {
         continue;
       }
       if (from === undefined) {

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -132,11 +132,18 @@ export class PackageUrlResolver extends UrlResolver {
     return this.brandAsResolved(urlLibFormat(resolvedUrl));
   }
 
+  relative(to: ResolvedUrl): PackageRelativeUrl;
+  relative(from: ResolvedUrl, to: ResolvedUrl, _kind?: string): FileRelativeUrl;
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):
-      FileRelativeUrl {
+      FileRelativeUrl|PackageRelativeUrl {
     const [from, to] = (maybeTo !== undefined) ? [fromOrTo, maybeTo] :
                                                  [this.packageUrl, fromOrTo];
-    return this.relativeImpl(from, to);
+    const result = this.relativeImpl(from, to);
+    if (maybeTo === undefined) {
+      return this.brandAsPackageRelative(result);
+    } else {
+      return result;
+    }
   }
 
   private relativeImpl(from: ResolvedUrl, to: ResolvedUrl): FileRelativeUrl {

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -53,12 +53,12 @@ export class RedirectResolver extends UrlResolver {
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):
       FileRelativeUrl|PackageRelativeUrl {
     let from, to;
-    if (maybeTo !== undefined) {
-      from = fromOrTo;
-      to = maybeTo;
-    } else {
+    if (maybeTo === undefined) {
       from = this.packageUrl;
       to = fromOrTo;
+    } else {
+      from = fromOrTo;
+      to = maybeTo;
     }
     if (!from.startsWith(this._redirectTo) && to.startsWith(this._redirectTo)) {
       to = this.brandAsResolved(

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -48,8 +48,10 @@ export class RedirectResolver extends UrlResolver {
     return undefined;
   }
 
+  relative(to: ResolvedUrl): PackageRelativeUrl;
+  relative(from: ResolvedUrl, to: ResolvedUrl, kind?: string): FileRelativeUrl;
   relative(fromOrTo: ResolvedUrl, maybeTo?: ResolvedUrl, _kind?: string):
-      FileRelativeUrl {
+      FileRelativeUrl|PackageRelativeUrl {
     let from, to;
     if (maybeTo !== undefined) {
       from = fromOrTo;
@@ -59,9 +61,14 @@ export class RedirectResolver extends UrlResolver {
       to = fromOrTo;
     }
     if (!from.startsWith(this._redirectTo) && to.startsWith(this._redirectTo)) {
-      to =
-          this._redirectFrom + to.slice(this._redirectTo.length) as ResolvedUrl;
+      to = this.brandAsResolved(
+          this._redirectFrom + to.slice(this._redirectTo.length));
     }
-    return this.simpleUrlRelative(from, to);
+    const result = this.simpleUrlRelative(from, to);
+    if (maybeTo === undefined) {
+      return this.brandAsPackageRelative(result);
+    } else {
+      return result;
+    }
   }
 }

--- a/src/url-loader/redirect-resolver.ts
+++ b/src/url-loader/redirect-resolver.ts
@@ -58,6 +58,10 @@ export class RedirectResolver extends UrlResolver {
       from = this.packageUrl;
       to = fromOrTo;
     }
+    if (!from.startsWith(this._redirectTo) && to.startsWith(this._redirectTo)) {
+      to =
+          this._redirectFrom + to.slice(this._redirectTo.length) as ResolvedUrl;
+    }
     return this.simpleUrlRelative(from, to);
   }
 }

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -38,15 +38,16 @@ export abstract class UrlResolver {
       baseUrl: ResolvedUrl, url: FileRelativeUrl,
       scannedImport?: ScannedImport): ResolvedUrl|undefined;
 
-  abstract relative(from: ResolvedUrl, to?: ResolvedUrl, kind?: string):
+  abstract relative(to: ResolvedUrl): PackageRelativeUrl;
+  abstract relative(from: ResolvedUrl, to: ResolvedUrl, kind?: string):
       FileRelativeUrl;
 
   protected getBaseAndUnresolved(
       url1: PackageRelativeUrl|ResolvedUrl, url2?: FileRelativeUrl):
       [ResolvedUrl|undefined, FileRelativeUrl|PackageRelativeUrl] {
     return url2 === undefined ?
-        [undefined, url1 as PackageRelativeUrl] :
-        [this.brandAsResolved(url1), this.brandAsRelative(url2)];
+        [undefined, this.brandAsPackageRelative(url1)] :
+        [this.brandAsResolved(url1), this.brandAsFileRelative(url2)];
   }
 
   protected simpleUrlResolve(
@@ -67,7 +68,7 @@ export abstract class UrlResolver {
             fromUrl.slashes !== toUrl.slashes ||
         typeof toUrl.host === 'string' && fromUrl.host !== toUrl.host ||
         typeof toUrl.auth === 'string' && fromUrl.auth !== toUrl.auth) {
-      return this.brandAsRelative(to);
+      return this.brandAsFileRelative(to);
     }
     let pathname;
     const {search, hash} = toUrl;
@@ -88,11 +89,15 @@ export abstract class UrlResolver {
 
       pathname = pathlib.relative(fromDir, toDir + '_').replace(/_$/, '');
     }
-    return this.brandAsRelative(urlLibFormat({pathname, search, hash}));
+    return this.brandAsFileRelative(urlLibFormat({pathname, search, hash}));
   }
 
-  protected brandAsRelative(url: string): FileRelativeUrl {
+  protected brandAsFileRelative(url: string): FileRelativeUrl {
     return url as FileRelativeUrl;
+  }
+
+  protected brandAsPackageRelative(url: string): PackageRelativeUrl {
+    return url as PackageRelativeUrl;
   }
 
   protected brandAsResolved(url: string): ResolvedUrl {


### PR DESCRIPTION
- In order to get a package relative URL back out of a resolver from a ResolveUrl, we essentially call `relative(url)` and it will convert something like `file:///this/package/has/a/file.js` to `has/a/file.js`.
- Now this is true for the `RedirectResolver` which will reverse the effect of a redirect from the provided `url` so as to return a URL relative to the package URL.
 - [x] CHANGELOG.md has been updated
