### PR TITLE
Recognize exported behaviors, classes, and mixins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Now recognizes classes, behaviors, elements, and mixins that are
+  declared in an ES6 `export` declaration.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.14] - 2018-03-09

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -58,12 +58,15 @@ class BehaviorVisitor implements Visitor {
   /**
    * Look for object declarations with @polymerBehavior in the docs.
    */
-  enterVariableDeclaration(
-      node: babel.VariableDeclaration, _parent: babel.Node, path: NodePath) {
-    if (node.declarations.length !== 1) {
-      return;  // Ambiguous.
-    }
-    this._initBehavior(node, getIdentifierName(node.declarations[0].id), path);
+  enterVariableDeclarator(
+      node: babel.VariableDeclarator, _parent: babel.Node, path: NodePath) {
+    this._initBehavior(node, getIdentifierName(node.id), path);
+  }
+
+  enterExportDefaultDeclaration(
+      node: babel.ExportDefaultDeclaration, _parent: babel.Node,
+      path: NodePath) {
+    this._initBehavior(node, 'default', path);
   }
 
   /**
@@ -140,10 +143,10 @@ class BehaviorVisitor implements Visitor {
 
   private _initBehavior(
       node: babel.Node, name: string|undefined, path: NodePath) {
-    const comment = esutil.getAttachedComment(node);
     if (name === undefined) {
       return;
     }
+    const comment = esutil.getBestComment(path);
     // Quickly filter down to potential candidates.
     if (!comment || comment.indexOf('@polymerBehavior') === -1) {
       if (name !== templatizer) {

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {NodePath} from 'babel-traverse';
+import {NodePath, Scope} from 'babel-traverse';
 import * as babel from 'babel-types';
 
 import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
@@ -77,85 +77,77 @@ export class MixinVisitor implements Visitor {
 
   enterFunctionDeclaration(
       node: babel.FunctionDeclaration, _parent: babel.Node, path: NodePath) {
-    const nodeComments = esutil.getAttachedComment(node) || '';
-    const nodeJsDocs = jsdoc.parseJsdoc(nodeComments);
-    if (hasMixinFunctionDocTag(nodeJsDocs)) {
-      const name = node.id.name;
-      const namespacedName =
-          name ? getNamespacedIdentifier(name, nodeJsDocs) : undefined;
-      const sourceRange = this._document.sourceRangeForNode(node)!;
-      this._currentMixinFunction = node;
-
-      const summaryTag = jsdoc.getTag(nodeJsDocs, 'summary');
-
-      if (namespacedName) {
-        this._currentMixin = new ScannedPolymerElementMixin({
-          name: namespacedName,
-          sourceRange,
-          astNode: node,
-          description: nodeJsDocs.description,
-          summary: (summaryTag && summaryTag.description) || '',
-          privacy: getOrInferPrivacy(namespacedName, nodeJsDocs),
-          jsdoc: nodeJsDocs,
-          mixins: jsdoc.getMixinApplications(
-              this._document, node, nodeJsDocs, this.warnings, path.scope)
-        });
-        this._currentMixinNode = node;
-        this.mixins.push(this._currentMixin);
-      } else {
-        // Warn about a mixin whose name we can't infer.
-      }
+    const nodeComments = esutil.getBestComment(path);
+    if (nodeComments === undefined) {
+      return;
     }
+    const nodeJsDocs = jsdoc.parseJsdoc(nodeComments);
+    if (!hasMixinFunctionDocTag(nodeJsDocs)) {
+      return;
+    }
+    const name = node.id.name;
+    const namespacedName =
+        name ? getNamespacedIdentifier(name, nodeJsDocs) : undefined;
+    if (namespacedName === undefined) {
+      // Warn about a mixin whose name we can't infer.
+      return;
+    }
+    this.initializeMixin(node, namespacedName, nodeJsDocs, path.scope);
   }
 
   leaveFunctionDeclaration(
       node: babel.FunctionDeclaration, _parent: babel.Node) {
-    if (this._currentMixinNode === node) {
-      this._currentMixin = null;
-      this._currentMixinNode = null;
-      this._currentMixinFunction = null;
-    }
+    this.clearOnLeave(node);
   }
 
   enterVariableDeclaration(
       node: babel.VariableDeclaration, _parent: babel.Node, path: NodePath) {
-    const comment = esutil.getAttachedComment(node) || '';
-    const docs = jsdoc.parseJsdoc(comment);
-    const isMixin = hasMixinFunctionDocTag(docs);
-    const sourceRange = this._document.sourceRangeForNode(node)!;
-    const summaryTag = jsdoc.getTag(docs, 'summary');
-    if (isMixin) {
-      let mixin: ScannedPolymerElementMixin|undefined = undefined;
-      if (node.declarations.length === 1) {
-        const declaration = node.declarations[0];
-        const name = getIdentifierName(declaration.id);
-        if (name) {
-          const namespacedName = getNamespacedIdentifier(name, docs);
-          mixin = new ScannedPolymerElementMixin({
-            name: namespacedName,
-            sourceRange,
-            astNode: node,
-            description: docs.description,
-            summary: (summaryTag && summaryTag.description) || '',
-            privacy: getOrInferPrivacy(namespacedName, docs),
-            jsdoc: docs,
-            mixins: jsdoc.getMixinApplications(
-                this._document, declaration, docs, this.warnings, path.scope)
-          });
-        }
-      }
-      if (mixin) {
-        this._currentMixin = mixin;
-        this._currentMixinNode = node;
-        this.mixins.push(this._currentMixin);
-      } else {
-        // TODO(rictic); warn about being unable to determine mixin name.
-      }
+    const comment = esutil.getBestComment(path);
+    if (comment === undefined) {
+      return;
     }
+    const docs = jsdoc.parseJsdoc(comment);
+    if (!hasMixinFunctionDocTag(docs)) {
+      return;
+    }
+    if (node.declarations.length !== 1) {
+      return;
+    }
+    const declaration = node.declarations[0];
+    const name = getIdentifierName(declaration.id);
+    if (name === undefined) {
+      // TODO(rictic); warn about being unable to determine mixin name.
+      return;
+    }
+    this.initializeMixin(node, name, docs, path.scope);
   }
 
   leaveVariableDeclaration(
       node: babel.VariableDeclaration, _parent: babel.Node) {
+    this.clearOnLeave(node);
+  }
+
+  private initializeMixin(
+      node: babel.Node, name: string, docs: jsdoc.Annotation, scope: Scope) {
+    const sourceRange = this._document.sourceRangeForNode(node)!;
+    const summaryTag = jsdoc.getTag(docs, 'summary');
+    const namespacedName = getNamespacedIdentifier(name, docs);
+    const mixin = new ScannedPolymerElementMixin({
+      name: namespacedName,
+      sourceRange,
+      astNode: node,
+      description: docs.description,
+      summary: (summaryTag && summaryTag.description) || '',
+      privacy: getOrInferPrivacy(namespacedName, docs),
+      jsdoc: docs,
+      mixins: jsdoc.getMixinApplications(
+          this._document, node, docs, this.warnings, scope)
+    });
+    this._currentMixin = mixin;
+    this._currentMixinNode = node;
+    this.mixins.push(this._currentMixin);
+  }
+  private clearOnLeave(node: babel.Node) {
     if (this._currentMixinNode === node) {
       this._currentMixin = null;
       this._currentMixinNode = null;

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -118,6 +118,8 @@ suite('Class', () => {
         'Namespace.AlsoAssignment',
         'Declared.AnotherAssignment',
         'ClassWithNoJsDoc',
+        'ExportedClass',
+        undefined,
       ]);
 
       assert.deepEqual(await Promise.all(classes.map((c) => getTestProps(c))), [
@@ -151,6 +153,16 @@ suite('Class', () => {
           name: 'ClassWithNoJsDoc',
           privacy: 'public',
         },
+        {
+          description: 'An exported class.',
+          name: 'ExportedClass',
+          privacy: 'public'
+        },
+        {
+          description: 'A default exported class.',
+          name: undefined,
+          privacy: 'public'
+        }
       ]);
     });
 
@@ -418,6 +430,8 @@ suite('Class', () => {
         'Namespace.AlsoAssignment',
         'Declared.AnotherAssignment',
         'ClassWithNoJsDoc',
+        'ExportedClass',
+        undefined
       ]);
 
       assert.deepEqual(await Promise.all(classes.map((c) => getTestProps(c))), [
@@ -451,6 +465,16 @@ suite('Class', () => {
           name: 'ClassWithNoJsDoc',
           privacy: 'public',
         },
+        {
+          description: 'An exported class.',
+          name: 'ExportedClass',
+          privacy: 'public'
+        },
+        {
+          description: 'A default exported class.',
+          name: undefined,
+          privacy: 'public'
+        }
       ]);
     });
 

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -120,6 +120,7 @@ suite('Class', () => {
         'ClassWithNoJsDoc',
         'ExportedClass',
         undefined,
+        'ExportedConstClass',
       ]);
 
       assert.deepEqual(await Promise.all(classes.map((c) => getTestProps(c))), [
@@ -162,6 +163,11 @@ suite('Class', () => {
           description: 'A default exported class.',
           name: undefined,
           privacy: 'public'
+        },
+        {
+          description: '',
+          name: 'ExportedConstClass',
+          privacy: 'public',
         }
       ]);
     });
@@ -431,7 +437,8 @@ suite('Class', () => {
         'Declared.AnotherAssignment',
         'ClassWithNoJsDoc',
         'ExportedClass',
-        undefined
+        undefined,
+        'ExportedConstClass',
       ]);
 
       assert.deepEqual(await Promise.all(classes.map((c) => getTestProps(c))), [
@@ -474,6 +481,11 @@ suite('Class', () => {
           description: 'A default exported class.',
           name: undefined,
           privacy: 'public'
+        },
+        {
+          description: '',
+          name: 'ExportedConstClass',
+          privacy: 'public',
         }
       ]);
     });

--- a/src/test/polymer/behavior-scanner_test.ts
+++ b/src/test/polymer/behavior-scanner_test.ts
@@ -47,7 +47,9 @@ suite('BehaviorScanner', () => {
       'AwesomeBehavior',
       'Polymer.AwesomeNamespacedBehavior',
       'Really.Really.Deep.Behavior',
-      'CustomBehaviorList'
+      'CustomBehaviorList',
+      'exportedBehavior',
+      'default',
     ].sort());
   });
 

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -463,4 +463,60 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
       }
     ]);
   });
+
+  test('finds exported mixin functions', async () => {
+    const mixins = await getScannedMixins('test-mixin-12.js');
+    const mixinData = await Promise.all(mixins.map(getTestProps));
+    assert.deepEqual(mixinData, [{
+                       name: 'TestMixin',
+                       description: 'A mixin description',
+                       summary: '',
+                       properties: [{
+                         name: 'foo',
+                       }],
+                       attributes: [{
+                         name: 'foo',
+                       }],
+                       methods: [],
+                       underlinedWarnings: []
+                     }, {
+                      name: 'DefaultTestMixin',
+                      description: 'Another mixin description',
+                      summary: '',
+                      properties: [{
+                        name: 'bar',
+                      }],
+                      attributes: [{
+                        name: 'bar',
+                      }],
+                      methods: [],
+                      underlinedWarnings: []
+                    });
+    const underlinedSource = await underliner.underline(mixins[0].sourceRange);
+    assert.deepEqual(underlinedSource, `
+export function TestMixin(superclass) {
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  return class extends superclass {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    static get properties() {
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      return {
+~~~~~~~~~~~~~~
+        foo: {
+~~~~~~~~~~~~~~
+          notify: true,
+~~~~~~~~~~~~~~~~~~~~~~~
+          type: String,
+~~~~~~~~~~~~~~~~~~~~~~~
+        },
+~~~~~~~~~~
+      };
+~~~~~~~~
+    }
+~~~~~
+  }
+~~~
+}
+~`);
+  });
 });

--- a/src/test/static/class/class-names.js
+++ b/src/test/static/class/class-names.js
@@ -19,3 +19,9 @@ AnotherAssignment = class IgnoreIgnoreIgnore { }
 let NotAClass; // this comment should not be attached to a class
 
 class ClassWithNoJsDoc { }
+
+/** An exported class. */
+export class ExportedClass { }
+
+/** A default exported class. */
+export default class { };

--- a/src/test/static/class/class-names.js
+++ b/src/test/static/class/class-names.js
@@ -25,3 +25,5 @@ export class ExportedClass { }
 
 /** A default exported class. */
 export default class { };
+
+export const ExportedConstClass = class { };

--- a/src/test/static/js-behaviors.js
+++ b/src/test/static/js-behaviors.js
@@ -43,3 +43,10 @@ Really.Really.Deep.Behavior = [
 */
 CustomBehaviorList =
     [SimpleBehavior, AwesomeBehavior, Really.Really.Deep.Behavior];
+
+
+/** @polymerBehavior */
+export const exportedBehavior = {exported: true};
+
+/** @polymerBehavior */
+export default { defaultExported: true };

--- a/src/test/static/polymer2/test-mixin-12.js
+++ b/src/test/static/polymer2/test-mixin-12.js
@@ -1,0 +1,34 @@
+/**
+ * A mixin description
+ * @polymer
+ * @mixinFunction
+ */
+export function TestMixin(superclass) {
+  return class extends superclass {
+    static get properties() {
+      return {
+        foo: {
+          notify: true,
+          type: String,
+        },
+      };
+    }
+  }
+}
+
+/**
+ * Another mixin description
+ * @polymer
+ * @mixinFunction
+ */
+export default function DefaultTestMixin(superclass) {
+  return class extends superclass {
+    static get properties() {
+      return {
+        bar: {
+          type: Boolean,
+        },
+      };
+    }
+  }
+}


### PR DESCRIPTION
The first step of resolving imports is to not get tripped up by export syntax :)

Adds a test of class recognition, and fixes up the behavior and mixin scanners to understand named and default export syntax.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
