### PR TITLE
Identify the names of exported bindings.

### DIFF
--- a/src/core/analysis-context.ts
+++ b/src/core/analysis-context.ts
@@ -25,6 +25,7 @@ import {HtmlStyleScanner} from '../html/html-style-scanner';
 import {ClassScanner} from '../javascript/class-scanner';
 import {FunctionScanner} from '../javascript/function-scanner';
 import {InlineHtmlDocumentScanner} from '../javascript/html-template-literal-scanner';
+import {JavaScriptExportScanner} from '../javascript/javascript-export-scanner';
 import {JavaScriptImportScanner} from '../javascript/javascript-import-scanner';
 import {JavaScriptParser} from '../javascript/javascript-parser';
 import {NamespaceScanner} from '../javascript/namespace-scanner';
@@ -122,6 +123,7 @@ export class AnalysisContext {
           new ClassScanner(),
           new JavaScriptImportScanner(
               {moduleResolution: options.moduleResolution}),
+          new JavaScriptExportScanner(),
           new InlineHtmlDocumentScanner(),
         ]
       ],

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -788,7 +788,11 @@ export function*
   }
 }
 
-// Utility function for getBindingNamesFromDeclaration
+/**
+ * Given an LValue, what are the names it assigns to?
+ *
+ * Internal utility function for getBindingNamesFromDeclaration.
+ */
 function* getNamesFromLValue(lhs: babel.LVal): IterableIterator<string> {
   switch (lhs.type) {
     case 'Identifier':

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -17,6 +17,7 @@ import babelTraverse from 'babel-traverse';
 import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 import * as doctrine from 'doctrine';
+import * as util from 'util';
 
 import {MethodParam, ScannedMethod, ScannedProperty} from '../index';
 import {Result} from '../model/analysis';
@@ -728,4 +729,118 @@ export function getCanonicalStatement(nodePath: NodePath): babel.Statement|
 function isStatementWithUniqueStatementChild(node: babel.Node): boolean {
   return babel.isExportNamedDeclaration(node) ||
       babel.isExportDefaultDeclaration(node);
+}
+
+/** What names does a declaration assign to? */
+export function*
+    getBindingNamesFromDeclaration(declaration: babel.Declaration|null|
+                                   undefined): IterableIterator<string> {
+  if (declaration == null) {
+    return;
+  }
+  switch (declaration.type) {
+    case 'ClassDeclaration':
+    case 'DeclareClass':
+      yield declaration.id.name;
+      break;
+    case 'VariableDeclaration':
+      for (const varDecl of declaration.declarations) {
+        yield* getNamesFromLValue(varDecl.id);
+      }
+      break;
+    case 'FunctionDeclaration':
+    case 'DeclareFunction':
+    case 'DeclareInterface':
+    case 'DeclareTypeAlias':
+    case 'InterfaceDeclaration':
+    case 'DeclareVariable':
+    case 'TypeAlias':
+      yield declaration.id.name;
+      break;
+    case 'ExportAllDeclaration':
+      yield '*';
+      break;
+    case 'ExportDefaultDeclaration':
+      yield 'default';
+      break;
+    case 'ExportNamedDeclaration':
+      for (const specifier of declaration.specifiers) {
+        if (specifier.exported.type === 'Identifier') {
+          yield specifier.exported.name;
+        }
+      }
+      yield* getBindingNamesFromDeclaration(declaration.declaration);
+      break;
+    case 'DeclareModule':
+      if (declaration.id.type === 'StringLiteral') {
+        yield declaration.id.value;
+      } else {
+        yield declaration.id.name;
+      }
+      break;
+    case 'ImportDeclaration':
+      for (const specifier of declaration.specifiers) {
+        yield specifier.local.name;
+      }
+      break;
+    default:
+      assertNever(declaration);
+  }
+}
+
+// Utility function for getBindingNamesFromDeclaration
+function* getNamesFromLValue(lhs: babel.LVal): IterableIterator<string> {
+  switch (lhs.type) {
+    case 'Identifier':
+      // x = _;
+      yield lhs.name;
+      break;
+    case 'ArrayPattern':
+      // [a, b, c] = _;
+      for (const element of lhs.elements) {
+        if (babel.isLVal(element)) {
+          yield* getNamesFromLValue(element);
+        }
+      }
+      break;
+    case 'RestElement':
+      // the `...more` part of either
+      // [a, b, ...more] = _;
+      // {a: b, ...more} = _;
+      yield* getNamesFromLValue(lhs.argument);
+      break;
+    case 'MemberExpression':
+      // foo.bar = _;
+      const name = astValue.getIdentifierName(lhs);
+      if (name !== undefined) {
+        yield name;
+      }
+      break;
+    case 'ObjectPattern':
+      // {a: b, c} = _;
+      for (const prop of lhs.properties) {
+        switch (prop.type) {
+          case 'ObjectProperty':
+            // If the property has a 'value' (like)
+            yield* getNamesFromLValue(prop.value);
+            break;
+          case 'RestProperty':
+            yield* getNamesFromLValue(prop.argument);
+            break;
+          default:
+            assertNever(prop);
+        }
+      }
+      break;
+    case 'AssignmentPattern':
+      // var [a = 'defaultVal'] = _;
+      yield* getNamesFromLValue(lhs.left);
+      break;
+    default:
+      assertNever(lhs);
+  }
+}
+
+function assertNever(never: never) {
+  throw new Error(`Unexpected ast node: ${util.inspect(never)}`);
 }

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -718,8 +718,9 @@ suite('Class', () => {
       }
       const document = result.value;
       for (const class_ of classes) {
-        const features = document.getFeatures({statement: class_.statementAst});
-        assert.deepEqual([class_], [...features]);
+        const features = document.getFeatures(
+            {statement: class_.statementAst, kind: 'class'});
+        assert.deepEqual([...features].map((c) => c.name), [class_.name]);
       }
     });
   });

