### PR TITLE
Mostly no-op change towards scoping

### DIFF
--- a/src/javascript/estree-visitor.ts
+++ b/src/javascript/estree-visitor.ts
@@ -12,353 +12,252 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 import {VisitorOption} from './estraverse-shim';
 
-export type VisitResult = VisitorOption|void|null|undefined;
+export type VisitResult = VisitorOption|null|undefined|void;
+export type VisitorCallback<N extends babel.Node> =
+    (node: N, parent: babel.Node|undefined|null, path: NodePath<N>) =>
+        VisitResult;
 
 export interface Visitor {
-  enter?: (node: babel.Node, parent: babel.Node) => VisitResult;
-  leave?: (node: babel.Node, parent: babel.Node) => VisitResult;
-  // TODO(usergenic): What is this fallback?  Look it up.  It's used in
-  // javascript-document.ts for example.
-  fallback?: 'iteration';
-  enterIdentifier?: (node: babel.Identifier, parent: babel.Node) => VisitResult;
-  leaveIdentifier?: (node: babel.Identifier, parent: babel.Node) => VisitResult;
-
-  enterLiteral?: (node: babel.Literal, parent: babel.Node) => VisitResult;
-  leaveLiteral?: (node: babel.Literal, parent: babel.Node) => VisitResult;
-
-  enterProgram?: (node: babel.Program, parent: babel.Node) => VisitResult;
-  leaveProgram?: (node: babel.Program, parent: babel.Node) => VisitResult;
-
-  enterExpressionStatement?:
-      (node: babel.ExpressionStatement, parent: babel.Node) => VisitResult;
-  leaveExpressionStatement?:
-      (node: babel.ExpressionStatement, parent: babel.Node) => VisitResult;
-
-  enterBlockStatement?:
-      (node: babel.BlockStatement, parent: babel.Node) => VisitResult;
-  leaveBlockStatement?:
-      (node: babel.BlockStatement, parent: babel.Node) => VisitResult;
-
-  enterEmptyStatement?:
-      (node: babel.EmptyStatement, parent: babel.Node) => VisitResult;
-  leaveEmptyStatement?:
-      (node: babel.EmptyStatement, parent: babel.Node) => VisitResult;
-
-  enterDebuggerStatement?:
-      (node: babel.DebuggerStatement, parent: babel.Node) => VisitResult;
-  leaveDebuggerStatement?:
-      (node: babel.DebuggerStatement, parent: babel.Node) => VisitResult;
-
-  enterWithStatement?:
-      (node: babel.WithStatement, parent: babel.Node) => VisitResult;
-  leaveWithStatement?:
-      (node: babel.WithStatement, parent: babel.Node) => VisitResult;
-
-  enterReturnStatement?:
-      (node: babel.ReturnStatement, parent: babel.Node) => VisitResult;
-  leaveReturnStatement?:
-      (node: babel.ReturnStatement, parent: babel.Node) => VisitResult;
-
-  enterLabeledStatement?:
-      (node: babel.LabeledStatement, parent: babel.Node) => VisitResult;
-  leaveLabeledStatement?:
-      (node: babel.LabeledStatement, parent: babel.Node) => VisitResult;
-
-  enterBreakStatement?:
-      (node: babel.BreakStatement, parent: babel.Node) => VisitResult;
-  leaveBreakStatement?:
-      (node: babel.BreakStatement, parent: babel.Node) => VisitResult;
-
-  enterContinueStatement?:
-      (node: babel.ContinueStatement, parent: babel.Node) => VisitResult;
-  leaveContinueStatement?:
-      (node: babel.ContinueStatement, parent: babel.Node) => VisitResult;
-
-  enterIfStatement?:
-      (node: babel.IfStatement, parent: babel.Node) => VisitResult;
-  leaveIfStatement?:
-      (node: babel.IfStatement, parent: babel.Node) => VisitResult;
-
-  enterSwitchStatement?:
-      (node: babel.SwitchStatement, parent: babel.Node) => VisitResult;
-  leaveSwitchStatement?:
-      (node: babel.SwitchStatement, parent: babel.Node) => VisitResult;
-
-  enterSwitchCase?: (node: babel.SwitchCase, parent: babel.Node) => VisitResult;
-  leaveSwitchCase?: (node: babel.SwitchCase, parent: babel.Node) => VisitResult;
-
-  enterThrowStatement?:
-      (node: babel.ThrowStatement, parent: babel.Node) => VisitResult;
-  leaveThrowStatement?:
-      (node: babel.ThrowStatement, parent: babel.Node) => VisitResult;
-
-  enterTryStatement?:
-      (node: babel.TryStatement, parent: babel.Node) => VisitResult;
-  leaveTryStatement?:
-      (node: babel.TryStatement, parent: babel.Node) => VisitResult;
-
-  enterCatchClause?:
-      (node: babel.CatchClause, parent: babel.Node) => VisitResult;
-  leaveCatchClause?:
-      (node: babel.CatchClause, parent: babel.Node) => VisitResult;
-
-  enterWhileStatement?:
-      (node: babel.WhileStatement, parent: babel.Node) => VisitResult;
-  leaveWhileStatement?:
-      (node: babel.WhileStatement, parent: babel.Node) => VisitResult;
-
-  enterDoWhileStatement?:
-      (node: babel.DoWhileStatement, parent: babel.Node) => VisitResult;
-  leaveDoWhileStatement?:
-      (node: babel.DoWhileStatement, parent: babel.Node) => VisitResult;
-
-  enterForStatement?:
-      (node: babel.ForStatement, parent: babel.Node) => VisitResult;
-  leaveForStatement?:
-      (node: babel.ForStatement, parent: babel.Node) => VisitResult;
-
-  enterForInStatement?:
-      (node: babel.ForInStatement, parent: babel.Node) => VisitResult;
-  leaveForInStatement?:
-      (node: babel.ForInStatement, parent: babel.Node) => VisitResult;
-
-  enterForOfStatement?:
-      (node: babel.ForOfStatement, parent: babel.Node) => VisitResult;
-  leaveForOfStatement?:
-      (node: babel.ForOfStatement, parent: babel.Node) => VisitResult;
-
-  enterFunctionDeclaration?:
-      (node: babel.FunctionDeclaration, parent: babel.Node) => VisitResult;
-  leaveFunctionDeclaration?:
-      (node: babel.FunctionDeclaration, parent: babel.Node) => VisitResult;
-
-  enterVariableDeclaration?:
-      (node: babel.VariableDeclaration, parent: babel.Node) => VisitResult;
-  leaveVariableDeclaration?:
-      (node: babel.VariableDeclaration, parent: babel.Node) => VisitResult;
-
-  enterVariableDeclarator?:
-      (node: babel.VariableDeclarator, parent: babel.Node) => VisitResult;
-  leaveVariableDeclarator?:
-      (node: babel.VariableDeclarator, parent: babel.Node) => VisitResult;
-
-  enterThisExpression?:
-      (node: babel.ThisExpression, parent: babel.Node) => VisitResult;
-  leaveThisExpression?:
-      (node: babel.ThisExpression, parent: babel.Node) => VisitResult;
-
-  enterArrayExpression?:
-      (node: babel.ArrayExpression, parent: babel.Node) => VisitResult;
-  leaveArrayExpression?:
-      (node: babel.ArrayExpression, parent: babel.Node) => VisitResult;
-
-  enterObjectExpression?:
-      (node: babel.ObjectExpression, parent: babel.Node) => VisitResult;
-  leaveObjectExpression?:
-      (node: babel.ObjectExpression, parent: babel.Node) => VisitResult;
-
-  enterProperty?: (node: babel.Property, parent: babel.Node) => VisitResult;
-  leaveProperty?: (node: babel.Property, parent: babel.Node) => VisitResult;
-
-  enterFunctionExpression?:
-      (node: babel.FunctionExpression, parent: babel.Node) => VisitResult;
-  leaveFunctionExpression?:
-      (node: babel.FunctionExpression, parent: babel.Node) => VisitResult;
-
-  enterArrowFunctionExpression?:
-      (node: babel.ArrowFunctionExpression, parent: babel.Node) => VisitResult;
-  leaveArrowFunctionExpression?:
-      (node: babel.ArrowFunctionExpression, parent: babel.Node) => VisitResult;
-
-  enterYieldExpression?:
-      (node: babel.YieldExpression, parent: babel.Node) => VisitResult;
-  leaveYieldExpression?:
-      (node: babel.YieldExpression, parent: babel.Node) => VisitResult;
-
-  enterSuper?: (node: babel.Super, parent: babel.Node) => VisitResult;
-  leaveSuper?: (node: babel.Super, parent: babel.Node) => VisitResult;
-
-  enterUnaryExpression?:
-      (node: babel.UnaryExpression, parent: babel.Node) => VisitResult;
-  leaveUnaryExpression?:
-      (node: babel.UnaryExpression, parent: babel.Node) => VisitResult;
-
-  enterUpdateExpression?:
-      (node: babel.UpdateExpression, parent: babel.Node) => VisitResult;
-  leaveUpdateExpression?:
-      (node: babel.UpdateExpression, parent: babel.Node) => VisitResult;
-
-  enterBinaryExpression?:
-      (node: babel.BinaryExpression, parent: babel.Node) => VisitResult;
-  leaveBinaryExpression?:
-      (node: babel.BinaryExpression, parent: babel.Node) => VisitResult;
-
-  enterAssignmentExpression?:
-      (node: babel.AssignmentExpression, parent: babel.Node) => VisitResult;
-  leaveAssignmentExpression?:
-      (node: babel.AssignmentExpression, parent: babel.Node) => VisitResult;
-
-  enterLogicalExpression?:
-      (node: babel.LogicalExpression, parent: babel.Node) => VisitResult;
-  leaveLogicalExpression?:
-      (node: babel.LogicalExpression, parent: babel.Node) => VisitResult;
-
-  enterMemberExpression?:
-      (node: babel.MemberExpression, parent: babel.Node) => VisitResult;
-  leaveMemberExpression?:
-      (node: babel.MemberExpression, parent: babel.Node) => VisitResult;
-
-  enterConditionalExpression?:
-      (node: babel.ConditionalExpression, parent: babel.Node) => VisitResult;
-  leaveConditionalExpression?:
-      (node: babel.ConditionalExpression, parent: babel.Node) => VisitResult;
-
-  enterCallExpression?:
-      (node: babel.CallExpression, parent: babel.Node) => VisitResult;
-  leaveCallExpression?:
-      (node: babel.CallExpression, parent: babel.Node) => VisitResult;
-
-  enterNewExpression?:
-      (node: babel.NewExpression, parent: babel.Node) => VisitResult;
-  leaveNewExpression?:
-      (node: babel.NewExpression, parent: babel.Node) => VisitResult;
-
-  enterSequenceExpression?:
-      (node: babel.SequenceExpression, parent: babel.Node) => VisitResult;
-  leaveSequenceExpression?:
-      (node: babel.SequenceExpression, parent: babel.Node) => VisitResult;
-
-  enterTemplateLiteral?:
-      (node: babel.TemplateLiteral, parent: babel.Node) => VisitResult;
-  leaveTemplateLiteral?:
-      (node: babel.TemplateLiteral, parent: babel.Node) => VisitResult;
-
-  enterTaggedTemplateExpression?:
-      (node: babel.TaggedTemplateExpression, parent: babel.Node) => VisitResult;
-  leaveTaggedTemplateExpression?:
-      (node: babel.TaggedTemplateExpression, parent: babel.Node) => VisitResult;
-
-  enterTemplateElement?:
-      (node: babel.TemplateElement, parent: babel.Node) => VisitResult;
-  leaveTemplateElement?:
-      (node: babel.TemplateElement, parent: babel.Node) => VisitResult;
-
-  enterSpreadElement?:
-      (node: babel.SpreadElement, parent: babel.Node) => VisitResult;
-  leaveSpreadElement?:
-      (node: babel.SpreadElement, parent: babel.Node) => VisitResult;
-
-  enterPattern?: (node: babel.Pattern, parent: babel.Node) => VisitResult;
-  leavePattern?: (node: babel.Pattern, parent: babel.Node) => VisitResult;
-
-  enterAssignmentProperty?:
-      (node: babel.AssignmentProperty, parent: babel.Node) => VisitResult;
-  leaveAssignmentProperty?:
-      (node: babel.AssignmentProperty, parent: babel.Node) => VisitResult;
-
-  enterObjectPattern?:
-      (node: babel.ObjectPattern, parent: babel.Node) => VisitResult;
-  leaveObjectPattern?:
-      (node: babel.ObjectPattern, parent: babel.Node) => VisitResult;
-
-  enterObjectMethod?:
-      (node: babel.ObjectMethod, parent: babel.Node) => VisitResult;
-  leaveObjectMethod?:
-      (node: babel.ObjectMethod, parent: babel.Node) => VisitResult;
-
-  enterObjectProperty?:
-      (node: babel.ObjectProperty, parent: babel.Node) => VisitResult;
-  leaveObjectProperty?:
-      (node: babel.ObjectProperty, parent: babel.Node) => VisitResult;
-
-  enterArrayPattern?:
-      (node: babel.ArrayPattern, parent: babel.Node) => VisitResult;
-  leaveArrayPattern?:
-      (node: babel.ArrayPattern, parent: babel.Node) => VisitResult;
-
-  enterRestElement?:
-      (node: babel.RestElement, parent: babel.Node) => VisitResult;
-  leaveRestElement?:
-      (node: babel.RestElement, parent: babel.Node) => VisitResult;
-
-  enterAssignmentPattern?:
-      (node: babel.AssignmentPattern, parent: babel.Node) => VisitResult;
-  leaveAssignmentPattern?:
-      (node: babel.AssignmentPattern, parent: babel.Node) => VisitResult;
-
-  enterMethod?: (node: babel.Method, parent: babel.Node) => VisitResult;
-  leaveMethod?: (node: babel.Method, parent: babel.Node) => VisitResult;
-
-  enterClassMethod?:
-      (node: babel.ClassMethod, parent: babel.Node) => VisitResult;
-  leaveClassMethod?:
-      (node: babel.ClassMethod, parent: babel.Node) => VisitResult;
-
-  enterClassDeclaration?:
-      (node: babel.ClassDeclaration, parent: babel.Node) => VisitResult;
-  leaveClassDeclaration?:
-      (node: babel.ClassDeclaration, parent: babel.Node) => VisitResult;
-
-  enterClassExpression?:
-      (node: babel.ClassExpression, parent: babel.Node) => VisitResult;
-  leaveClassExpression?:
-      (node: babel.ClassExpression, parent: babel.Node) => VisitResult;
-
-  enterMetaProperty?:
-      (node: babel.MetaProperty, parent: babel.Node) => VisitResult;
-  leaveMetaProperty?:
-      (node: babel.MetaProperty, parent: babel.Node) => VisitResult;
-
-  enterModuleDeclaration?:
-      (node: babel.ModuleDeclaration, parent: babel.Node) => VisitResult;
-  leaveModuleDeclaration?:
-      (node: babel.ModuleDeclaration, parent: babel.Node) => VisitResult;
-
-  enterModuleSpecifier?:
-      (node: babel.ModuleSpecifier, parent: babel.Node) => VisitResult;
-  leaveModuleSpecifier?:
-      (node: babel.ModuleSpecifier, parent: babel.Node) => VisitResult;
-
-  enterImportDeclaration?:
-      (node: babel.ImportDeclaration, parent: babel.Node) => VisitResult;
-  leaveImportDeclaration?:
-      (node: babel.ImportDeclaration, parent: babel.Node) => VisitResult;
-
-  enterImportSpecifier?:
-      (node: babel.ImportSpecifier, parent: babel.Node) => VisitResult;
-  leaveImportSpecifier?:
-      (node: babel.ImportSpecifier, parent: babel.Node) => VisitResult;
-
-  enterImportDefaultSpecifier?:
-      (node: babel.ImportDefaultSpecifier, parent: babel.Node) => VisitResult;
-  leaveImportDefaultSpecifier?:
-      (node: babel.ImportDefaultSpecifier, parent: babel.Node) => VisitResult;
-
-  enterImportNamespaceSpecifier?:
-      (node: babel.ImportNamespaceSpecifier, parent: babel.Node) => VisitResult;
-  leaveImportNamespaceSpecifier?:
-      (node: babel.ImportNamespaceSpecifier, parent: babel.Node) => VisitResult;
-
-  enterExportNamedDeclaration?:
-      (node: babel.ExportNamedDeclaration, parent: babel.Node) => VisitResult;
-  leaveExportNamedDeclaration?:
-      (node: babel.ExportNamedDeclaration, parent: babel.Node) => VisitResult;
-
-  enterExportSpecifier?:
-      (node: babel.ExportSpecifier, parent: babel.Node) => VisitResult;
-  leaveExportSpecifier?:
-      (node: babel.ExportSpecifier, parent: babel.Node) => VisitResult;
-
-  enterExportDefaultDeclaration?:
-      (node: babel.ExportDefaultDeclaration, parent: babel.Node) => VisitResult;
-  leaveExportDefaultDeclaration?:
-      (node: babel.ExportDefaultDeclaration, parent: babel.Node) => VisitResult;
-
-  enterExportAllDeclaration?:
-      (node: babel.ExportAllDeclaration, parent: babel.Node) => VisitResult;
-  leaveExportAllDeclaration?:
-      (node: babel.ExportAllDeclaration, parent: babel.Node) => VisitResult;
+  readonly enter?: VisitorCallback<babel.Node>;
+  readonly leave?: VisitorCallback<babel.Node>;
+  readonly enterIdentifier?: VisitorCallback<babel.Identifier>;
+  readonly leaveIdentifier?: VisitorCallback<babel.Identifier>;
+
+  readonly enterLiteral?: VisitorCallback<babel.Literal>;
+  readonly leaveLiteral?: VisitorCallback<babel.Literal>;
+
+  readonly enterProgram?: VisitorCallback<babel.Program>;
+  readonly leaveProgram?: VisitorCallback<babel.Program>;
+
+  readonly enterExpressionStatement?:
+      VisitorCallback<babel.ExpressionStatement>;
+  readonly leaveExpressionStatement?:
+      VisitorCallback<babel.ExpressionStatement>;
+
+  readonly enterBlockStatement?: VisitorCallback<babel.BlockStatement>;
+  readonly leaveBlockStatement?: VisitorCallback<babel.BlockStatement>;
+
+  readonly enterEmptyStatement?: VisitorCallback<babel.EmptyStatement>;
+  readonly leaveEmptyStatement?: VisitorCallback<babel.EmptyStatement>;
+
+  readonly enterDebuggerStatement?: VisitorCallback<babel.DebuggerStatement>;
+  readonly leaveDebuggerStatement?: VisitorCallback<babel.DebuggerStatement>;
+
+  readonly enterWithStatement?: VisitorCallback<babel.WithStatement>;
+  readonly leaveWithStatement?: VisitorCallback<babel.WithStatement>;
+
+  readonly enterReturnStatement?: VisitorCallback<babel.ReturnStatement>;
+  readonly leaveReturnStatement?: VisitorCallback<babel.ReturnStatement>;
+
+  readonly enterLabeledStatement?: VisitorCallback<babel.LabeledStatement>;
+  readonly leaveLabeledStatement?: VisitorCallback<babel.LabeledStatement>;
+
+  readonly enterBreakStatement?: VisitorCallback<babel.BreakStatement>;
+  readonly leaveBreakStatement?: VisitorCallback<babel.BreakStatement>;
+
+  readonly enterContinueStatement?: VisitorCallback<babel.ContinueStatement>;
+  readonly leaveContinueStatement?: VisitorCallback<babel.ContinueStatement>;
+
+  readonly enterIfStatement?: VisitorCallback<babel.IfStatement>;
+  readonly leaveIfStatement?: VisitorCallback<babel.IfStatement>;
+
+  readonly enterSwitchStatement?: VisitorCallback<babel.SwitchStatement>;
+  readonly leaveSwitchStatement?: VisitorCallback<babel.SwitchStatement>;
+
+  readonly enterSwitchCase?: VisitorCallback<babel.SwitchCase>;
+  readonly leaveSwitchCase?: VisitorCallback<babel.SwitchCase>;
+
+  readonly enterThrowStatement?: VisitorCallback<babel.ThrowStatement>;
+  readonly leaveThrowStatement?: VisitorCallback<babel.ThrowStatement>;
+
+  readonly enterTryStatement?: VisitorCallback<babel.TryStatement>;
+  readonly leaveTryStatement?: VisitorCallback<babel.TryStatement>;
+
+  readonly enterCatchClause?: VisitorCallback<babel.CatchClause>;
+  readonly leaveCatchClause?: VisitorCallback<babel.CatchClause>;
+
+  readonly enterWhileStatement?: VisitorCallback<babel.WhileStatement>;
+  readonly leaveWhileStatement?: VisitorCallback<babel.WhileStatement>;
+
+  readonly enterDoWhileStatement?: VisitorCallback<babel.DoWhileStatement>;
+  readonly leaveDoWhileStatement?: VisitorCallback<babel.DoWhileStatement>;
+
+  readonly enterForStatement?: VisitorCallback<babel.ForStatement>;
+  readonly leaveForStatement?: VisitorCallback<babel.ForStatement>;
+
+  readonly enterForInStatement?: VisitorCallback<babel.ForInStatement>;
+  readonly leaveForInStatement?: VisitorCallback<babel.ForInStatement>;
+
+  readonly enterForOfStatement?: VisitorCallback<babel.ForOfStatement>;
+  readonly leaveForOfStatement?: VisitorCallback<babel.ForOfStatement>;
+
+  readonly enterFunctionDeclaration?:
+      VisitorCallback<babel.FunctionDeclaration>;
+  readonly leaveFunctionDeclaration?:
+      VisitorCallback<babel.FunctionDeclaration>;
+
+  readonly enterVariableDeclaration?:
+      VisitorCallback<babel.VariableDeclaration>;
+  readonly leaveVariableDeclaration?:
+      VisitorCallback<babel.VariableDeclaration>;
+
+  readonly enterVariableDeclarator?: VisitorCallback<babel.VariableDeclarator>;
+  readonly leaveVariableDeclarator?: VisitorCallback<babel.VariableDeclarator>;
+
+  readonly enterThisExpression?: VisitorCallback<babel.ThisExpression>;
+  readonly leaveThisExpression?: VisitorCallback<babel.ThisExpression>;
+
+  readonly enterArrayExpression?: VisitorCallback<babel.ArrayExpression>;
+  readonly leaveArrayExpression?: VisitorCallback<babel.ArrayExpression>;
+
+  readonly enterObjectExpression?: VisitorCallback<babel.ObjectExpression>;
+  readonly leaveObjectExpression?: VisitorCallback<babel.ObjectExpression>;
+
+  readonly enterProperty?: VisitorCallback<babel.Property>;
+  readonly leaveProperty?: VisitorCallback<babel.Property>;
+
+  readonly enterFunctionExpression?: VisitorCallback<babel.FunctionExpression>;
+  readonly leaveFunctionExpression?: VisitorCallback<babel.FunctionExpression>;
+
+  readonly enterArrowFunctionExpression?:
+      VisitorCallback<babel.ArrowFunctionExpression>;
+  readonly leaveArrowFunctionExpression?:
+      VisitorCallback<babel.ArrowFunctionExpression>;
+
+  readonly enterYieldExpression?: VisitorCallback<babel.YieldExpression>;
+  readonly leaveYieldExpression?: VisitorCallback<babel.YieldExpression>;
+
+  readonly enterSuper?: VisitorCallback<babel.Super>;
+  readonly leaveSuper?: VisitorCallback<babel.Super>;
+
+  readonly enterUnaryExpression?: VisitorCallback<babel.UnaryExpression>;
+  readonly leaveUnaryExpression?: VisitorCallback<babel.UnaryExpression>;
+
+  readonly enterUpdateExpression?: VisitorCallback<babel.UpdateExpression>;
+  readonly leaveUpdateExpression?: VisitorCallback<babel.UpdateExpression>;
+
+  readonly enterBinaryExpression?: VisitorCallback<babel.BinaryExpression>;
+  readonly leaveBinaryExpression?: VisitorCallback<babel.BinaryExpression>;
+
+  readonly enterAssignmentExpression?:
+      VisitorCallback<babel.AssignmentExpression>;
+  readonly leaveAssignmentExpression?:
+      VisitorCallback<babel.AssignmentExpression>;
+
+  readonly enterLogicalExpression?: VisitorCallback<babel.LogicalExpression>;
+  readonly leaveLogicalExpression?: VisitorCallback<babel.LogicalExpression>;
+
+  readonly enterMemberExpression?: VisitorCallback<babel.MemberExpression>;
+  readonly leaveMemberExpression?: VisitorCallback<babel.MemberExpression>;
+
+  readonly enterConditionalExpression?:
+      VisitorCallback<babel.ConditionalExpression>;
+  readonly leaveConditionalExpression?:
+      VisitorCallback<babel.ConditionalExpression>;
+
+  readonly enterCallExpression?: VisitorCallback<babel.CallExpression>;
+  readonly leaveCallExpression?: VisitorCallback<babel.CallExpression>;
+
+  readonly enterNewExpression?: VisitorCallback<babel.NewExpression>;
+  readonly leaveNewExpression?: VisitorCallback<babel.NewExpression>;
+
+  readonly enterSequenceExpression?: VisitorCallback<babel.SequenceExpression>;
+  readonly leaveSequenceExpression?: VisitorCallback<babel.SequenceExpression>;
+
+  readonly enterTemplateLiteral?: VisitorCallback<babel.TemplateLiteral>;
+  readonly leaveTemplateLiteral?: VisitorCallback<babel.TemplateLiteral>;
+
+  readonly enterTaggedTemplateExpression?:
+      VisitorCallback<babel.TaggedTemplateExpression>;
+  readonly leaveTaggedTemplateExpression?:
+      VisitorCallback<babel.TaggedTemplateExpression>;
+
+  readonly enterTemplateElement?: VisitorCallback<babel.TemplateElement>;
+  readonly leaveTemplateElement?: VisitorCallback<babel.TemplateElement>;
+
+  readonly enterSpreadElement?: VisitorCallback<babel.SpreadElement>;
+  readonly leaveSpreadElement?: VisitorCallback<babel.SpreadElement>;
+
+  readonly enterPattern?: VisitorCallback<babel.Pattern>;
+  readonly leavePattern?: VisitorCallback<babel.Pattern>;
+
+  readonly enterAssignmentProperty?: VisitorCallback<babel.AssignmentProperty>;
+  readonly leaveAssignmentProperty?: VisitorCallback<babel.AssignmentProperty>;
+
+  readonly enterObjectPattern?: VisitorCallback<babel.ObjectPattern>;
+  readonly leaveObjectPattern?: VisitorCallback<babel.ObjectPattern>;
+
+  readonly enterObjectMethod?: VisitorCallback<babel.ObjectMethod>;
+  readonly leaveObjectMethod?: VisitorCallback<babel.ObjectMethod>;
+
+  readonly enterObjectProperty?: VisitorCallback<babel.ObjectProperty>;
+  readonly leaveObjectProperty?: VisitorCallback<babel.ObjectProperty>;
+
+  readonly enterArrayPattern?: VisitorCallback<babel.ArrayPattern>;
+  readonly leaveArrayPattern?: VisitorCallback<babel.ArrayPattern>;
+
+  readonly enterRestElement?: VisitorCallback<babel.RestElement>;
+  readonly leaveRestElement?: VisitorCallback<babel.RestElement>;
+
+  readonly enterAssignmentPattern?: VisitorCallback<babel.AssignmentPattern>;
+  readonly leaveAssignmentPattern?: VisitorCallback<babel.AssignmentPattern>;
+
+  readonly enterMethod?: VisitorCallback<babel.Method>;
+  readonly leaveMethod?: VisitorCallback<babel.Method>;
+
+  readonly enterClassMethod?: VisitorCallback<babel.ClassMethod>;
+  readonly leaveClassMethod?: VisitorCallback<babel.ClassMethod>;
+
+  readonly enterClassDeclaration?: VisitorCallback<babel.ClassDeclaration>;
+  readonly leaveClassDeclaration?: VisitorCallback<babel.ClassDeclaration>;
+
+  readonly enterClassExpression?: VisitorCallback<babel.ClassExpression>;
+  readonly leaveClassExpression?: VisitorCallback<babel.ClassExpression>;
+
+  readonly enterMetaProperty?: VisitorCallback<babel.MetaProperty>;
+  readonly leaveMetaProperty?: VisitorCallback<babel.MetaProperty>;
+
+  readonly enterModuleDeclaration?: VisitorCallback<babel.ModuleDeclaration>;
+  readonly leaveModuleDeclaration?: VisitorCallback<babel.ModuleDeclaration>;
+
+  readonly enterModuleSpecifier?: VisitorCallback<babel.ModuleSpecifier>;
+  readonly leaveModuleSpecifier?: VisitorCallback<babel.ModuleSpecifier>;
+
+  readonly enterImportDeclaration?: VisitorCallback<babel.ImportDeclaration>;
+  readonly leaveImportDeclaration?: VisitorCallback<babel.ImportDeclaration>;
+
+  readonly enterImportSpecifier?: VisitorCallback<babel.ImportSpecifier>;
+  readonly leaveImportSpecifier?: VisitorCallback<babel.ImportSpecifier>;
+
+  readonly enterImportDefaultSpecifier?:
+      VisitorCallback<babel.ImportDefaultSpecifier>;
+  readonly leaveImportDefaultSpecifier?:
+      VisitorCallback<babel.ImportDefaultSpecifier>;
+
+  readonly enterImportNamespaceSpecifier?:
+      VisitorCallback<babel.ImportNamespaceSpecifier>;
+  readonly leaveImportNamespaceSpecifier?:
+      VisitorCallback<babel.ImportNamespaceSpecifier>;
+
+  readonly enterExportNamedDeclaration?:
+      VisitorCallback<babel.ExportNamedDeclaration>;
+  readonly leaveExportNamedDeclaration?:
+      VisitorCallback<babel.ExportNamedDeclaration>;
+
+  readonly enterExportSpecifier?: VisitorCallback<babel.ExportSpecifier>;
+  readonly leaveExportSpecifier?: VisitorCallback<babel.ExportSpecifier>;
+
+  readonly enterExportDefaultDeclaration?:
+      VisitorCallback<babel.ExportDefaultDeclaration>;
+  readonly leaveExportDefaultDeclaration?:
+      VisitorCallback<babel.ExportDefaultDeclaration>;
+
+  readonly enterExportAllDeclaration?:
+      VisitorCallback<babel.ExportAllDeclaration>;
+  readonly leaveExportAllDeclaration?:
+      VisitorCallback<babel.ExportAllDeclaration>;
 }

