### PR TITLE
Add specialized subclass JS Imports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   canonical statement (see esutil.getCanonicalStatement), it will lookup
   the feature at that statement. This will be used by internal
   APIs to do scope-based dereferencing of super classes, behaviors, and mixins.
+* Added JavascriptImport#specifier for getting the original import specifier,
+  before it may have been resolved to a file-relative url by the node module
+  resolution algorithm.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.14] - 2018-03-09

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -88,8 +88,10 @@ export class JavascriptImport extends Import {
   constructor(
       url: ResolvedUrl, originalUrl: FileRelativeUrl, type: string,
       document: Document, sourceRange: SourceRange|undefined,
-      urlSourceRange: SourceRange|undefined, ast: any, warnings: Warning[],
-      lazy: boolean, specifier: string) {
+      urlSourceRange: SourceRange|undefined,
+      ast: babel.ImportDeclaration|babel.CallExpression|
+      babel.ExportAllDeclaration|babel.ExportNamedDeclaration,
+      warnings: Warning[], lazy: boolean, specifier: string) {
     super(
         url,
         originalUrl,

--- a/src/javascript/javascript-import-scanner.ts
+++ b/src/javascript/javascript-import-scanner.ts
@@ -15,7 +15,8 @@
 import * as babel from 'babel-types';
 import {dirname, relative} from 'path';
 import {URL} from 'whatwg-url';
-import {FileRelativeUrl, ScannedImport, Severity, Warning} from '../model/model';
+
+import {Document, FileRelativeUrl, Import, ResolvedUrl, ScannedImport, Severity, Warning} from '../model/model';
 
 import {Visitor} from './estree-visitor';
 import {JavaScriptDocument} from './javascript-document';
@@ -23,16 +24,84 @@ import {JavaScriptScanner} from './javascript-scanner';
 
 import isWindows = require('is-windows');
 import resolve = require('resolve');
+import {SourceRange} from '../model/model';
 
 const isPathSpecifier = (s: string) => /^\.{0,2}\//.test(s);
 
 export interface JavaScriptImportScannerOptions {
   /**
    * Algorithm to use for resolving module specifiers in import
-   * and export statements when rewriting them to be web-compatible.
+   * and export statements when converting them to URLs.
    * A value of 'node' uses Node.js resolution to find modules.
+   *
+   * If this argument is not given, module specifiers must be web-compatible
+   * urls.
    */
   moduleResolution?: 'node';
+}
+
+export class ScannedJavascriptImport extends ScannedImport {
+  readonly type!: 'js-import';
+
+  // The original text of the specifier. Unlike `this.url`, this may not
+  // be a URL, but may be a bare module specifier, like 'jquery'.
+  readonly specifier: string;
+
+  constructor(
+      url: FileRelativeUrl|undefined, sourceRange: SourceRange|undefined,
+      urlSourceRange: SourceRange|undefined,
+      ast: babel.ImportDeclaration|babel.CallExpression|
+      babel.ExportAllDeclaration|babel.ExportNamedDeclaration,
+      lazy: boolean, originalSpecifier: string) {
+    super('js-import', url, sourceRange, urlSourceRange, ast, lazy);
+    this.specifier = originalSpecifier;
+  }
+
+  protected constructImport(
+      resolvedUrl: ResolvedUrl, relativeUrl: FileRelativeUrl,
+      importedDocument: Document, _containingDocument: Document) {
+    return new JavascriptImport(
+        resolvedUrl,
+        relativeUrl,
+        this.type,
+        importedDocument,
+        this.sourceRange,
+        this.urlSourceRange,
+        this.astNode,
+        this.warnings,
+        this.lazy,
+        this.specifier);
+  }
+}
+
+declare module '../model/queryable' {
+  interface FeatureKindMap {
+    'js-import': JavascriptImport;
+  }
+}
+export class JavascriptImport extends Import {
+  /**
+   * The original text of the specifier. Unlike `this.url`, this may not
+   * be a URL, but may be a bare module specifier, like 'jquery'.
+   */
+  readonly specifier: string;
+  constructor(
+      url: ResolvedUrl, originalUrl: FileRelativeUrl, type: string,
+      document: Document, sourceRange: SourceRange|undefined,
+      urlSourceRange: SourceRange|undefined, ast: any, warnings: Warning[],
+      lazy: boolean, specifier: string) {
+    super(
+        url,
+        originalUrl,
+        type,
+        document,
+        sourceRange,
+        urlSourceRange,
+        ast,
+        warnings,
+        lazy);
+    this.specifier = specifier;
+  }
 }
 
 export class JavaScriptImportScanner implements JavaScriptScanner {
@@ -44,7 +113,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
   async scan(
       document: JavaScriptDocument,
       visit: (visitor: Visitor) => Promise<void>) {
-    const imports: ScannedImport[] = [];
+    const imports: ScannedJavascriptImport[] = [];
     const warnings: Warning[] = [];
     const scanner = this;
 
@@ -79,50 +148,50 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
           }));
           return;
         }
-        imports.push(new ScannedImport(
-            'js-import',
-            scanner._resolveSpecifier(
-                arg.value as string, document, node, warnings),
+        const specifier = arg.value as string;
+        imports.push(new ScannedJavascriptImport(
+            scanner._resolveSpecifier(specifier, document, node, warnings),
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.callee)!,
             node,
-            true));
+            true,
+            specifier));
       },
 
       enterImportDeclaration(node: babel.ImportDeclaration, _: babel.Node) {
-        imports.push(new ScannedImport(
-            'js-import',
-            scanner._resolveSpecifier(
-                node.source.value, document, node, warnings),
+        const specifier = node.source.value;
+        imports.push(new ScannedJavascriptImport(
+            scanner._resolveSpecifier(specifier, document, node, warnings),
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.source)!,
             node,
-            false));
+            false,
+            specifier));
       },
 
       enterExportAllDeclaration(node, _parent) {
-        imports.push(new ScannedImport(
-            'js-import',
-            scanner._resolveSpecifier(
-                node.source.value, document, node, warnings),
+        const specifier = node.source.value;
+        imports.push(new ScannedJavascriptImport(
+            scanner._resolveSpecifier(specifier, document, node, warnings),
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.source)!,
             node,
-            false));
+            false,
+            specifier));
       },
 
       enterExportNamedDeclaration(node, _parent) {
         if (node.source == null) {
           return;
         }
-        imports.push(new ScannedImport(
-            'js-import',
-            scanner._resolveSpecifier(
-                node.source.value, document, node, warnings),
+        const specifier = node.source.value;
+        imports.push(new ScannedJavascriptImport(
+            scanner._resolveSpecifier(specifier, document, node, warnings),
             document.sourceRangeForNode(node)!,
             document.sourceRangeForNode(node.source)!,
             node,
-            false));
+            false,
+            specifier));
       }
 
     });
