### PR TITLE
Fixed resolution of protocol-relative URLs with protocol option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,25 +16,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   before it may have been resolved to a file-relative url by the node module
   resolution algorithm.
 * Parse concatenated strings in expressions
+* Fixed issue where FsUrlResolver and IndirectUrlResolver didn't correctly
+  resolve protocol-relative URLs.  These classes now accept a protocol option
+  which defaults to `https:` that is prepended when resolving these URLs.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.14] - 2018-03-09
-* [breaking] JavascriptDocument#ast is now a `babel.File` rather than a
+* [BREAKING] JavascriptDocument#ast is now a `babel.File` rather than a
   `babel.Program`. Use `jsDoc.ast.program` instead of `jsDoc.ast` in the
   unlikely case that the `Program` is required.
 * Fix bug where if a package's name was a prefix of one of its dependencies,
   that dependency would not resolve to its components directory.
 
 ## [3.0.0-pre.13] - 2018-03-05
- * Support specifying tag names in jsdoc, e.g. `@customElement fancy-button`
- * Add "bare" module specifier support for JavaScript imports and exports. ie,
-   `import * as jquery from 'jquery'`.
+* Support specifying tag names in jsdoc, e.g. `@customElement fancy-button`
+* Add "bare" module specifier support for JavaScript imports and exports. ie,
+  `import * as jquery from 'jquery'`.
 
 ## [3.0.0-pre.12] - 2018-02-14
- * Functions and methods will now be automatically inferred as returning `void`
-   in certain cases. This occurs when all of the following are true: 1) it has
-   no `@return` or `@returns` JSDoc annotation, 2) it is not async or a
-   generator, 3) its body contains no return statements with arguments.
+* Functions and methods will now be automatically inferred as returning `void`
+  in certain cases. This occurs when all of the following are true: 1) it has
+  no `@return` or `@returns` JSDoc annotation, 2) it is not async or a
+  generator, 3) its body contains no return statements with arguments.
 
 ## [3.0.0-pre.11] - 2018-02-14
 * Support Windows line endings in JSDoc annotations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Parse concatenated strings in expressions
 * Fixed issue where FsUrlResolver and IndirectUrlResolver didn't correctly
   resolve protocol-relative URLs.  These classes now accept a protocol option
-  which defaults to `https:` that is prepended when resolving these URLs.
+  which defaults to `https` that is prepended when resolving these URLs.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.14] - 2018-03-09

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,16 +102,16 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.101",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-      "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw=="
+      "version": "6.0.102",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.102.tgz",
+      "integrity": "sha512-EhNufyBoC1Kqaj+XMHGzi6mPUC8wVABOMTPE5XaSJc49LIVvXsyrV1HYMAPTUViT7E4wLUB38OdDmb+HshjGmA=="
     },
     "@types/parse5": {
       "version": "2.2.34",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
-        "@types/node": "6.0.101"
+        "@types/node": "6.0.102"
       }
     },
     "@types/resolve": {
@@ -119,7 +119,7 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
       "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
       "requires": {
-        "@types/node": "6.0.101"
+        "@types/node": "6.0.102"
       }
     },
     "@types/winston": {
@@ -127,7 +127,7 @@
       "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
       "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
       "requires": {
-        "@types/node": "6.0.101"
+        "@types/node": "6.0.102"
       }
     },
     "acorn": {
@@ -453,7 +453,7 @@
         "babylon": "7.0.0-beta.27",
         "debug": "3.1.0",
         "globals": "10.4.0",
-        "invariant": "2.2.3",
+        "invariant": "2.2.4",
         "lodash": "4.17.5"
       },
       "dependencies": {
@@ -482,9 +482,9 @@
       }
     },
     "babylon": {
-      "version": "7.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
-      "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg=="
+      "version": "7.0.0-beta.41",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.41.tgz",
+      "integrity": "sha512-AfQfqR9hbNSpY/9yyGaUAiT1tmyHzaJbHJpqkfn8DGAUkPTG5VwPoulajQu3FUQXTr8NGm4MFaupVzmWkvln4Q=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -580,7 +580,7 @@
         "isobject": "3.0.1",
         "kind-of": "6.0.2",
         "repeat-element": "1.1.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "snapdragon-node": "2.1.1",
         "split-string": "3.1.0",
         "to-regex": "3.0.2"
@@ -1173,7 +1173,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.40"
       }
     },
     "dargs": {
@@ -1350,7 +1350,7 @@
             "babylon": "6.18.0",
             "debug": "2.6.9",
             "globals": "9.18.0",
-            "invariant": "2.2.3",
+            "invariant": "2.2.4",
             "lodash": "4.17.5"
           }
         },