--- a/src/javascript/javascript-export-scanner.ts
+++ b/src/javascript/javascript-export-scanner.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {NodePath} from 'babel-traverse';
+import * as babel from 'babel-types';
+
+import {Document, Feature, SourceRange, Warning} from '../model/model';
+import {Resolvable} from '../model/resolvable';
+
+import {Visitor} from './estree-visitor';
+import {JavaScriptDocument} from './javascript-document';
+import {JavaScriptScanner} from './javascript-scanner';
+
+export type ExportNode = babel.ExportNamedDeclaration|
+                         babel.ExportAllDeclaration|
+                         babel.ExportDefaultDeclaration;
+
+
+declare module '../model/queryable' {
+  interface FeatureKindMap {
+    'export': Export;
+  }
+}
+
+const scannedExportKinds: ReadonlySet<string> = new Set(['export']);
+export class Export implements Resolvable, Feature {
+  readonly kinds = scannedExportKinds;
+  readonly identifiers = new Set();
+  readonly description: undefined;
+  readonly jsdoc: undefined;
+  readonly sourceRange: SourceRange|undefined;
+  readonly astNodePath: NodePath<babel.Node>;
+  readonly astNode: ExportNode;
+  readonly warnings: ReadonlyArray<Warning> = [];
+
+  constructor(
+      astNode: ExportNode, sourceRange: SourceRange|undefined,
+      nodePath: NodePath<babel.Node>) {
+    this.astNode = astNode;
+    if (astNode.type === 'ExportDefaultDeclaration') {
+      this.identifiers.add('default');
+    } else if (astNode.type === 'ExportNamedDeclaration') {
+      for (const specifier of astNode.specifiers) {
+        if (specifier.exported.type === 'Identifier') {
+          this.identifiers.add(specifier.exported.name);
+        }
+      }
+    }
+    this.astNodePath = nodePath;
+    this.sourceRange = sourceRange;
+  }
+
+  // It's immutable, and it doesn't care about other documents, so it's
+  // both a ScannedFeature and a Feature.
+  resolve(_document: Document): Feature|undefined {
+    return this;
+  }
+}
+
+export class JavaScriptExportScanner implements JavaScriptScanner {
+  async scan(
+      document: JavaScriptDocument,
+      visit: (visitor: Visitor) => Promise<void>) {
+    const exports: Export[] = [];
+    const warnings: Warning[] = [];
+
+    await visit({
+      enterExportNamedDeclaration(node, _parent, path) {
+        exports.push(new Export(node, document.sourceRangeForNode(node), path));
+      },
+      enterExportAllDeclaration(node, _parent, path) {
+        exports.push(new Export(node, document.sourceRangeForNode(node), path));
+      },
+      enterExportDefaultDeclaration(node, _parent, path) {
+        exports.push(new Export(node, document.sourceRangeForNode(node), path));
+      }
+    });
+    return {features: exports, warnings};
+  }
+}

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -98,7 +98,33 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
             document.sourceRangeForNode(node.source)!,
             node,
             false));
