### PR TITLE
Resolve references through imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
 <!-- Add new, unreleased changes here. -->
+* Reference resolution now supports javascript scoping rules, and will follow
+  javascript module imports, including aliased imports, namespace imports, and
+  re-exports. References to super classes, mixins, and behaviors use this
+  resolution system.
 * Add `nodeName` to `LocalId` references
+* Added an `Export` feature, for JS module exports.
+
 
 ## [3.0.0-pre.16] - 2018-03-15
 * Import URLs which are resolved, but for which the URL loader returns

--- a/src/javascript/estraverse-shim.ts
+++ b/src/javascript/estraverse-shim.ts
@@ -55,7 +55,7 @@ export function traverse(ast: babel.Node, visitor: Visitor): void {
       dispatchVisitMethods(
           ['leave', `leave${path.type}` as keyof Visitor], path, visitor);
     },
-    noScope: true,
+    noScope: !babel.isFile(ast),
   });
 }
 

--- a/src/model/reference.ts
+++ b/src/model/reference.ts
@@ -165,6 +165,8 @@ function resolveThroughImport<K extends keyof FeatureKindMap>(
       export_.astNodePath, exportedAs, import_.document, kind);
 }
 
+// We handle ImportNamespaceSpecifiers separately, as resolving their bindings
+// is slightly tricky.
 type ImportIndicator = babel.ImportDefaultSpecifier|babel.ImportSpecifier|
                        babel.ExportNamedDeclaration|babel.ExportAllDeclaration;
 function isSomeKindOfImport(path: NodePath): path is NodePath<ImportIndicator> {

--- a/src/model/reference.ts
+++ b/src/model/reference.ts
@@ -128,12 +128,13 @@ function resolveScopedAt<K extends keyof FeatureKindMap>(
 
 
 type ImportIndicator = babel.ImportDefaultSpecifier|babel.ImportSpecifier|
-                       babel.ExportNamedDeclaration;
+                       babel.ExportNamedDeclaration|babel.ExportAllDeclaration;
 function isSomeKindOfImport(path: NodePath): path is NodePath<ImportIndicator> {
   const node = path.node;
   return babel.isImportSpecifier(node) ||
       babel.isImportDefaultSpecifier(node) ||
-      (babel.isExportNamedDeclaration(node) && node.source != null);
+      (babel.isExportNamedDeclaration(node) && node.source != null) ||
+      (babel.isExportAllDeclaration(node));
 }
 
 function resolveThroughImport<K extends keyof FeatureKindMap>(
@@ -166,6 +167,10 @@ function resolveThroughImport<K extends keyof FeatureKindMap>(
     if (exportedAs === undefined) {
       return {successful: false, error: undefined};
     }
+  } else if (babel.isExportAllDeclaration(node)) {
+    // Can't rename through an export all, the name we're looking for in
+    // this file is the same name in the next file.
+    exportedAs = identifier;
   } else {
     exportedAs = node.imported.name;
   }

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -158,17 +158,23 @@ suite('Class', () => {
         {
           description: 'An exported class.',
           name: 'ExportedClass',
-          privacy: 'public'
+          privacy: 'public',
+          methods:
+              [{description: '', name: 'method1', return: {type: 'void'}}]
         },
         {
           description: 'A default exported class.',
           name: undefined,
-          privacy: 'public'
+          privacy: 'public',
+          methods:
+              [{description: '', name: 'method2', return: {type: 'void'}}]
         },
         {
           description: '',
           name: 'ExportedConstClass',
           privacy: 'public',
+          methods:
+              [{description: '', name: 'method3', return: {type: 'void'}}]
         }
       ]);
     });
@@ -476,17 +482,23 @@ suite('Class', () => {
         {
           description: 'An exported class.',
           name: 'ExportedClass',
-          privacy: 'public'
+          privacy: 'public',
+          methods:
+              [{description: '', name: 'method1', return: {type: 'void'}}]
         },
         {
           description: 'A default exported class.',
           name: undefined,
-          privacy: 'public'
+          privacy: 'public',
+          methods:
+              [{description: '', name: 'method2', return: {type: 'void'}}]
         },
         {
           description: '',
           name: 'ExportedConstClass',
           privacy: 'public',
+          methods:
+              [{description: '', name: 'method3', return: {type: 'void'}}]
         }
       ]);
     });