@@ -131,7 +200,7 @@ export class JavaScriptImportScanner implements JavaScriptScanner {
 
   private _resolveSpecifier(
       specifier: string, document: JavaScriptDocument, node: babel.Node,
-      warnings: any[]): FileRelativeUrl|undefined {
+      warnings: Warning[]): FileRelativeUrl|undefined {
     if (isPathSpecifier(specifier)) {
       return specifier as FileRelativeUrl;
     }

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -27,7 +27,7 @@ import {Severity, Warning} from './warning';
  * @template N The AST node type
  */
 export class ScannedImport implements Resolvable {
-  type: 'html-import'|'html-script'|'html-style'|'js-import'|string;
+  readonly type: 'html-import'|'html-script'|'html-style'|'js-import'|string;
 
   /**
    * URL of the import, relative to the base directory.
@@ -90,11 +90,18 @@ export class ScannedImport implements Resolvable {
       }));
       return undefined;
     }
+    return this.constructImport(
+        resolvedUrl, this.url, importedDocumentOrWarning, document);
+  }
+
+  protected constructImport(
+      resolvedUrl: ResolvedUrl, relativeUrl: FileRelativeUrl,
+      importedDocument: Document, _containingDocument: Document) {
     return new Import(
         resolvedUrl,
-        this.url,
+        relativeUrl,
         this.type,
-        importedDocumentOrWarning,
+        importedDocument,
         this.sourceRange,
         this.urlSourceRange,
         this.astNode,
@@ -112,7 +119,6 @@ declare module './queryable' {
     'html-import': Import;
     'html-script': Import;
     'html-style': Import;
-    'js-import': Import;
     'css-import': Import;
   }
 }

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -48,11 +48,13 @@ suite('JavaScriptImportScanner', () => {
         type: 'js-import',
         url: './submodule.js',
         lazy: true,
+        specifier: './submodule.js',
       },
       {
         type: 'js-import',
         url: './node_modules/test-package/index.js',
         lazy: true,
+        specifier: 'test-package'
       },
     ]);
   });
@@ -69,6 +71,7 @@ suite('JavaScriptImportScanner', () => {
         type: 'js-import',
         url: './node_modules/test-package/index.js',
         lazy: false,
+        specifier: 'test-package'
       },
     ]);
   });


### PR DESCRIPTION
This is a good place to add the original module specifiers, and may be useful hook for caching reference lookups.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
