### PR TITLE
Parse JS to a `File` rather than a `Program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* [breaking] JavascriptDocument#ast is now a `babel.File` rather than a
+  `babel.Program`. Use `jsDoc.ast.program` instead of `jsDoc.ast` in the
+  unlikely case that the `Program` is required.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.13] - 2018-03-05

--- a/src/javascript/javascript-document.ts
+++ b/src/javascript/javascript-document.ts
@@ -13,7 +13,8 @@
  */
 
 import generate from 'babel-generator';
-import {Node, Program} from 'babel-types';
+import * as babel from 'babel-types';
+import {Node} from 'babel-types';
 import indent = require('indent');
 
 import {SourceRange} from '../model/model';
@@ -39,14 +40,14 @@ interface SkipRecord {
   depth: number;
 }
 
-export interface Options extends ParsedDocumentOptions<Program> {
+export interface Options extends ParsedDocumentOptions<babel.File> {
   parsedAsSourceType: 'script'|'module';
 }
 
 export class JavaScriptDocument extends ParsedDocument<Node, Visitor> {
   readonly type = 'js';
   private visitorSkips = new Map<Visitor, SkipRecord>();
-  ast!: Program;  // assigned in super, this type is just a refinement.
+  ast!: babel.File;  // assigned in super, this type is just a refinement.
 
   /**
    * How the js document was parsed. If 'module' then the source code is

--- a/src/javascript/javascript-parser.ts
+++ b/src/javascript/javascript-parser.ts
@@ -73,7 +73,7 @@ export class JavaScriptParser implements Parser<JavaScriptDocument> {
       url,
       contents,
       baseUrl: inlineInfo.baseUrl,
-      ast: result.program,
+      ast: result.parsedFile,
       locationOffset: inlineInfo.locationOffset,
       astNode: inlineInfo.astNode,
       isInline,
@@ -93,7 +93,7 @@ export class JavaScriptScriptParser extends JavaScriptParser {
 export type ParseResult = {
   type: 'success',
   sourceType: SourceType,
-  program: babel.Program,
+  parsedFile: babel.File,
 }|{
   type: 'failure',
   warningish: {
@@ -119,7 +119,7 @@ export function parseJs(
     warningCode = 'parse-error';
   }
 
-  let program: babel.Program;
+  let parsedFile: babel.File;
   const parseOptions = {sourceFilename: file, ...baseParseOptions};
 
   try {
@@ -129,20 +129,18 @@ export function parseJs(
     if (!sourceType) {
       try {
         sourceType = 'script';
-        program =
-            babylon.parse(contents, {sourceType, ...parseOptions}).program;
+        parsedFile = babylon.parse(contents, {sourceType, ...parseOptions});
       } catch (_ignored) {
         sourceType = 'module';
-        program =
-            babylon.parse(contents, {sourceType, ...parseOptions}).program;
+        parsedFile = babylon.parse(contents, {sourceType, ...parseOptions});
       }
     } else {
-      program = babylon.parse(contents, {sourceType, ...parseOptions}).program;
+      parsedFile = babylon.parse(contents, {sourceType, ...parseOptions});
     }
     return {
       type: 'success',
       sourceType: sourceType,
-      program: program,
+      parsedFile,
     };
   } catch (err) {
     if (err instanceof SyntaxError) {

--- a/src/polymer/expression-scanner.ts
+++ b/src/polymer/expression-scanner.ts
@@ -361,7 +361,7 @@ function extractDataBindingsFromTextNode(
           node,
           sourceRange,
           dataBinding.expressionText,
-          parseResult.program,
+          parseResult.parsedFile.program,
           document);
       for (const warning of expression.warnings) {
         warnings.push(warning);
@@ -420,7 +420,7 @@ function extractDataBindingsFromAttr(
           attr,
           sourceRange,
           expressionText,
-          parseResult.program,
+          parseResult.parsedFile.program,
           document);
       for (const warning of expression.warnings) {
         warnings.push(warning);
@@ -461,10 +461,10 @@ function findDatabindingInString(str: string) {
 
 function transformPath(expression: string) {
   return expression
-    // replace .0, .123, .kebab-case with ['0'], ['123'], ['kebab-case']
-    .replace(/\.([a-zA-Z_$]([\w:$*]*-+[\w:$*]*)+|[1-9][0-9]*|0)/g, "['$1']")
-    // remove .* and .splices from the end of the paths
-    .replace(/\.(\*|splices)$/, '');
+      // replace .0, .123, .kebab-case with ['0'], ['123'], ['kebab-case']
+      .replace(/\.([a-zA-Z_$]([\w:$*]*-+[\w:$*]*)+|[1-9][0-9]*|0)/g, '[\'$1\']')
+      // remove .* and .splices from the end of the paths
+      .replace(/\.(\*|splices)$/, '');
 }
 
 /**
@@ -488,12 +488,12 @@ function transformPolymerExprToJS(expression: string) {
 
 function transformArg(rawArg: string) {
   const arg = rawArg
-    // replace comma entity with comma
-    .replace(/&comma;/g, ',')
-    // repair extra escape sequences; note only commas strictly need
-    // escaping, but we allow any other char to be escaped since its
-    // likely users will do this
-    .replace(/\\(.)/g, '\$1');
+                  // replace comma entity with comma
+                  .replace(/&comma;/g, ',')
+                  // repair extra escape sequences; note only commas strictly
+                  // need escaping, but we allow any other char to be escaped
+                  // since its likely users will do this
+                  .replace(/\\(.)/g, '\$1');
   // detect literal value (must be String or Number)
   const i = arg.search(/[^\s]/);
   let fc = arg[i];
@@ -504,7 +504,7 @@ function transformArg(rawArg: string) {
     fc = '#';
   }
   switch (fc) {
-    case "'":
+    case '\'':
     case '"':
       return arg;
     case '#':
@@ -593,7 +593,7 @@ export function parseExpressionInJsStringLiteral(
         stringLiteral,
         sourceRange,
         expressionText,
-        parsed.program,
+        parsed.parsedFile.program,
         kind,
         document);
     for (const warning of result.databinding.warnings) {

--- a/src/test/javascript/javascript-parser_test.ts
+++ b/src/test/javascript/javascript-parser_test.ts
@@ -52,10 +52,10 @@ suite('JavaScriptParser', () => {
           new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
-      assert.equal(document.ast.type, 'Program');
+      assert.equal(document.ast.type, 'File');
       assert.equal(document.parsedAsSourceType, 'script');
       // First statement is a class declaration
-      assert.equal(document.ast.body[0].type, 'ClassDeclaration');
+      assert.equal(document.ast.program.body[0].type, 'ClassDeclaration');
     });
 
     test('parses async await', () => {
@@ -70,10 +70,10 @@ suite('JavaScriptParser', () => {
           new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
-      assert.equal(document.ast.type, 'Program');
+      assert.equal(document.ast.type, 'File');
       assert.equal(document.parsedAsSourceType, 'script');
       // First statement is an async function declaration
-      const functionDecl = document.ast.body[0];
+      const functionDecl = document.ast.program.body[0];
       if (!babel.isFunctionDeclaration(functionDecl)) {
         throw new Error('Expected a function declaration.');
       }
@@ -96,7 +96,7 @@ suite('JavaScriptParser', () => {
       const document = parser.parse(
           file, resolvedUrl`/static/js-elements.js`, new PackageUrlResolver());
       const ast = document.ast;
-      const element1 = ast.body[0];
+      const element1 = ast.program.body[0];
       const comment = esutil.getAttachedComment(element1)!;
       assert.isTrue(comment.indexOf('test-element') !== -1);
     });
@@ -111,7 +111,7 @@ suite('JavaScriptParser', () => {
           new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
-      assert.equal(document.ast.type, 'Program');
+      assert.equal(document.ast.type, 'File');
       assert.equal(document.parsedAsSourceType, 'module');
     });
   });
@@ -155,7 +155,7 @@ suite('JavaScriptModuleParser', () => {
           new PackageUrlResolver());
       assert.instanceOf(document, JavaScriptDocument);
       assert.equal(document.url, '/static/es6-support.js');
-      assert.equal(document.ast.type, 'Program');
+      assert.equal(document.ast.type, 'File');
       assert.equal(document.parsedAsSourceType, 'module');
     });
   });

--- a/src/test/polymer/expression-scanner_test.ts
+++ b/src/test/polymer/expression-scanner_test.ts
@@ -61,9 +61,15 @@ suite('ExpressionScanner', () => {
       const generalExpressions = results.expressions;
 
       assert.deepEqual(results.warnings, []);
-      assert.deepEqual(
-          generalExpressions.map((e) => e.databindingInto),
-          ['attribute', 'attribute', 'attribute', 'attribute', 'attribute', 'attribute', 'attribute']);
+      assert.deepEqual(generalExpressions.map((e) => e.databindingInto), [
+        'attribute',
+        'attribute',
+        'attribute',
+        'attribute',
+        'attribute',
+        'attribute',
+        'attribute'
+      ]);
       const expressions =
           generalExpressions as AttributeDatabindingExpression[];
       assert.deepEqual(
@@ -83,7 +89,7 @@ suite('ExpressionScanner', () => {
             `
           <div id="{{baz}}"></div>
                      ~~~`,
-          `
+            `
           <div id="{{camel.casePath}}"></div>
                      ~~~~~~~~~~~~~~`,
             `
@@ -91,19 +97,39 @@ suite('ExpressionScanner', () => {
                      ~~~~~~~~~~~~~~~`,
           ]);
       assert.deepEqual(
-          expressions.map((e) => e.direction), ['{', '{', '{', '[', '{', '{', '{']);
-      assert.deepEqual(
-          expressions.map((e) => e.expressionText),
-          ['foo', 'val', 'bada(wing, daba.boom, 10, -20)', 'bar', 'baz', 'camel.casePath', 'kebab.case-path']);
-      assert.deepEqual(
-          expressions.map((e) => e.eventName),
-          [undefined, 'changed', undefined, undefined, undefined, undefined, undefined]);
+          expressions.map((e) => e.direction),
+          ['{', '{', '{', '[', '{', '{', '{']);
+      assert.deepEqual(expressions.map((e) => e.expressionText), [
+        'foo',
+        'val',
+        'bada(wing, daba.boom, 10, -20)',
+        'bar',
+        'baz',
+        'camel.casePath',
+        'kebab.case-path'
+      ]);
+      assert.deepEqual(expressions.map((e) => e.eventName), [
+        undefined,
+        'changed',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      ]);
       assert.deepEqual(
           expressions.map((e) => e.attribute && e.attribute.name),
           ['id', 'value', 'id', 'id', 'id', 'id', 'id']);
       assert.deepEqual(
-          expressions.map((e) => e.properties.map((p) => p.name)),
-          [['foo'], ['val'], ['bada', 'wing', 'daba'], ['bar'], ['baz'], ['camel'], ['kebab']]);
+          expressions.map((e) => e.properties.map((p) => p.name)), [
+            ['foo'],
+            ['val'],
+            ['bada', 'wing', 'daba'],
+            ['bar'],
+            ['baz'],
+            ['camel'],
+            ['kebab']
+          ]);
       assert.deepEqual(
           expressions.map((e) => e.warnings), [[], [], [], [], [], [], []]);
       assert.deepEqual(
@@ -321,7 +347,7 @@ suite('ExpressionScanner', () => {
       const javascriptDocument = new JavaScriptParser().parse(
           contents, resolvedUrl`test.html`, new PackageUrlResolver());
       const literals: babel.Literal[] =
-          (javascriptDocument.ast as any)
+          (javascriptDocument.ast.program as any)
               .body[0]['declarations'][0]['init']['elements'];
 
       const parsedLiterals = literals.map(


### PR DESCRIPTION
We need the `File` for babel traverse to do scope analysis.

 - [x] CHANGELOG.md has been updated

This is a breaking change, but there's ~0% chance that anyone is actually broken by this.