### PR TITLE
Fix #477 on the 2.x branch

### DIFF
--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -463,13 +463,70 @@ function findDatabindingInString(str: string) {
   return expressions;
 }
 
+function transformPath(expression: string) {
+  return expression
+    // replace .0, .123, .kebab-case with ['0'], ['123'], ['kebab-case']
+    .replace(/\.([a-zA-Z_$]([\w:$*]*-+[\w:$*]*)+|[1-9][0-9]*|0)/g, "['$1']")
+    // remove .* and .splices from the end of the paths
+    .replace(/\.(\*|splices)$/, '');
+}
+
+/**
+ * Transform polymer expression based on
+ * https://github.com/Polymer/polymer/blob/10aded461b1a107ed1cfc4a1d630149ad8508bda/lib/mixins/property-effects.html#L864
+ */
+function transformPolymerExprToJS(expression: string) {
+  const method = expression.match(/([^\s]+?)\(([\s\S]*)\)/);
+  if (method) {
+    const methodName = method[1];
+    if (method[2].trim()) {
+      // replace escaped commas with comma entity, split on un-escaped commas
+      const args = method[2].replace(/\\,/g, '&comma;').split(',');
+      return methodName + '(' + args.map(transformArg).join(',') + ')';
+    } else {
+      return expression;
+    }
+  }
+  return transformPath(expression);
+}
+
+function transformArg(rawArg: string) {
+  const arg = rawArg
+    // replace comma entity with comma
+    .replace(/&comma;/g, ',')
+    // repair extra escape sequences; note only commas strictly need
+    // escaping, but we allow any other char to be escaped since its
+    // likely users will do this
+    .replace(/\\(.)/g, '\$1');
+  // detect literal value (must be String or Number)
+  const i = arg.search(/[^\s]/);
+  let fc = arg[i];
+  if (fc === '-') {
+    fc = arg[i + 1];
+  }
+  if (fc >= '0' && fc <= '9') {
+    fc = '#';
+  }
+  switch (fc) {
+    case "'":
+    case '"':
+      return arg;
+    case '#':
+      return arg;
+  }
+  if (arg.indexOf('.') !== -1) {
+    return transformPath(arg);
+  }
+  return arg;
+}
+
 function parseExpression(content: string, expressionSourceRange: SourceRange) {
   const expressionOffset = {
     line: expressionSourceRange.start.line,
     col: expressionSourceRange.start.column
   };
   const parseResult = parseJs(
-      content,
+      transformPolymerExprToJS(content),
       expressionSourceRange.file,
       expressionOffset,
       'polymer-expression-parse-error');

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -49,6 +49,8 @@ suite('ExpressionScanner', () => {
 
         <template is="dom-bind">
           <div id="{{baz}}"></div>
+          <div id="{{camel.casePath}}"></div>
+          <div id="{{kebab.case-path}}"></div>
         </template>
       `;
       const underliner = CodeUnderliner.withMapping('test.html', contents);
@@ -61,7 +63,7 @@ suite('ExpressionScanner', () => {
       assert.deepEqual(results.warnings, []);
       assert.deepEqual(
           generalExpressions.map((e) => e.databindingInto),
-          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
+          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
       const expressions =
           generalExpressions as AttributeDatabindingExpression[];
       assert.deepEqual(
@@ -81,26 +83,32 @@ suite('ExpressionScanner', () => {
             `
           <div id="{{baz}}"></div>
                      ~~~`,
+            `
+          <div id="{{camel.casePath}}"></div>
+                     ~~~~~~~~~~~~~~`,
+            `
+          <div id="{{kebab.case-path}}"></div>
+                     ~~~~~~~~~~~~~~~`
           ]);
       assert.deepEqual(
-          expressions.map((e) => e.direction), ['{', '{', '{', '[', '{']);
+          expressions.map((e) => e.direction), ['{', '{', '{', '[', '{', '{', '{']);
       assert.deepEqual(
           expressions.map((e) => e.expressionText),
-          ['foo', 'val', 'bada(wing, daba.boom, 10, -20)', 'bar', 'baz']);
+          ['foo', 'val', 'bada(wing, daba.boom, 10, -20)', 'bar', 'baz', 'camel.casePath', 'kebab.case-path']);
       assert.deepEqual(
           expressions.map((e) => e.eventName),
-          [undefined, 'changed', undefined, undefined, undefined]);
+          [undefined, 'changed', undefined, undefined, undefined, undefined, undefined]);
       assert.deepEqual(
           expressions.map((e) => e.attribute && e.attribute.name),
-          ['id', 'value', 'id', 'id', 'id']);
+          ['id', 'value', 'id', 'id', 'id', 'id', 'id']);
       assert.deepEqual(
           expressions.map((e) => e.properties.map((p) => p.name)),
-          [['foo'], ['val'], ['bada', 'wing', 'daba'], ['bar'], ['baz']]);
+          [['foo'], ['val'], ['bada', 'wing', 'daba'], ['bar'], ['baz'], ['camel'], ['kebab']]);
       assert.deepEqual(
-          expressions.map((e) => e.warnings), [[], [], [], [], []]);
+          expressions.map((e) => e.warnings), [[], [], [], [], [], [], []]);
       assert.deepEqual(
           expressions.map((e) => e.isCompleteBinding),
-          [true, true, true, true, true]);
+          [true, true, true, true, true, true, true]);
     });
 
     test('finds interpolated attribute expressions', async() => {
@@ -324,7 +332,9 @@ suite('ExpressionScanner', () => {
           'foo(bar, baz)',
            ~~~~~~~~~~~~~`,
         `No source range given.`,
-        `No source range given.`,
+        `
+          'foo(bar.*)',
+           ~~~~~~~~~~`,
         `No source range given.`,
         `No source range given.`,
       ]);


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

This is a quick-and-dirty fix for #477.

It's based on property-effects parser code of Polymer (https://github.com/Polymer/polymer/blob/10aded461b1a107ed1cfc4a1d630149ad8508bda/lib/mixins/property-effects.html#L864).

It converts polymer expressions to valid javascript, before passing it to the AST parser (eg.:
```js
> transformPolymerExprToJS(
    "_compute(_myObject.kebab-array-prop.0, 'some-string', 1.0, _otherObj.*)"
  )
< _compute(_myObject['kebab-array-prop']['0'], 'some-string', 1.0, _otherObj)
```

 - [ ] CHANGELOG.md has been updated
