### PR TITLE
Resolve aliased super-classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
+* Support super-classes referenced from aliased imports
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.12] - 2018-02-14

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -584,6 +584,25 @@ suite('Class', () => {
       ]);
     });
 
+    test('deals with aliased super classes', async () => {
+      const classes = await getClasses('class/super-class-alias.js');
+
+      assert.deepEqual(classes.map((f) => f.name), ['Base', 'Subclass']);
+      assert.deepEqual(await Promise.all(classes.map((c) => getTestProps(c))), [
+        {
+          name: 'Base',
+          description: '',
+          privacy: 'public'
+        },
+        {
+          name: 'Subclass',
+          description: '',
+          privacy: 'public',
+          superClass: 'Base'
+        }
+      ]);
+    });
+
     test('deals with super classes correctly', async () => {
       const classes = await getClasses('class/super-class.js');
 

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -49,6 +49,26 @@ suite('JavaScriptImportScanner', () => {
     ]);
   });
 
+  test('finds named imports and aliases', async () => {
+    const {features} = await runScanner(
+        analyzer,
+        new JavaScriptImportScanner(),
+        'javascript/module-with-import-alias.js');
+
+    assert.containSubset(features, [
+      {
+        type: 'js-import',
+        url: './foo',
+        lazy: false,
+      },
+      {
+        type: 'js-import',
+        url: './baz',
+        lazy: false,
+      },
+    ]);
+  });
+
   test('skips non-path imports', async () => {
     const {features} = await runScanner(
         analyzer,

--- a/src/test/static/class/super-class-alias.js
+++ b/src/test/static/class/super-class-alias.js
@@ -1,0 +1,4 @@
+import { Base as foo } from './super-class-base.js';
+
+class Subclass extends foo {
+}

--- a/src/test/static/class/super-class-base.js
+++ b/src/test/static/class/super-class-base.js
@@ -1,0 +1,1 @@
+export class Base {}

--- a/src/test/static/javascript/module-with-import-alias.js
+++ b/src/test/static/javascript/module-with-import-alias.js
@@ -1,0 +1,2 @@
+import { foo as bar } from './foo';
+import { baz } from './baz';


### PR DESCRIPTION
Fixes #863.

Just tries to find import aliases when resolving the superclass of a given class, instead of assuming the scanned reference is correct.

```ts
import { foo as bar } from './foo';
class Test extends bar {}
```

Also added a test to make sure these work in the JS import scanner, though i suppose it wasn't needed (really i slipped up and thought that's where this needed fixing but was wrong 🤐 )

cc @chadkillingsworth