@@ -1558,9 +1558,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.39",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
-      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "version": "0.10.40",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.40.tgz",
+      "integrity": "sha512-S9Fh3oya5OOvYSNGvPZJ+vyrs6VYpe1IXPowVe3N1OhaiwVaGlwfn3Zf5P5klYcWOA0toIwYQW8XEv/QqhdHvQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -1574,7 +1574,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.40",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1585,7 +1585,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.40",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1599,7 +1599,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.40",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1612,7 +1612,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.40"
       }
     },
     "es6-weak-map": {
@@ -1622,7 +1622,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.40",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -1770,7 +1770,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.40"
       }
     },
     "execa": {
@@ -1805,7 +1805,7 @@
         "extend-shallow": "2.0.1",
         "posix-character-classes": "0.1.1",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -2000,7 +2000,7 @@
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -3248,9 +3248,9 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -3680,15 +3680,6 @@
       "dev": true,
       "requires": {
         "package-json": "4.0.1"
-      }
-    },
-    "lazy-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-      "dev": true,
-      "requires": {
-        "set-getter": "0.1.0"
       }
     },
     "lazy-debug-legacy": {
@@ -4135,7 +4126,7 @@
         "nanomatch": "1.2.9",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       }
     },
@@ -4301,7 +4292,7 @@
         "kind-of": "6.0.2",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       }
     },
@@ -4838,7 +4829,7 @@
       "requires": {
         "@types/node": "4.2.23",
         "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -4849,11 +4840,11 @@
       }
     },
     "polymer-project-config": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.9.0.tgz",
-      "integrity": "sha512-WPOqlV2W/M4Ni40QIqYSv8PE7H4rjiPm1KEf02QPtjZOGlAC4Rv7e6UJ1Ke1O70WT5bydcsEn3LViFIqYpVOJw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.10.0.tgz",
+      "integrity": "sha512-+vrx5aAZM3rpViqnYhTX1bIpXXTlGpiAGZEsk7WzN6EqSMQPI5eYRw4XD1kmjo1W6GShIhPfvhh+Ik/pywGGkw==",
       "requires": {
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.102",
         "jsonschema": "1.2.2",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
@@ -4934,9 +4925,9 @@
       }
     },
     "rc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -5036,7 +5027,7 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -5046,7 +5037,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.5"
+        "rc": "1.2.6"
       }
     },
     "remove-trailing-separator": {
@@ -5237,15 +5228,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
-    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -5326,9 +5308,9 @@
       "dev": true
     },
     "snapdragon": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
         "base": "0.11.2",
@@ -5338,7 +5320,7 @@
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
         "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "use": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5966,14 +5948,14 @@
       "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.4",
+        "@types/node": "8.9.5",
         "semver": "5.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.4.tgz",
-          "integrity": "sha512-dSvD36qnQs78G1BPsrZFdPpvLgMW/dnvr5+nTW2csMs5TiP9MOXrjUbnMZOEwnIuBklXtn7b6TPA2Cuq07bDHA==",
+          "version": "8.9.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
+          "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
           "dev": true
         }
       }
@@ -5985,7 +5967,7 @@
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "diff": "3.2.0",
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
@@ -6007,9 +5989,9 @@
           }
         },
         "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
           "dev": true
         },
         "findup-sync": {
@@ -6245,82 +6227,12 @@
       }
     },
     "use": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
+        "kind-of": "6.0.2"
       }
     },
     "user-home": {
@@ -6522,9 +6434,9 @@
       }
     },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -14,27 +14,29 @@
 
 import {parse as parseUrl_, resolve as resolveUrl_, Url} from 'url';
 