+      },
+
+      enterExportAllDeclaration(node, _parent) {
+        imports.push(new ScannedImport(
+            'js-import',
+            scanner._resolveSpecifier(
+                node.source.value, document, node, warnings),
+            document.sourceRangeForNode(node)!,
+            document.sourceRangeForNode(node.source)!,
+            node,
+            false));
+      },
+
+      enterExportNamedDeclaration(node, _parent) {
+        if (node.source == null) {
+          return;
+        }
+        imports.push(new ScannedImport(
+            'js-import',
+            scanner._resolveSpecifier(
+                node.source.value, document, node, warnings),
+            document.sourceRangeForNode(node)!,
+            document.sourceRangeForNode(node.source)!,
+            node,
+            false));
       }
+
     });
     return {features: imports, warnings};
   }

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Scope} from 'babel-traverse';
 import * as babel from 'babel-types';
 import * as doctrine from 'doctrine';
 import {Annotation, Tag} from 'doctrine';
@@ -143,7 +144,8 @@ export function getMixinApplications(
     document: JavaScriptDocument,
     node: babel.Node,
     docs: Annotation,
-    warnings: Warning[]): ScannedReference[] {
+    warnings: Warning[],
+    scope: Scope): ScannedReference[] {
   // TODO(justinfagnani): remove @mixes support
   const appliesMixinAnnotations = docs.tags!.filter(
       (tag) => tag.title === 'appliesMixin' || tag.title === 'mixes');
@@ -164,7 +166,8 @@ export function getMixinApplications(
                  }));
                  return;
                }
