### PR TITLE
Fix bug in package URL resolution due to startsWith containment check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [breaking] JavascriptDocument#ast is now a `babel.File` rather than a
   `babel.Program`. Use `jsDoc.ast.program` instead of `jsDoc.ast` in the
   unlikely case that the `Program` is required.
+* Fix bug where if a package's name was a prefix of one of its dependencies,
+  that dependency would not resolve to its components directory.
 
 <!-- Add new, unreleased changes here. -->
 

--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -1,5 +1,6 @@
 /// <reference path="./chai.d.ts" />
 /// <reference path="./indent.d.ts" />
-/// <reference path="knuth-shuffle.d.ts" />
+/// <reference path="./knuth-shuffle.d.ts" />
 /// <reference path="./strip-indent.d.ts" />
 /// <reference path="./whatwg-url.d.ts" />
+/// <reference path="./path-is-inside.d.ts" />

--- a/custom_typings/path-is-inside.d.ts
+++ b/custom_typings/path-is-inside.d.ts
@@ -1,0 +1,4 @@
+declare module 'path-is-inside' {
+  function pathIsInside(thePath: string, potentialParent: string): boolean;
+  export = pathIsInside;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4703,8 +4703,7 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "jsonschema": "^1.1.0",
     "minimatch": "^3.0.4",
     "parse5": "^4.0.0",
+    "path-is-inside": "^1.0.2",
     "polymer-project-config": "^3.6.0",
     "resolve": "^1.5.0",
     "shady-css-parser": "^0.1.0",

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -12,7 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as pathlib from 'path';
 import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
@@ -32,17 +31,6 @@ export function trimLeft(str: string, char: string): string {
     leftEdge++;
   }
   return str.substring(leftEdge);
-}
-
-/**
- * Returns whether the given file path points to a location inside the given
- * directory. Also return true if the paths are the same.
- */
-export function isPathInside(directory: string, file: string): boolean {
-  // If the path from the directory to the file does not require traversing up,
-  // then it must be either a descendent or the same directory. Note this is
-  // case-insensitive on Windows (which is what we want).
-  return !pathlib.relative(directory, file).startsWith('..');
 }
 
 export class Deferred<T> {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as pathlib from 'path';
 import {parse as parseUrl_, Url} from 'url';
 
 const unspecifiedProtocol = '-:';
@@ -35,13 +36,13 @@ export function trimLeft(str: string, char: string): string {
 
 /**
  * Returns whether the given file path points to a location inside the given
- * directory.
+ * directory. Also return true if the paths are the same.
  */
-export function isPathInside(directory: string, filePath: string): boolean {
-  if (process.platform === 'win32') {
-    return filePath.toLowerCase().startsWith(directory.toLowerCase());
-  }
-  return filePath.startsWith(directory);
+export function isPathInside(directory: string, file: string): boolean {
+  // If the path from the directory to the file does not require traversing up,
+  // then it must be either a descendent or the same directory. Note this is
+  // case-insensitive on Windows (which is what we want).
+  return !pathlib.relative(directory, file).startsWith('..');
 }
 
 export class Deferred<T> {

--- a/src/test/core/utils_test.ts
+++ b/src/test/core/utils_test.ts
@@ -17,7 +17,7 @@
 import {assert, use} from 'chai';
 import {Url} from 'url';
 
-import {Deferred, isPathInside, parseUrl} from '../../core/utils';
+import {Deferred, parseUrl} from '../../core/utils';
 
 import chaiAsPromised = require('chai-as-promised');
 import {invertPromise} from '../test-utils';
@@ -65,28 +65,6 @@ suite('parseUrl', () => {
       pathname: '/path',
     });
   });
-});
-
-suite('isPathInside', () => {
-  function checkTrue(directory: string, file: string) {
-    test(`${file} is a path inside ${directory}`, () => {
-      assert.isTrue(isPathInside(directory, file));
-    });
-  }
-
-  function checkFalse(directory: string, file: string) {
-    test(`${file} is not a path inside ${directory}`, () => {
-      assert.isFalse(isPathInside(directory, file));
-    });
-  }
-
-  checkTrue('/', '/foo');
-  checkTrue('/foo', '/foo/bar');
-  checkTrue('/foo/', '/foo/bar/');
-  checkTrue('/foo', '/foo');
-
-  checkFalse('/foo/bar', '/foo');
-  checkFalse('/foo', '/foobar');
 });
 
 suite('Deferred', () => {

--- a/src/test/core/utils_test.ts
+++ b/src/test/core/utils_test.ts
@@ -17,7 +17,7 @@
 import {assert, use} from 'chai';
 import {Url} from 'url';
 
-import {Deferred, parseUrl} from '../../core/utils';
+import {Deferred, isPathInside, parseUrl} from '../../core/utils';
 
 import chaiAsPromised = require('chai-as-promised');
 import {invertPromise} from '../test-utils';
@@ -65,6 +65,28 @@ suite('parseUrl', () => {
       pathname: '/path',
     });
   });
