### PR TITLE
Fixed resolution of protocol-relative URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+ * Fixed issue where `UrlResolver#simpleUrlResolve` treated protocol-relative URL like `//something` as a path.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.13] - 2018-03-05

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -12,17 +12,33 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {parse as parseUrl_, Url} from 'url';
+import {parse as parseUrl_, resolve as resolveUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
+
 export function parseUrl(url: string): Url {
   if (!url.startsWith('//')) {
     return parseUrl_(url);
   }
-  const urlObject = parseUrl_(`${unspecifiedProtocol}${url}`);
+  const urlObject = parseUrl_(addUnspecifiedProtocol(url));
   urlObject.protocol = undefined;
   urlObject.href = urlObject.href!.replace(/^-:/, '');
   return urlObject;
+}
+
+export function resolveUrl(baseUrl: string, target: string): string {
+  return removeUnspecifiedProtocol(resolveUrl_(
+      addUnspecifiedProtocol(baseUrl), addUnspecifiedProtocol(target)));
+}
+
+function addUnspecifiedProtocol(url: string): string {
+  return url.startsWith('//') ? unspecifiedProtocol + url : url;
+}
+
+function removeUnspecifiedProtocol(url: string): string {
+  return url.startsWith(unspecifiedProtocol) ?
+      url.slice(unspecifiedProtocol.length) :
+      url;
 }
 
 export function trimLeft(str: string, char: string): string {

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -72,7 +72,7 @@ suite('PackageUrlResolver', function() {
           resolvedUrl`http://abc.xyz/foo.html`);
       assert.equal(
           r.resolve(packageRelativeUrl`//abc.xyz/foo.html`),
-          resolvedUrl`file://abc.xyz/foo.html`);
+          resolvedUrl`//abc.xyz/foo.html`);
     });
 
     test(`resolves a URL with the right hostname`, () => {

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -13,9 +13,8 @@
  */
 
 import * as path from 'path';
-import {format as urlLibFormat, resolve as urlLibResolver} from 'url';
-
-import {parseUrl} from '../core/utils';
+import {format as urlLibFormat} from 'url';
+import {parseUrl, resolveUrl} from '../core/utils';
 import {PackageRelativeUrl, ScannedImport} from '../index';
 import {FileRelativeUrl, ResolvedUrl} from '../model/url';
 
@@ -53,7 +52,7 @@ export abstract class UrlResolver {
   protected simpleUrlResolve(
       baseUrl: ResolvedUrl,
       url: FileRelativeUrl|PackageRelativeUrl): ResolvedUrl {
-    return this.brandAsResolved(urlLibResolver(baseUrl, url));
+    return this.brandAsResolved(resolveUrl(baseUrl, url));
   }
 
   protected simpleUrlRelative(from: ResolvedUrl, to: ResolvedUrl):


### PR DESCRIPTION
 - Fixes https://github.com/Polymer/polymer-analyzer/issues/893 where `UrlResolver#simpleUrlResolve` treated protocol-relative URL like `//something` as a path.
 - [x] CHANGELOG.md has been updated