-               return new ScannedReference(mixinId, sourceRange);
+               return new ScannedReference(
+                   mixinId, sourceRange, undefined, scope);
              })
              .filter((m) => m !== undefined) as ScannedReference[];
 }

--- a/src/model/reference.ts
+++ b/src/model/reference.ts
@@ -12,11 +12,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Scope} from 'babel-traverse';
+import * as babel from 'babel-types';
+
 import {Annotation} from '../javascript/jsdoc';
+import {ParsedDocument} from '../parser/document';
 
 import {Document} from './document';
 import {Feature, ScannedFeature} from './feature';
-import {ImmutableArray, unsafeAsMutable} from './immutable';
 import {Resolvable} from './resolvable';
 import {SourceRange} from './source-range';
 import {Warning} from './warning';
@@ -26,22 +29,24 @@ import {Warning} from './warning';
  */
 export class ScannedReference extends ScannedFeature implements Resolvable {
   readonly identifier: string;
-  readonly sourceRange: SourceRange;
+  readonly sourceRange: SourceRange|undefined;
+  readonly scope: Scope;
+  readonly astNode: babel.Node|undefined;
 
   constructor(
-      identifier: string, sourceRange: SourceRange, astNode?: any,
-      description?: string, jsdoc?: Annotation, warnings?: Warning[]) {
+      identifier: string, sourceRange: SourceRange|undefined,
+      astNode: babel.Node|undefined, scope: Scope, description?: string,
+      jsdoc?: Annotation, warnings?: Warning[]) {
     super(sourceRange, astNode, description, jsdoc, warnings);
+    this.astNode = astNode;
+    this.scope = scope;
     this.sourceRange = sourceRange;
     this.identifier = identifier;
   }
 
-  resolve(_document: Document): Reference {
-    // TODO(justinfagnani): include an actual reference?
-    // Would need a way to get a Kind to pass to Document.getById().
-    // Should Kind in getById by optional?
-    return new Reference(
-        this.identifier, this.sourceRange, this.astNode, this.warnings);
+  resolve(document: Document): Reference {
+    const feature = undefined;  // TODO(rictic): the resolve logic
+    return new Reference(this, feature, document.parsedDocument);
   }
 }
 
@@ -50,17 +55,40 @@ declare module './queryable' {
     'reference': Reference;
   }
 }