--- a/src/test/javascript/javascript-export-scanner_test.ts
+++ b/src/test/javascript/javascript-export-scanner_test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+
+import {assert} from 'chai';
+
+import {Analyzer} from '../../core/analyzer';
+import {fixtureDir} from '../test-utils';
+
+suite('JavaScriptExportScanner', () => {
+  const analyzer = Analyzer.createForDirectory(fixtureDir);
+
+  async function getExports(filename: string) {
+    const analysis = await analyzer.analyze([filename]);
+    const result = analysis.getDocument(filename);
+    if (!result.successful) {
+      throw new Error('could not get document');
+    }
+    assert.deepEqual(result.value.getWarnings().map((w) => w.toString()), []);
+    return result.value.getFeatures({kind: 'export'});
+  }
+
+  test('identifies the names that of exports', async () => {
+    const features = await getExports('javascript/all-export-types.js');
+    assert.containSubset([...features].map((f) => [...f.identifiers]), [
+      ['namedConstIdentifier'],
+      ['default'],
+      ['ClassName'],
+      ['functionName'],
+      ['identifierAssignedFunction'],
+      ['a', 'b', 'c', 'd'],
+      ['g', 'i', 'k']
+    ]);
+  });
+});

--- a/src/test/javascript/javascript-export-scanner_test.ts
+++ b/src/test/javascript/javascript-export-scanner_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at

--- a/src/test/static/javascript/all-export-types.js
+++ b/src/test/static/javascript/all-export-types.js
@@ -1,0 +1,16 @@
+export const namedConstIdentifier = 10;
+
+export default 100;
+
+export class ClassName { };
+
+export function functionName() { };
+
+export const identifierAssignedFunction = function funcExpressionName() { };
+
+export const [a, b, c= 10, ...d] = [1, 2, 3, 5, 6, 7];
+
+export const { g, h: i, j: k = l } = lol;
+
+// TODO re-exports, including export *
+//


### PR DESCRIPTION
This is useful for matching up imports to exports. No user facing changes yet.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not updated, this isn't exposed anywhere.