+});
+
+suite('isPathInside', () => {
+  function checkTrue(directory: string, file: string) {
+    test(`${file} is a path inside ${directory}`, () => {
+      assert.isTrue(isPathInside(directory, file));
+    });
+  }
+
+  function checkFalse(directory: string, file: string) {
+    test(`${file} is not a path inside ${directory}`, () => {
+      assert.isFalse(isPathInside(directory, file));
+    });
+  }
+
+  checkTrue('/', '/foo');
+  checkTrue('/foo', '/foo/bar');
+  checkTrue('/foo/', '/foo/bar/');
+  checkTrue('/foo', '/foo');
+
+  checkFalse('/foo/bar', '/foo');
+  checkFalse('/foo', '/foobar');
 });
 
 suite('Deferred', () => {

--- a/src/test/url-loader/fs-url-loader_test.ts
+++ b/src/test/url-loader/fs-url-loader_test.ts
@@ -31,6 +31,7 @@ suite('FSUrlLoader', function() {
       assert.isFalse(new FSUrlLoader('/a/').canLoad(
           Uri.file(path.resolve('/b/foo.html')).toString() as ResolvedUrl));
     });
+
     test('canLoad is false for a file url with a host', () => {
       assert.isFalse(new FSUrlLoader('/foo/').canLoad(
           resolvedUrl`file://foo/foo/foo.html`));

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -59,6 +59,18 @@ suite('PackageUrlResolver', function() {
           rootedFileUrl`1/2/components/bar/bar.html`);
     });
 
+    test('resolves sibling with matching name prefix to component dir', () => {
+      // Regression test for bug in path containment check.
+      const configured =
+          new PackageUrlResolver({packageDir: '/repos/iron-icons'});
+      assert.equal(
+          configured.resolve(
+              rootedFileUrl`repos/iron-iconset-svg/foo.html` as any as
+              PackageRelativeUrl),
+          rootedFileUrl
+          `repos/iron-icons/bower_components/iron-iconset-svg/foo.html`);
+    });
+
     test('resolves cousin URLs as normal', () => {
       assert.equal(
           resolver.resolve(packageRelativeUrl`../../foo/foo.html`),
@@ -168,6 +180,7 @@ suite('PackageUrlResolver', function() {
           rootedFileUrl`1/2/foo.html?fiz#buz`);
     });
   });
+
   suite('relative', () => {
     // We want process.cwd so that on Windows we test Windows paths and on
     // posix we test posix paths.

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -14,9 +14,9 @@
 
 import * as fs from 'fs';
 import * as pathlib from 'path';
+import pathIsInside = require('path-is-inside');
 import Uri from 'vscode-uri';
 
-import {isPathInside} from '../core/utils';
 import {ResolvedUrl} from '../index';
 import {Result} from '../model/analysis';
 import {PackageRelativeUrl} from '../model/url';
@@ -36,7 +36,7 @@ export class FSUrlLoader implements UrlLoader {
   canLoad(url: ResolvedUrl): boolean {
     const parsed = Uri.parse(url);
     return parsed.scheme === 'file' && !parsed.authority &&
-        isPathInside(this.root, parsed.fsPath);
+        pathIsInside(parsed.fsPath, this.root);
   }
 
   load(url: ResolvedUrl): Promise<string> {

--- a/src/url-loader/fs-url-loader.ts
+++ b/src/url-loader/fs-url-loader.ts
@@ -30,15 +30,13 @@ export class FSUrlLoader implements UrlLoader {
   root: string;
 
   constructor(root: string = '') {
-    if (root.endsWith('/')) {
-      root += '/';
-    }
     this.root = pathlib.resolve(root);
   }
 
   canLoad(url: ResolvedUrl): boolean {
-    return url.startsWith('file://') &&
-        isPathInside(this.root, Uri.parse(url).fsPath);
+    const parsed = Uri.parse(url);
+    return parsed.scheme === 'file' && !parsed.authority &&
+        isPathInside(this.root, parsed.fsPath);
   }
 
   load(url: ResolvedUrl): Promise<string> {

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -14,9 +14,10 @@
 
 import * as pathlib from 'path';
 import {posix as posix} from 'path';
+import pathIsInside = require('path-is-inside');
 import {format as urlLibFormat} from 'url';
 
-import {isPathInside, parseUrl} from '../core/utils';
+import {parseUrl} from '../core/utils';
 import {FileRelativeUrl, PackageRelativeUrl} from '../index';
 import {ResolvedUrl} from '../model/url';
 
@@ -46,8 +47,8 @@ export class PackageUrlResolver extends FsUrlResolver {
     // If the path points to a sibling directory, resolve it to the
     // component directory
     const parentOfPackageDir = pathlib.dirname(this.packageDir);
-    if (isPathInside(parentOfPackageDir, path) &&
-        !isPathInside(this.packageDir, path)) {
+    if (pathIsInside(path, parentOfPackageDir) &&
+        !pathIsInside(path, this.packageDir)) {
       path = pathlib.join(
           this.packageDir,
           this.componentDir,
@@ -114,7 +115,7 @@ export class PackageUrlResolver extends FsUrlResolver {
         return undefined;
       }
       const path = this.filesystemPathForPathname(pathname);
-      if (path && isPathInside(this.resolvedComponentDir, path)) {
+      if (path && pathIsInside(path, this.resolvedComponentDir)) {
         return path;
       }
     }

--- a/src/url-loader/package-url-resolver.ts
+++ b/src/url-loader/package-url-resolver.ts
@@ -16,7 +16,7 @@ import * as pathlib from 'path';
 import {posix as posix} from 'path';
 import {format as urlLibFormat} from 'url';
 
-import {parseUrl} from '../core/utils';
+import {isPathInside, parseUrl} from '../core/utils';
 import {FileRelativeUrl, PackageRelativeUrl} from '../index';
 import {ResolvedUrl} from '../model/url';
 
@@ -46,8 +46,8 @@ export class PackageUrlResolver extends FsUrlResolver {
     // If the path points to a sibling directory, resolve it to the
     // component directory
     const parentOfPackageDir = pathlib.dirname(this.packageDir);
-    if (path.startsWith(parentOfPackageDir) &&
-        !path.startsWith(this.packageDir)) {
+    if (isPathInside(parentOfPackageDir, path) &&
+        !isPathInside(this.packageDir, path)) {
       path = pathlib.join(
           this.packageDir,
           this.componentDir,
@@ -114,7 +114,7 @@ export class PackageUrlResolver extends FsUrlResolver {
         return undefined;
       }
       const path = this.filesystemPathForPathname(pathname);
-      if (path && path.startsWith(this.resolvedComponentDir)) {
+      if (path && isPathInside(this.resolvedComponentDir, path)) {
         return path;
       }
     }


### PR DESCRIPTION
If a dependency name began with the name of the package it was being resolved from, we would not resolve the dependency to the components directory, because we were checking for containment naively with string `startsWith`.

Real life example:

  - `/repos/iron-icons/a.html` imports `../iron-iconset-svg/b.html`
  - We test `"/repos/iron-iconset-svg/b.html".startsWith("/repos/iron-icons")` and did not rewrite the url into the components directory, because it looked like it was already inside the package.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