+
+const referenceSet: ReadonlySet<'reference'> =
+    new Set<'reference'>(['reference']);
+const emptySet: ReadonlySet<string> = new Set();
+
 /**
  * A reference to another feature by identifier.
  */
-export class Reference extends Feature {
-  identifier: string;
+export class Reference implements Feature {
+  readonly kinds = referenceSet;
+  readonly identifiers = emptySet;
+  readonly identifier: string;
+  readonly sourceRange: SourceRange|undefined;
+  readonly astNode: any;
+  readonly feature: Feature|undefined;
+  readonly warnings: ReadonlyArray<Warning> = [];
 
   constructor(
-      identifier: string, sourceRange: SourceRange, astNode: any,
-      warnings: ImmutableArray<Warning>) {
-    super(sourceRange, astNode, warnings);
-    unsafeAsMutable(this.kinds).add('reference');
-    this.identifier = identifier;
+      scannedReference: ScannedReference, _feature: Feature|undefined,
+      _document: ParsedDocument) {
+    this.identifier = scannedReference.identifier;
+    this.sourceRange = scannedReference.sourceRange;
+    this.warnings = scannedReference.warnings;
+    /*
+    TODO(rictic): enable this, after actually performing resolution.
+    if (feature === undefined && this.sourceRange) {
+      this.warnings = this.warnings.concat([new Warning({
+        sourceRange: this.sourceRange,
+        code: 'could-not-resolve-reference',
+        parsedDocument: document,
+        severity: Severity.WARNING,
+        message: `Could not resolve this reference. Did you import it?`
+      })]);
+    }
+    */
   }
 }

--- a/src/polymer/behavior.ts
+++ b/src/polymer/behavior.ts
@@ -12,26 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document, SourceRange} from '../model/model';
+import {Document} from '../model/model';
 import {Options as ElementOptions, PolymerElement, ScannedPolymerElement} from '../polymer/polymer-element';
