### PR TITLE
Fix #477 on master

### DIFF
--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -48,6 +48,8 @@ suite('ExpressionScanner', () => {
 
         <template is="dom-bind">
           <div id="{{baz}}"></div>
+          <div id="{{camel.casePath}}"></div>
+          <div id="{{kebab.case-path}}"></div>
         </template>
       `;
       const underliner =
@@ -61,7 +63,7 @@ suite('ExpressionScanner', () => {
       assert.deepEqual(results.warnings, []);
       assert.deepEqual(
           generalExpressions.map((e) => e.databindingInto),
-          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
+          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
       const expressions =
           generalExpressions as AttributeDatabindingExpression[];
       assert.deepEqual(
@@ -81,26 +83,32 @@ suite('ExpressionScanner', () => {
             `
           <div id="{{baz}}"></div>
                      ~~~`,
+          `
+          <div id="{{camel.casePath}}"></div>
+                     ~~~~~~~~~~~~~~`,
+            `
+          <div id="{{kebab.case-path}}"></div>
+                     ~~~~~~~~~~~~~~~`,
           ]);
       assert.deepEqual(
-          expressions.map((e) => e.direction), ['{', '{', '{', '[', '{']);
+          expressions.map((e) => e.direction), ['{', '{', '{', '[', '{', '{', '{']);
       assert.deepEqual(
           expressions.map((e) => e.expressionText),
-          ['foo', 'val', 'bada(wing, daba.boom, 10, -20)', 'bar', 'baz']);
+          ['foo', 'val', 'bada(wing, daba.boom, 10, -20)', 'bar', 'baz', 'camel.casePath', 'kebab.case-path']);
       assert.deepEqual(
           expressions.map((e) => e.eventName),
-          [undefined, 'changed', undefined, undefined, undefined]);
+          [undefined, 'changed', undefined, undefined, undefined, undefined, undefined]);
       assert.deepEqual(
           expressions.map((e) => e.attribute && e.attribute.name),
-          ['id', 'value', 'id', 'id', 'id']);
+          ['id', 'value', 'id', 'id', 'id', 'id', 'id']);
       assert.deepEqual(
           expressions.map((e) => e.properties.map((p) => p.name)),
-          [['foo'], ['val'], ['bada', 'wing', 'daba'], ['bar'], ['baz']]);
+          [['foo'], ['val'], ['bada', 'wing', 'daba'], ['bar'], ['baz'], ['camel'], ['kebab']]);
       assert.deepEqual(
-          expressions.map((e) => e.warnings), [[], [], [], [], []]);
+          expressions.map((e) => e.warnings), [[], [], [], [], [], [], []]);
       assert.deepEqual(
           expressions.map((e) => e.isCompleteBinding),
-          [true, true, true, true, true]);
+          [true, true, true, true, true, true, true]);
     });
 
     test('finds interpolated attribute expressions', async () => {
@@ -328,7 +336,9 @@ suite('ExpressionScanner', () => {
           'foo(bar, baz)',
            ~~~~~~~~~~~~~`,
         `No source range given.`,
-        `No source range given.`,
+        `
+          'foo(bar.*)',
+           ~~~~~~~~~~`,
         `No source range given.`,
         `No source range given.`,
       ]);


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

This is a quick-and-dirty fix for #477.

It's based on property-effects parser code of Polymer (https://github.com/Polymer/polymer/blob/10aded461b1a107ed1cfc4a1d630149ad8508bda/lib/mixins/property-effects.html#L864).

It converts polymer expressions to valid javascript, before passing it to the AST parser (eg.:
```js
> transformPolymerExprToJS(
    "_compute(_myObject.kebab-array-prop.0, 'some-string', 1.0, _otherObj.*)"
  )
< _compute(_myObject['kebab-array-prop']['0'], 'some-string', 1.0, _otherObj)
```

 - [ ] CHANGELOG.md has been updated
