### PR TITLE
trim whitespace when parsing jsdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
+* Support Windows line endings in JSDoc annotations
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.9] - 2018-01-26

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -80,7 +80,7 @@ export function removeLeadingAsterisks(description: string): string {
   return description.split('\n')
       .map(function(line) {
         // remove leading '\s*' from each line
-        const match = line.match(/^[\s]*\*\s?(.*)$/);
+        const match = line.trim().match(/^[\s]*\*\s?(.*)$/);
         return match ? match[1] : line;
       })
       .join('\n');

--- a/src/test/javascript/jsdoc_test.ts
+++ b/src/test/javascript/jsdoc_test.ts
@@ -28,6 +28,14 @@ suite('jsdoc', () => {
       });
     });
 
+    test('parses CRLF comments', () => {
+      const parsed = jsdoc.parseJsdoc('* Just some text\r\n* in multiple lines.');
+      assert.deepEqual(parsed, {
+        description: 'Just some text\nin multiple lines.',
+        tags: [],
+      });
+    });
+
     test('parses body-only', () => {
       const parsed = jsdoc.parseJsdoc('* Just some text\n* in multiple lines.');
       assert.deepEqual(parsed, {


### PR DESCRIPTION
Fixes #854.

There's some funkiness going on with the pattern here so I just trim it to drop any leftover newlines or CRs.