-
-/**
- * A scanned behavior assignment of a Polymer element. This is only a
- * reference to the behavior and not the actual behavior definition itself.
- *
- * Example:
- *
- *   Polymer({
- *     is: 'custom-element',
- *     behaviors: [Polymer.SomeBehavior]
- *                 ^^^^^^^^^^^^^^^^^^^^
- *   });
- * TODO(justinfagnani): replace with Reference
- */
-export interface ScannedBehaviorAssignment {
-  name: string;
-  sourceRange: SourceRange;
-}
 
 export interface Options extends ElementOptions {}
 

--- a/src/polymer/polymer-element-mixin.ts
+++ b/src/polymer/polymer-element-mixin.ts
@@ -16,7 +16,6 @@ import * as babel from 'babel-types';
 import {Annotation as JsDocAnnotation} from '../javascript/jsdoc';
 import {Class, Document, ElementMixin, Privacy, ScannedElementMixin, ScannedMethod, ScannedReference, SourceRange} from '../model/model';
 
-import {ScannedBehaviorAssignment} from './behavior';
 import {addMethod, addProperty, getBehaviors, LocalId, Observer, PolymerExtension, PolymerProperty, ScannedPolymerExtension, ScannedPolymerProperty} from './polymer-element';
 
 export interface Options {
@@ -38,7 +37,7 @@ export class ScannedPolymerElementMixin extends ScannedElementMixin implements
   readonly staticMethods: Map<string, ScannedMethod> = new Map();
   readonly observers: Observer[] = [];
   readonly listeners: {event: string, handler: string}[] = [];
-  readonly behaviorAssignments: ScannedBehaviorAssignment[] = [];
+  readonly behaviorAssignments: ScannedReference[] = [];
   pseudo: boolean = false;
   readonly abstract: boolean = false;
   readonly sourceRange: SourceRange;
@@ -91,7 +90,7 @@ export class PolymerElementMixin extends ElementMixin implements
 
   readonly observers: Observer[];
   readonly listeners: {event: string, handler: string}[] = [];
-  readonly behaviorAssignments: ScannedBehaviorAssignment[] = [];
+  readonly behaviorAssignments: ScannedReference[] = [];
   readonly localIds: LocalId[] = [];
   readonly pseudo: boolean;
 

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -12,7 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
+
 import {getIdentifierName} from '../javascript/ast-value';
 import {Visitor} from '../javascript/estree-visitor';
 import * as esutil from '../javascript/esutil';
@@ -45,7 +47,8 @@ class ElementVisitor implements Visitor {
     this.document = document;
   }
 
-  enterCallExpression(node: babel.CallExpression, parent: babel.Node) {
+  enterCallExpression(
+      node: babel.CallExpression, parent: babel.Node, path: NodePath) {
     const callee = node.callee;
     if (!babel.isIdentifier(callee) || callee.name !== 'Polymer') {
       return;
@@ -81,7 +84,7 @@ class ElementVisitor implements Visitor {
     });
     element.description = (element.description || '').trim();
     const propertyHandlers =
-        declarationPropertyHandlers(element, this.document);
+        declarationPropertyHandlers(element, this.document, path.scope);
 
     const argument = node.arguments[0];
     if (babel.isObjectExpression(argument)) {

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 
 import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
@@ -40,7 +41,7 @@ export class MixinVisitor implements Visitor {
   }
 
   enterAssignmentExpression(
-      node: babel.AssignmentExpression, parent: babel.Node) {
+      node: babel.AssignmentExpression, parent: babel.Node, path: NodePath) {
     if (!babel.isExpressionStatement(parent)) {
       return;
     }
@@ -64,7 +65,7 @@ export class MixinVisitor implements Visitor {
           privacy: getOrInferPrivacy(namespacedName, parentJsDocs),
           jsdoc: parentJsDocs,
           mixins: jsdoc.getMixinApplications(
-              this._document, node, parentJsDocs, this.warnings),
+              this._document, node, parentJsDocs, this.warnings, path.scope),
         });
         this._currentMixinNode = node;
         this.mixins.push(this._currentMixin);
@@ -75,7 +76,7 @@ export class MixinVisitor implements Visitor {
   }
 
   enterFunctionDeclaration(
-      node: babel.FunctionDeclaration, _parent: babel.Node) {
+      node: babel.FunctionDeclaration, _parent: babel.Node, path: NodePath) {
     const nodeComments = esutil.getAttachedComment(node) || '';
     const nodeJsDocs = jsdoc.parseJsdoc(nodeComments);
     if (hasMixinFunctionDocTag(nodeJsDocs)) {
@@ -97,7 +98,7 @@ export class MixinVisitor implements Visitor {
           privacy: getOrInferPrivacy(namespacedName, nodeJsDocs),
           jsdoc: nodeJsDocs,
           mixins: jsdoc.getMixinApplications(
-              this._document, node, nodeJsDocs, this.warnings)
+              this._document, node, nodeJsDocs, this.warnings, path.scope)
         });
         this._currentMixinNode = node;
         this.mixins.push(this._currentMixin);
@@ -117,7 +118,7 @@ export class MixinVisitor implements Visitor {
   }
 
   enterVariableDeclaration(
-      node: babel.VariableDeclaration, _parent: babel.Node) {
+      node: babel.VariableDeclaration, _parent: babel.Node, path: NodePath) {
     const comment = esutil.getAttachedComment(node) || '';
     const docs = jsdoc.parseJsdoc(comment);
     const isMixin = hasMixinFunctionDocTag(docs);
@@ -139,7 +140,7 @@ export class MixinVisitor implements Visitor {
             privacy: getOrInferPrivacy(namespacedName, docs),
             jsdoc: docs,
             mixins: jsdoc.getMixinApplications(
-                this._document, declaration, docs, this.warnings)
+                this._document, declaration, docs, this.warnings, path.scope)
           });
         }
       }

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -20,7 +20,7 @@ import * as clone from 'clone';
 import * as path from 'path';
 import * as shady from 'shady-css-parser';
 