-const unspecifiedProtocol = '-:';
+const unspecifiedProtocol = '-';
 export function parseUrl(
     url: string, defaultProtocol: string = unspecifiedProtocol): Url {
   const urlObject = parseUrl_(ensureProtocol(url, defaultProtocol));
-  if (urlObject.protocol === unspecifiedProtocol) {
+  if (urlObject.protocol &&
+      urlObject.protocol.slice(0, -1) === unspecifiedProtocol) {
     urlObject.protocol = undefined;
     urlObject.href =
-        urlObject.href && urlObject.href.slice(unspecifiedProtocol.length);
+        urlObject.href && urlObject.href.slice(unspecifiedProtocol.length + 1);
   }
   return urlObject;
 }
 
 export function ensureProtocol(url: string, defaultProtocol: string): string {
-  return url.startsWith('//') ? defaultProtocol + url : url;
+  return url.startsWith('//') ? `${defaultProtocol}:${url}` : url;
 }
 
 export function resolveUrl(
     baseUrl: string, targetUrl: string, defaultProtocol: string): string {
-  baseUrl = ensureProtocol(baseUrl, defaultProtocol);
-  targetUrl = ensureProtocol(targetUrl, defaultProtocol);
-  return resolveUrl_(baseUrl, targetUrl);
+  const baseProtocol = (parseUrl_(baseUrl).protocol || '').slice(0, -1);
+  const protocol = baseProtocol !== 'file' && baseProtocol || defaultProtocol;
+  return resolveUrl_(
+      ensureProtocol(baseUrl, protocol), ensureProtocol(targetUrl, protocol));
 }
 
 export function trimLeft(str: string, char: string): string {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -12,17 +12,29 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {parse as parseUrl_, Url} from 'url';
+import {parse as parseUrl_, resolve as resolveUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
-export function parseUrl(url: string): Url {
-  if (!url.startsWith('//')) {
-    return parseUrl_(url);
+export function parseUrl(
+    url: string, defaultProtocol: string = unspecifiedProtocol): Url {
+  const urlObject = parseUrl_(ensureProtocol(url, defaultProtocol));
+  if (urlObject.protocol === unspecifiedProtocol) {
+    urlObject.protocol = undefined;
+    urlObject.href =
+        urlObject.href && urlObject.href.slice(unspecifiedProtocol.length);
   }
-  const urlObject = parseUrl_(`${unspecifiedProtocol}${url}`);
-  urlObject.protocol = undefined;
-  urlObject.href = urlObject.href!.replace(/^-:/, '');
   return urlObject;
+}
+
+export function ensureProtocol(url: string, defaultProtocol: string): string {
+  return url.startsWith('//') ? defaultProtocol + url : url;
+}
+
+export function resolveUrl(
+    baseUrl: string, targetUrl: string, defaultProtocol: string): string {
+  baseUrl = ensureProtocol(baseUrl, defaultProtocol);
+  targetUrl = ensureProtocol(targetUrl, defaultProtocol);
+  return resolveUrl_(baseUrl, targetUrl);
 }
 
 export function trimLeft(str: string, char: string): string {

--- a/src/test/url-loader/indirect-url-resolver_test.ts
+++ b/src/test/url-loader/indirect-url-resolver_test.ts
@@ -18,7 +18,7 @@ import {Analyzer} from '../../core/analyzer';
 import {FsUrlResolver} from '../../url-loader/fs-url-resolver';
 import {IndirectUrlResolver} from '../../url-loader/indirect-url-resolver';
 import {InMemoryOverlayUrlLoader} from '../../url-loader/overlay-loader';
-import {fileRelativeUrl, packageRelativeUrl, rootedFileUrl} from '../test-utils';
+import {fileRelativeUrl, packageRelativeUrl, resolvedUrl, rootedFileUrl} from '../test-utils';
 
 suite('IndirectUrlResolver', function() {
   const mapping = new Map<string, string>([
@@ -47,6 +47,18 @@ suite('IndirectUrlResolver', function() {
             rootedFileUrl`root/sub/package/foo/foo.html`,
             fileRelativeUrl`../bar/bar.html`),
         rootedFileUrl`root/different/x/y/bar.html`);
+
+    // Protocol-relative urls are resolved with default https: protocol
+    assert.deepEqual(
+        indirectResolver.resolve(packageRelativeUrl`//foo.com/bar.html`),
+        resolvedUrl`https://foo.com/bar.html`);
+
+    // Protocol-relative urls are resolved with provided protocol
+    assert.deepEqual(
+        (new IndirectUrlResolver(
+             '/root', '/root/sub/package', mapping, 'potato:'))
+            .resolve(packageRelativeUrl`//foo.com/bar.html`),
+        resolvedUrl`potato://foo.com/bar.html`);
   });
 
   test('relative', async () => {

--- a/src/test/url-loader/indirect-url-resolver_test.ts
+++ b/src/test/url-loader/indirect-url-resolver_test.ts
@@ -56,7 +56,7 @@ suite('IndirectUrlResolver', function() {
     // Protocol-relative urls are resolved with provided protocol
     assert.deepEqual(
         (new IndirectUrlResolver(
-             '/root', '/root/sub/package', mapping, 'potato:'))
+             '/root', '/root/sub/package', mapping, 'potato'))
             .resolve(packageRelativeUrl`//foo.com/bar.html`),
         resolvedUrl`potato://foo.com/bar.html`);
   });

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -82,9 +82,37 @@ suite('PackageUrlResolver', function() {
       assert.equal(
           r.resolve(packageRelativeUrl`http://abc.xyz/foo.html`),
           resolvedUrl`http://abc.xyz/foo.html`);
+
+      assert.equal(
+          r.resolve(
+              resolvedUrl`https://baz.com/qux.js`,
+              fileRelativeUrl`https://foo.com/bar.html`),
+          resolvedUrl`https://foo.com/bar.html`);
+    });
+
+    test('resolves protocol-relative URLs using default protocol', () => {
+      const r = new PackageUrlResolver();
       assert.equal(
           r.resolve(packageRelativeUrl`//abc.xyz/foo.html`),
-          resolvedUrl`file://abc.xyz/foo.html`);
+          resolvedUrl`https://abc.xyz/foo.html`);
+
+      assert.equal(
+          r.resolve(
+              resolvedUrl`http://foo.com/bar.html`,
+              fileRelativeUrl`//foo.com/bar.html`),
+          resolvedUrl`https://foo.com/bar.html`);
+    });
+    test('resolves protocol-relative URLs using provided protocol', () => {
+      const r = new PackageUrlResolver({protocol: 'potato:'});
+      assert.equal(
+          r.resolve(packageRelativeUrl`//abc.xyz/foo.html`),
+          resolvedUrl`potato://abc.xyz/foo.html`);
+
+      assert.equal(
+          r.resolve(
+              resolvedUrl`https://foo.com/bar.html`,
+              fileRelativeUrl`//foo.com/bar.html`),
+          resolvedUrl`potato://foo.com/bar.html`);
     });
 
     test(`resolves a URL with the right hostname`, () => {

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -102,17 +102,20 @@ suite('PackageUrlResolver', function() {
               fileRelativeUrl`//foo.com/bar.html`),
           resolvedUrl`https://foo.com/bar.html`);
     });
+
     test('resolves protocol-relative URLs using provided protocol', () => {
-      const r = new PackageUrlResolver({protocol: 'potato:'});
-      assert.equal(
-          r.resolve(packageRelativeUrl`//abc.xyz/foo.html`),
-          resolvedUrl`potato://abc.xyz/foo.html`);
+      const r = new PackageUrlResolver(
+          {protocol: 'potato:', packageDir: `/1/2`, host: 'foo.com'});
 
       assert.equal(
           r.resolve(
               resolvedUrl`https://foo.com/bar.html`,
               fileRelativeUrl`//foo.com/bar.html`),
-          resolvedUrl`potato://foo.com/bar.html`);
+          rootedFileUrl`1/2/bar.html`);
+
+      assert.equal(
+          r.resolve(packageRelativeUrl`//abc.xyz/foo.html`),
+          resolvedUrl`potato://abc.xyz/foo.html`);
     });
 
     test(`resolves a URL with the right hostname`, () => {

--- a/src/test/url-loader/url-resolver_test.ts
+++ b/src/test/url-loader/url-resolver_test.ts
@@ -22,7 +22,7 @@ class SimplestUrlResolver extends UrlResolver {
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl) {
     const [baseUrl = '/test/' as ResolvedUrl, url] =
         this.getBaseAndUnresolved(firstUrl, secondUrl);
-    return this.simpleUrlResolve(baseUrl, url, 'https:');
+    return this.simpleUrlResolve(baseUrl, url, 'https');
   }
 
   relative(to: ResolvedUrl): PackageRelativeUrl;

--- a/src/test/url-loader/url-resolver_test.ts
+++ b/src/test/url-loader/url-resolver_test.ts
@@ -22,7 +22,7 @@ class SimplestUrlResolver extends UrlResolver {
       firstUrl: ResolvedUrl|PackageRelativeUrl, secondUrl?: FileRelativeUrl) {
     const [baseUrl = '/test/' as ResolvedUrl, url] =
         this.getBaseAndUnresolved(firstUrl, secondUrl);
-    return this.simpleUrlResolve(baseUrl, url);
+    return this.simpleUrlResolve(baseUrl, url, 'https:');
   }
 
   relative(to: ResolvedUrl): PackageRelativeUrl;

--- a/src/url-loader/fs-url-resolver.ts
+++ b/src/url-loader/fs-url-resolver.ts
@@ -41,7 +41,7 @@ export class FsUrlResolver extends UrlResolver {
   protected readonly packageUrl: ResolvedUrl;
   constructor(
       packageDir: string|undefined, private readonly host?: string,
-      protected readonly protocol: string = 'https:') {
+      protected readonly protocol: string = 'https') {
     super();
     this.packageDir =
         normalizeFsPath(pathlib.resolve(packageDir || process.cwd()));

--- a/src/url-loader/fs-url-resolver.ts
+++ b/src/url-loader/fs-url-resolver.ts
@@ -39,7 +39,9 @@ export class FsUrlResolver extends UrlResolver {
   protected readonly packageDir: string;
   // file:// URL format of `packageDir`.
   protected readonly packageUrl: ResolvedUrl;
-  constructor(packageDir: string|undefined, private readonly host?: string) {
+  constructor(
+      packageDir: string|undefined, private readonly host?: string,
+      protected readonly protocol: string = 'https:') {
     super();
     this.packageDir =
         normalizeFsPath(pathlib.resolve(packageDir || process.cwd()));
@@ -55,7 +57,8 @@ export class FsUrlResolver extends UrlResolver {
       _import?: ScannedImport): ResolvedUrl|undefined {
     const [baseUrl = this.packageUrl, unresolvedHref] =
         this.getBaseAndUnresolved(firstHref, secondHref);
-    const resolvedHref = this.simpleUrlResolve(baseUrl, unresolvedHref);
+    const resolvedHref =
+        this.simpleUrlResolve(baseUrl, unresolvedHref, this.protocol);
     if (resolvedHref === undefined) {
       return undefined;
     }

--- a/src/url-loader/fs-url-resolver.ts
+++ b/src/url-loader/fs-url-resolver.ts
@@ -40,7 +40,14 @@ export class FsUrlResolver extends UrlResolver {
   // file:// URL format of `packageDir`.
   protected readonly packageUrl: ResolvedUrl;
   constructor(
-      packageDir: string|undefined, private readonly host?: string,
+      packageDir: string|undefined,
+      // If provided, any URL which matches `host` will attempt to resolve
+      // to a `file` protocol URL regardless of the protocol represented in the
+      // URL to-be-resolved.
+      private readonly host?: string,
+      // When attempting to resolve a protocol-relative URL (that is a URL which
+      // begins `//`), the default protocol to resolve to if the resolver can
+      // not produce a `file` URL.
       protected readonly protocol: string = 'https') {
     super();
     this.packageDir =

--- a/src/url-loader/indirect-url-resolver.ts
+++ b/src/url-loader/indirect-url-resolver.ts
@@ -54,7 +54,8 @@ export class IndirectUrlResolver extends FsUrlResolver implements UrlResolver {
    */
   constructor(
       rootPath: string, packagePath: string,
-      indirectionMap: Map<string, string>) {
+      indirectionMap: Map<string, string>,
+      protected readonly protocol: string = 'https:') {
     super(packagePath);
 
     const rootResolver = new FsUrlResolver(rootPath);
@@ -98,8 +99,8 @@ export class IndirectUrlResolver extends FsUrlResolver implements UrlResolver {
   private runtimeResolve(
       url: FileRelativeUrl|PackageRelativeUrl,
       runtimeBaseUrl: RuntimeUrl): RuntimeUrl {
-    const resolved: ResolvedUrl =
-        this.simpleUrlResolve(this.brandAsResolved(runtimeBaseUrl), url);
+    const resolved: ResolvedUrl = this.simpleUrlResolve(
+        this.brandAsResolved(runtimeBaseUrl), url, this.protocol);
     return resolved as any as RuntimeUrl;
   }
 

--- a/src/url-loader/indirect-url-resolver.ts
+++ b/src/url-loader/indirect-url-resolver.ts
@@ -55,7 +55,7 @@ export class IndirectUrlResolver extends FsUrlResolver implements UrlResolver {
   constructor(
       rootPath: string, packagePath: string,
       indirectionMap: Map<string, string>,
-      protected readonly protocol: string = 'https:') {
+      protected readonly protocol: string = 'https') {
     super(packagePath);
 
     const rootResolver = new FsUrlResolver(rootPath);

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -27,6 +27,7 @@ export interface PackageUrlResolverOptions {
   packageDir?: string;
   componentDir?: string;
   host?: string;
+  protocol?: string;
 }
 
 /**
@@ -37,7 +38,7 @@ export class PackageUrlResolver extends FsUrlResolver {
   private readonly resolvedComponentDir: string;
 
   constructor(options: PackageUrlResolverOptions = {}) {
-    super(options.packageDir, options.host);
+    super(options.packageDir, options.host, options.protocol);
     this.componentDir = options.componentDir || 'bower_components/';
     this.resolvedComponentDir =
         pathlib.join(this.packageDir, this.componentDir);
@@ -85,7 +86,9 @@ export class PackageUrlResolver extends FsUrlResolver {
         const componentDirPath =
             pathnameInComponentDir.slice(this.resolvedComponentDir.length);
         const reresolved = this.simpleUrlResolve(
-            this.packageUrl, ('../' + componentDirPath) as FileRelativeUrl);
+            this.packageUrl,
+            ('../' + componentDirPath) as FileRelativeUrl,
+            this.protocol);
         if (reresolved !== undefined) {
           const reresolvedUrl = parseUrl(reresolved);
           const toUrl = parseUrl(to);

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -26,7 +26,13 @@ import {FsUrlResolver} from './fs-url-resolver';
 export interface PackageUrlResolverOptions {
   packageDir?: string;
   componentDir?: string;
+  // If provided, any URL which matches `host` will attempt to resolve
+  // to a `file` protocol URL regardless of the protocol represented in the
+  // URL to-be-resolved.
   host?: string;
+  // When attempting to resolve a protocol-relative URL (that is a URL which
+  // begins `//`), the default protocol to resolve to if the resolver can
+  // not produce a `file` URL.
   protocol?: string;
 }
 

--- a/src/url-loader/url-resolver.ts
+++ b/src/url-loader/url-resolver.ts
@@ -13,9 +13,9 @@
  */
 
 import * as path from 'path';
-import {format as urlLibFormat, resolve as urlLibResolver} from 'url';
+import {format as urlLibFormat} from 'url';
 
-import {parseUrl} from '../core/utils';
+import {parseUrl, resolveUrl} from '../core/utils';
 import {PackageRelativeUrl, ScannedImport} from '../index';
 import {FileRelativeUrl, ResolvedUrl} from '../model/url';
 
@@ -51,9 +51,9 @@ export abstract class UrlResolver {
   }
 
   protected simpleUrlResolve(
-      baseUrl: ResolvedUrl,
-      url: FileRelativeUrl|PackageRelativeUrl): ResolvedUrl {
-    return this.brandAsResolved(urlLibResolver(baseUrl, url));
+      baseUrl: ResolvedUrl, url: FileRelativeUrl|PackageRelativeUrl,
+      defaultProtocol: string): ResolvedUrl {
+    return this.brandAsResolved(resolveUrl(baseUrl, url, defaultProtocol));
   }
 
   protected simpleUrlRelative(from: ResolvedUrl, to: ResolvedUrl):


### PR DESCRIPTION
- [x] CHANGELOG.md has been updated
- Fixed issue #893 where FsUrlResolver and IndirectUrlResolver didn't correctly resolve protocol-relative URLs.  These classes now accept a protocol option which defaults to `https` that is prepended when resolving these URLs.

(opportunistically adjusted/normalized some lines in the changelog which had inconsistent indentation)