@@ -726,7 +738,7 @@ suite('Class', () => {
 
     test('we resolve superclasses by scope when possible', async () => {
       const filename = 'class/super-class-scoped.js';
-      const {classes, analysis} = await getClasses(filename);
+      const {classes} = await getClasses(filename);
       assert.deepEqual(classes.map((c) => c.name), [
         'Foo',
         'Foo',
@@ -746,6 +758,23 @@ suite('Class', () => {
       assert.deepEqual(
           subclasses.map((c) => [...c.methods.keys()]),
           [['method1'], ['method2'], ['method3']]);
+    });
+
+    test.skip('we resolve imported super classes', async () => {
+      const filename = 'class/super-class-imported.js';
+      const analysis = await analyzer.analyze([filename]);
+      const result = analysis.getDocument(filename);
+      if (result.successful === false) {
+        throw new Error('Could not get document');
+      }
+      const document = result.value;
+      const classes = Array.from(document.getFeatures({kind: 'class'}));
+      assert.deepEqual(classes.map((c) => c.name), [
+        'CL1',
+      ]);
+
+      assert.deepEqual(
+          classes.map((c) => [...c.methods.keys()]), [['method1']]);
     });
   });
 });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -760,7 +760,7 @@ suite('Class', () => {
           [['method1'], ['method2'], ['method3']]);
     });
 
-    test.skip('we resolve imported super classes', async () => {
+    test('we resolve imported super classes', async () => {
       const filename = 'class/super-class-imported.js';
       const analysis = await analyzer.analyze([filename]);
       const result = analysis.getDocument(filename);
@@ -771,10 +771,15 @@ suite('Class', () => {
       const classes = Array.from(document.getFeatures({kind: 'class'}));
       assert.deepEqual(classes.map((c) => c.name), [
         'CL1',
+        'CL2',
+        'CL3',
       ]);
 
-      assert.deepEqual(
-          classes.map((c) => [...c.methods.keys()]), [['method1']]);
+      assert.deepEqual(classes.map((c) => [...c.methods.keys()]), [
+        ['method1'],
+        ['method2'],
+        ['method3'],
+      ]);
     });
   });
 });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -774,12 +774,14 @@ suite('Class', () => {
         'CL2',
         'CL3',
         'CL4',
+        'CL5',
       ]);
 
       assert.deepEqual(classes.map((c) => [...c.methods.keys()]), [
         ['method1'],
         ['method2'],
         ['method3'],
+        ['method1'],
         ['method1'],
       ]);
     });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -723,5 +723,29 @@ suite('Class', () => {
         assert.deepEqual([...features].map((c) => c.name), [class_.name]);
       }
     });
+
+    test('we resolve superclasses by scope when possible', async () => {
+      const filename = 'class/super-class-scoped.js';
+      const {classes, analysis} = await getClasses(filename);
+      assert.deepEqual(classes.map((c) => c.name), [
+        'Foo',
+        'Foo',
+        'One',
+        'Foo',
+        'Two',
+        'Three',
+      ]);
+
+      const subclasses = classes.filter((c) => c.superClass !== undefined);
+      assert.deepEqual(
+          subclasses.map(((c) => c.name)), ['One', 'Two', 'Three']);
+
+      // Despite the fact that their superclasses all have the same name,
+      // we're able to use JS scoping rules to resolve them to the correct
+      // referant.
+      assert.deepEqual(
+          subclasses.map((c) => [...c.methods.keys()]),
+          [['method1'], ['method2'], ['method3']]);
+    });
   });
 });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -773,12 +773,14 @@ suite('Class', () => {
         'CL1',
         'CL2',
         'CL3',
+        'CL4',
       ]);
 
       assert.deepEqual(classes.map((c) => [...c.methods.keys()]), [
         ['method1'],
         ['method2'],
         ['method3'],
+        ['method1'],
       ]);
     });
   });

--- a/src/test/javascript/class-scanner_test.ts
+++ b/src/test/javascript/class-scanner_test.ts
@@ -775,6 +775,7 @@ suite('Class', () => {
         'CL3',
         'CL4',
         'CL5',
+        'CL6',
       ]);
 
       assert.deepEqual(classes.map((c) => [...c.methods.keys()]), [
@@ -783,6 +784,7 @@ suite('Class', () => {
         ['method3'],
         ['method1'],
         ['method1'],
+        ['method1']
       ]);
     });
   });

--- a/src/test/javascript/javascript-import-scanner_test.ts
+++ b/src/test/javascript/javascript-import-scanner_test.ts
@@ -108,4 +108,25 @@ suite('JavaScriptImportScanner', () => {
       },
     ]);
   });
+
+  test('recognizes reexports as imports', async () => {
+    const {features, warnings} = await runScanner(
+        analyzer,
+        new JavaScriptImportScanner(),
+        'javascript/all-export-types.js');
+
+    assert.equal(warnings.length, 0);
+    assert.containSubset(features, [
+      {
+        type: 'js-import',
+        url: './module-with-export.js',
+        lazy: false,
+      },
+      {
+        type: 'js-import',
+        url: './module-with-export.js',
+        lazy: false,
+      },
+    ]);
+  });
 });