-import {Analyzer} from '../../core/analyzer';
+import {Analyzer, Options} from '../../core/analyzer';
 import {Deferred} from '../../core/utils';
 import {ParsedCssDocument} from '../../css/css-document';
 import {ParsedHtmlDocument} from '../../html/html-document';
@@ -560,19 +560,20 @@ suite('Analyzer', () => {
       });
 
       test('gracefully handles a scanner that throws', async () => {
-        const scanners = AnalysisContext.getDefaultScanners(new Map());
+        const options: Options = {
+          urlResolver: analyzer.urlResolver,
+          urlLoader: inMemoryOverlay
+        };
+        const scanners = AnalysisContext.getDefaultScanners(options);
         class FailingScanner implements HtmlScanner {
           async scan():
               Promise<{features: ScannedFeature[], warnings?: Warning[]}> {
             throw new Error('Method not implemented.');
           }
         }
+        options.scanners = scanners;
         scanners.get('html')!.push(new FailingScanner());
-        const localAnalyzer = new Analyzer({
-          scanners,
-          urlResolver: analyzer.urlResolver,
-          urlLoader: inMemoryOverlay
-        });
+        const localAnalyzer = new Analyzer(options);
         const url = localAnalyzer.resolveUrl(`foo.html`)!;
         inMemoryOverlay.urlContentsMap.set(url, `
           <dom-module id="foo-bar"></dom-module>

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -16,7 +16,7 @@
 import {assert} from 'chai';
 
 import {Analyzer} from '../../core/analyzer';
-import {ScannedBehavior, ScannedBehaviorAssignment} from '../../polymer/behavior';
+import {ScannedBehavior} from '../../polymer/behavior';
 import {BehaviorScanner} from '../../polymer/behavior-scanner';
 import {fixtureDir, runScanner} from '../test-utils';
 
@@ -88,11 +88,10 @@ suite('BehaviorScanner', () => {
     const deepChainedBehaviors =
         behaviors.get('Really.Really.Deep.Behavior')!.behaviorAssignments;
     assert.deepEqual(
-        childBehaviors.map((b: ScannedBehaviorAssignment) => b.name),
+        childBehaviors.map((b) => b.identifier),
         ['SimpleBehavior', 'AwesomeBehavior', 'Really.Really.Deep.Behavior']);
     assert.deepEqual(
-        deepChainedBehaviors.map((b: ScannedBehaviorAssignment) => b.name),
-        ['Do.Re.Mi.Fa']);
+        deepChainedBehaviors.map((b) => b.identifier), ['Do.Re.Mi.Fa']);
   });
 
   test('Does not count methods as properties', function() {


### PR DESCRIPTION
* Remove BehaviorAssignment, use ScannedReference instead.
* Include a babel traversal Scope when constructing a ScannedReference
* Basic scanning of exports (not hooked up)
* Also scan re-exports as imports

 - [X] CHANGELOG.md has been updated
