### PR TITLE
 Index referenced features by their statement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 * Now recognizes classes, behaviors, elements, and mixins that are
   declared in an ES6 `export` declaration.
+* Document#getFeatures now supports querying by `statement`. Given the
+  canonical statement (see esutil.getCanonicalStatement), it will lookup
+  the feature at that statement. This will be used by internal
+  APIs to do scope-based dereferencing of super classes, behaviors, and mixins.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.14] - 2018-03-09

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -69,13 +69,15 @@ export function matchesCallExpression(
   return false;
 }
 
+export type PropertyOrMethod = babel.ObjectProperty|babel.ObjectMethod|
+                               babel.ClassMethod|babel.SpreadProperty|
+                               babel.AssignmentProperty;
+
 /**
  * Given a property or method, return its name, or undefined if that name can't
  * be determined.
  */
-export function getPropertyName(
-    prop: babel.ObjectProperty|babel.ObjectMethod|babel.ClassMethod|
-    babel.SpreadProperty|babel.AssignmentProperty): string|undefined {
+export function getPropertyName(prop: PropertyOrMethod): string|undefined {
   if (babel.isSpreadProperty(prop)) {
     return undefined;
   }
@@ -192,10 +194,9 @@ export function getEventComments(node: babel.Node): Map<string, ScannedEvent> {
   const eventComments = new Set<string>();
 
   babelTraverse(node, {
-    enter(path: NodePath<babel.Node>) {
+    enter(path: NodePath) {
       const node = path.node;
-      (node.leadingComments || [])
-          .concat(node.trailingComments || [])
+      [...(node.leadingComments || []), ...(node.trailingComments || [])]
           .map((commentAST) => commentAST.value)
           .filter((comment) => comment.indexOf('@event') !== -1)
           .forEach((comment) => eventComments.add(comment));

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -685,7 +685,21 @@ export function extractPropertiesFromClassOrObjectBody(
 }
 
 /**
- * Get the statement or declaration for the given node.
+ * Get the canonical statement or declaration for the given node.
+ *
+ * It would otherwise be difficult, or require specialized code for each kind of
+ * feature, to determine which node is the canonical node for a feature. This
+ * function is simple, it only walks up, and it stops once it reaches a clear
+ * feature boundary. And since we're calling this function both on the indexing
+ * and the lookup sides, we can be confident that both will agree on the same
+ * node.
+ *
+ * There may be more than one feature within a single statement (e.g. `export
+ * class Foo {}` is both a Class and an Export, but between `kind` and `id` we
+ * should still have enough info to narrow down to the intended feature.
+ *
+ * See `DeclaredWithStatement` and `BaseDocumentQuery` to see where this is
+ * used.
  */
 export function getCanonicalStatement(nodePath: NodePath): babel.Statement|
     undefined {

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as babel from 'babel-types';
+
 import {AnalysisContext} from '../core/analysis-context';
 import {ParsedCssDocument} from '../css/css-document';
 import {ParsedHtmlDocument} from '../html/html-document';
@@ -26,6 +28,7 @@ import {Feature, ScannedFeature} from './feature';
 import {ImmutableSet, unsafeAsMutable} from './immutable';
 import {Import} from './import';
 import {AstNodeWithLanguage, ScannedInlineDocument} from './inline-document';
+import {MapWithDefault} from './map';
 import {DocumentQuery as Query, DocumentQueryWithKind as QueryWithKind, FeatureKind, FeatureKindMap, Queryable} from './queryable';
 import {isResolvable} from './resolvable';
 import {SourceRange} from './source-range';
@@ -84,6 +87,14 @@ export class ScannedDocument {
     }
   }
 }
+export interface DeclaredWithStatement {
+  statementAst: babel.Statement|undefined;
+}
+function isDeclaredWithStatement(
+    feature: Feature&Partial<DeclaredWithStatement>): feature is Feature&
+    DeclaredWithStatement {
+  return feature.statementAst !== undefined;
+}
 
 declare module './queryable' {
   interface FeatureKindMap {
@@ -112,6 +123,8 @@ export class Document<ParsedType extends ParsedDocument = ParsedDocument>
 
   private readonly _localFeatures = new Set<Feature>();
   private readonly _scannedDocument: ScannedDocument;
+  private readonly _localFeaturesByStatement =
+      new MapWithDefault<babel.Statement, Set<Feature>>(() => new Set());
 
 
   /**
@@ -210,6 +223,11 @@ export class Document<ParsedType extends ParsedDocument = ParsedDocument>
     }
     this._indexFeature(feature);
     this._localFeatures.add(feature);
+
+    if (isDeclaredWithStatement(feature) &&
+        feature.statementAst !== undefined) {
+      this._localFeaturesByStatement.get(feature.statementAst).add(feature);
+    }
   }
 
   /**
@@ -226,6 +244,9 @@ export class Document<ParsedType extends ParsedDocument = ParsedDocument>
       Set<FeatureKindMap[K]>;
   getFeatures(query?: Query): Set<Feature>;
   getFeatures(query: Query = {}): Set<Feature> {
+    if (query.statement !== undefined) {
+      return this._getByStatement(query.statement, query.kind);
+    }
     if (query.id && query.kind) {
       return this._getById(query.kind, query.id, query);
     } else if (query.kind) {
@@ -286,6 +307,25 @@ export class Document<ParsedType extends ParsedDocument = ParsedDocument>
     for (const featureOfKind of this._getByKind(kind, query)) {
       if (featureOfKind.identifiers.has(identifier)) {
         result.add(featureOfKind);
+      }
+    }
+    return result;
+  }
+
+  private _getByStatement(statement: babel.Statement, kind: string|undefined) {
+    const result = this._localFeaturesByStatement.get(statement);
+    if (kind === undefined) {
+      return result;
+    }
+    return this._filterByKind(result, kind);
+  }
+
+  /** Filters out the given features by the given kind. */
+  private _filterByKind(features: Iterable<Feature>, kind: string) {
+    const result = new Set<Feature>();
+    for (const feature of features) {
+      if (feature.kinds.has(kind)) {
+        result.add(feature);
       }
     }
     return result;

--- a/src/model/document.ts
+++ b/src/model/document.ts
@@ -88,6 +88,14 @@ export class ScannedDocument {
   }
 }
 export interface DeclaredWithStatement {
+  /**
+   * This is the nearest statement at or above `this.astNode`.
+   *
+   * This is a fast and simple way to get a canonical, indexable AST node,
+   * so that we can look up a feature syntactically.
+   *
+   * Populate this field with `esutil.getCanonicalStatement`.
+   */
   statementAst: babel.Statement|undefined;
 }
 function isDeclaredWithStatement(

--- a/src/model/element-base.ts
+++ b/src/model/element-base.ts
@@ -43,6 +43,7 @@ export abstract class ScannedElementBase implements Resolvable {
   staticMethods: Map<string, ScannedMethod> = new Map();
   methods: Map<string, ScannedMethod> = new Map();
   astNode: babel.Node|null = null;
+  statementAst: babel.Statement|undefined;
   warnings: Warning[] = [];
   jsdoc?: jsdoc.Annotation;
   'slots': Slot[] = [];

--- a/src/model/queryable.ts
+++ b/src/model/queryable.ts
@@ -65,6 +65,9 @@ export type BaseDocumentQuery = BaseQueryOptions&{
   /**
    * If given, returns any features which are defined by the given statement.
    * This argument implies `imported: false`.
+   *
+   * See esutil.getStatement for going from a babel traverse NodePath to the
+   * canonical statment node.
    */
   statement?: babel.Statement;
   /**

--- a/src/model/queryable.ts
+++ b/src/model/queryable.ts
@@ -11,6 +11,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+
+import * as babel from 'babel-types';
 import {Feature} from './feature';
 import {Warning} from './warning';
 
@@ -60,6 +62,11 @@ export type BaseAnalysisQuery = BaseQueryOptions&{
 };
 
 export type BaseDocumentQuery = BaseQueryOptions&{
+  /**
+   * If given, returns any features which are defined by the given statement.
+   * This argument implies `imported: false`.
+   */
+  statement?: babel.Statement;
   /**
    * If true, the query will return results from the document and its
    * dependencies. Otherwise it will only include results from the document.

--- a/src/model/queryable.ts
+++ b/src/model/queryable.ts
@@ -66,10 +66,11 @@ export type BaseDocumentQuery = BaseQueryOptions&{
    * If given, returns any features which are defined by the given statement.
    * This argument implies `imported: false`.
    *
-   * See esutil.getStatement for going from a babel traverse NodePath to the
+   * See esutil.getStatement for going from a babel-traverse NodePath to the
    * canonical statment node.
    */
   statement?: babel.Statement;
+
   /**
    * If true, the query will return results from the document and its
    * dependencies. Otherwise it will only include results from the document.

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -162,6 +162,7 @@ class BehaviorVisitor implements Visitor {
 
     this._startBehavior(new ScannedBehavior({
       astNode: node,
+      statementAst: esutil.getCanonicalStatement(path),
       description: parsedJsdocs.description,
       events: esutil.getEventComments(node),
       sourceRange: this.document.sourceRangeForNode(node),

--- a/src/polymer/polymer-core-feature.ts
+++ b/src/polymer/polymer-core-feature.ts
@@ -75,6 +75,7 @@ export class ScannedPolymerCoreFeature extends ScannedFeature implements
           summary: '',
           sourceRange: this.sourceRange,
           astNode: this.astNode,
+          statementAst: undefined,
         },
         document);
   }
@@ -93,6 +94,7 @@ export class PolymerCoreFeature implements Feature {
   kinds = new Set(['polymer-core-feature']);
   identifiers = new Set<string>();
   warnings: Warning[] = [];
+  readonly statementAst = undefined;
 
   constructor(
       public properties: Map<string, Property>,

--- a/src/polymer/polymer-element-mixin.ts
+++ b/src/polymer/polymer-element-mixin.ts
@@ -27,6 +27,7 @@ export interface Options {
   sourceRange: SourceRange;
   mixins: ScannedReference<'element-mixin'>[];
   astNode: babel.Node;
+  statementAst: babel.Statement|undefined;
   classAstNode?: babel.Node;
 }
 
@@ -52,6 +53,7 @@ export class ScannedPolymerElementMixin extends ScannedElementMixin implements
     sourceRange,
     mixins,
     astNode,
+    statementAst,
     classAstNode
   }: Options) {
     super({name});
@@ -62,6 +64,7 @@ export class ScannedPolymerElementMixin extends ScannedElementMixin implements
     this.sourceRange = sourceRange;
     this.mixins = mixins;
     this.astNode = astNode;
+    this.statementAst = statementAst;
     this.classAstNode = classAstNode;
   }
 

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -64,6 +64,7 @@ class ElementVisitor implements Visitor {
     const element = new ScannedPolymerElement({
       className,
       astNode: node,
+      statementAst: esutil.getCanonicalStatement(path),
       description: jsDoc.description,
       events: esutil.getEventComments(parent),
       sourceRange: this.document.sourceRangeForNode(node.arguments[0]),

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -155,6 +155,7 @@ export interface Options {
   privacy: Privacy;
   // TODO(rictic): make this AstNodeWithLanguage
   astNode: any;
+  statementAst: babel.Statement|undefined;
   sourceRange: SourceRange|undefined;
 }
 
@@ -247,6 +248,7 @@ export class ScannedPolymerElement extends ScannedElement implements
     this.abstract = options.abstract;
     this.privacy = options.privacy;
     this.astNode = options.astNode;
+    this.statementAst = options.statementAst;
     this.sourceRange = options.sourceRange;
 
     if (options.properties) {

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {NodePath, Scope} from 'babel-traverse';
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 
 import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
@@ -41,7 +41,7 @@ export class MixinVisitor implements Visitor {
   }
 
   enterAssignmentExpression(
-      node: babel.AssignmentExpression, parent: babel.Node, path: NodePath) {
+      node: babel.AssignmentExpression, _parent: babel.Node, path: NodePath) {
     this.tryInitializeMixin(path, node.left);
   }
 

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -88,6 +88,7 @@ export class MixinVisitor implements Visitor {
       name: namespacedName,
       sourceRange,
       astNode: node,
+      statementAst: esutil.getCanonicalStatement(nodePath),
       description: docs.description,
       summary: (summaryTag && summaryTag.description) || '',
       privacy: getOrInferPrivacy(namespacedName, docs),

--- a/src/polymer/pseudo-element-scanner.ts
+++ b/src/polymer/pseudo-element-scanner.ts
@@ -44,6 +44,7 @@ export class PseudoElementScanner implements HtmlScanner {
         if (tagName) {
           const element = new ScannedPolymerElement({
             astNode: node,
+            statementAst: undefined,
             tagName: tagName,
             jsdoc: parsedJsdoc,
             description: parsedJsdoc.description,

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -467,31 +467,34 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
   test('finds exported mixin functions', async () => {
     const mixins = await getScannedMixins('test-mixin-12.js');
     const mixinData = await Promise.all(mixins.map(getTestProps));
-    assert.deepEqual(mixinData, [{
-                       name: 'TestMixin',
-                       description: 'A mixin description',
-                       summary: '',
-                       properties: [{
-                         name: 'foo',
-                       }],
-                       attributes: [{
-                         name: 'foo',
-                       }],
-                       methods: [],
-                       underlinedWarnings: []
-                     }, {
-                      name: 'DefaultTestMixin',
-                      description: 'Another mixin description',
-                      summary: '',
-                      properties: [{
-                        name: 'bar',
-                      }],
-                      attributes: [{
-                        name: 'bar',
-                      }],
-                      methods: [],
-                      underlinedWarnings: []
-                    });
+    assert.deepEqual(mixinData, [
+      {
+        name: 'TestMixin',
+        description: 'A mixin description',
+        summary: '',
+        properties: [{
+          name: 'foo',
+        }],
+        attributes: [{
+          name: 'foo',
+        }],
+        methods: [],
+        underlinedWarnings: []
+      },
+      {
+        name: 'DefaultTestMixin',
+        description: 'Another mixin description',
+        summary: '',
+        properties: [{
+          name: 'bar',
+        }],
+        attributes: [{
+          name: 'bar',
+        }],
+        methods: [],
+        underlinedWarnings: []
+      }
+    ]);
     const underlinedSource = await underliner.underline(mixins[0].sourceRange);
     assert.deepEqual(underlinedSource, `
 export function TestMixin(superclass) {


### PR DESCRIPTION
This way we can use babel traverse Scopes to get bindings, use bindings to get NodePaths, use NodePaths to get canonical statements, and then query the Document for the referenced Feature.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