--- a/src/test/static/class/class-names.js
+++ b/src/test/static/class/class-names.js
@@ -21,9 +21,9 @@ let NotAClass; // this comment should not be attached to a class
 class ClassWithNoJsDoc { }
 
 /** An exported class. */
-export class ExportedClass { }
+export class ExportedClass { method1() { } }
 
 /** A default exported class. */
-export default class { };
+export default class { method2() { } };
 
-export const ExportedConstClass = class { };
+export const ExportedConstClass = class { method3() { } };

--- a/src/test/static/class/reexported-all.js
+++ b/src/test/static/class/reexported-all.js
@@ -1,0 +1,1 @@
+export * from './class-names.js';

--- a/src/test/static/class/reexported-classes.js
+++ b/src/test/static/class/reexported-classes.js
@@ -1,0 +1,1 @@
+export { ExportedClass as ReexportedClass } from './class-names.js';

--- a/src/test/static/class/super-class-imported.js
+++ b/src/test/static/class/super-class-imported.js
@@ -1,8 +1,11 @@
 import { ExportedClass as Super1, ExportedConstClass as Super3 } from './class-names.js';
 import Super2 from './class-names.js';
+import {ReexportedClass as Super1Again} from './reexported-classes.js';
 
 class CL1 extends Super1 { };
 
 class CL2 extends Super2 { };
 
 class CL3 extends Super3 { };
+
+class CL4 extends Super1Again { };

--- a/src/test/static/class/super-class-imported.js
+++ b/src/test/static/class/super-class-imported.js
@@ -2,6 +2,7 @@ import { ExportedClass as Super1, ExportedConstClass as Super3 } from './class-n
 import Super2 from './class-names.js';
 import {ReexportedClass as Super1Again} from './reexported-classes.js';
 import { ExportedClass as Super1FromExportAll } from './reexported-all.js';
+import * as importedNS from './reexported-all.js'
 
 class CL1 extends Super1 { }
 
@@ -12,3 +13,5 @@ class CL3 extends Super3 { }
 class CL4 extends Super1Again { }
 
 class CL5 extends Super1FromExportAll { }
+
+class CL6 extends importedNS.ExportedClass { }

--- a/src/test/static/class/super-class-imported.js
+++ b/src/test/static/class/super-class-imported.js
@@ -1,0 +1,3 @@
+import { ExportedClass as Super1 } from './class-names.js';
+
+class CL1 extends Super1 { };

--- a/src/test/static/class/super-class-imported.js
+++ b/src/test/static/class/super-class-imported.js
@@ -1,11 +1,14 @@
 import { ExportedClass as Super1, ExportedConstClass as Super3 } from './class-names.js';
 import Super2 from './class-names.js';
 import {ReexportedClass as Super1Again} from './reexported-classes.js';
+import { ExportedClass as Super1FromExportAll } from './reexported-all.js';
 
-class CL1 extends Super1 { };
+class CL1 extends Super1 { }
 
-class CL2 extends Super2 { };
+class CL2 extends Super2 { }
 
-class CL3 extends Super3 { };
+class CL3 extends Super3 { }
 
-class CL4 extends Super1Again { };
+class CL4 extends Super1Again { }
+
+class CL5 extends Super1FromExportAll { }

--- a/src/test/static/class/super-class-imported.js
+++ b/src/test/static/class/super-class-imported.js
@@ -1,3 +1,8 @@
-import { ExportedClass as Super1 } from './class-names.js';
+import { ExportedClass as Super1, ExportedConstClass as Super3 } from './class-names.js';
+import Super2 from './class-names.js';
 
 class CL1 extends Super1 { };
+
+class CL2 extends Super2 { };
+
+class CL3 extends Super3 { };

--- a/src/test/static/class/super-class-scoped.js
+++ b/src/test/static/class/super-class-scoped.js
@@ -1,0 +1,10 @@
+class Foo { method3() { } }
+{
+  class Foo { method1() { }}
+  class One extends Foo { }
+}
+{
+  class Foo { method2() { } }
+  class Two extends Foo { }
+}
+class Three extends Foo { }


### PR DESCRIPTION
This has all of the other PRs merged in. Will rebase to undo the merge commits after those other PRs land, or we can just review everything all at once here.

Scoped reference resolution could be enhanced further. e.g. it wouldn't be hard to resolve through const assignments. I've got that working in one of my prototype branches actually.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
