### PR TITLE
Construct a ScannedReference with a NodePath.

### DIFF
--- a/src/javascript/class-scanner.ts
+++ b/src/javascript/class-scanner.ts
@@ -13,7 +13,7 @@
  */
 
 import generate from 'babel-generator';
-import {NodePath, Scope} from 'babel-traverse';
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 import * as doctrine from 'doctrine';
 
@@ -644,9 +644,9 @@ class ClassFinder implements Visitor {
         properties,
         methods,
         getStaticMethods(astNode, this._document),
-        this._getExtends(astNode, doc, warnings, this._document, path.scope),
+        this._getExtends(astNode, doc, warnings, this._document, path),
         jsdoc.getMixinApplications(
-            this._document, astNode, doc, warnings, path.scope),
+            this._document, astNode, doc, warnings, path),
         getOrInferPrivacy(namespacedName || '', doc),
         warnings,
         jsdoc.hasTag(doc, 'abstract'),
@@ -662,7 +662,7 @@ class ClassFinder implements Visitor {
   private _getExtends(
       node: babel.Node, docs: jsdoc.Annotation, warnings: Warning[],
       document: JavaScriptDocument,
-      scope: Scope): ScannedReference<'class'>|undefined {
+      path: NodePath): ScannedReference<'class'>|undefined {
     const extendsAnnotations =
         docs.tags!.filter((tag) => tag.title === 'extends');
 
@@ -681,7 +681,7 @@ class ClassFinder implements Visitor {
         }));
       } else {
         return new ScannedReference(
-            'class', extendsId, sourceRange, undefined, scope);
+            'class', extendsId, sourceRange, undefined, path);
       }
     } else if (
         babel.isClassDeclaration(node) || babel.isClassExpression(node)) {
@@ -695,7 +695,7 @@ class ClassFinder implements Visitor {
           }
           const sourceRange = document.sourceRangeForNode(superClass)!;
           return new ScannedReference(
-              'class', extendsId, sourceRange, node.superClass, scope);
+              'class', extendsId, sourceRange, node.superClass, path);
         }
       }
     }

--- a/src/javascript/esutil.ts
+++ b/src/javascript/esutil.ts
@@ -845,6 +845,6 @@ function* getNamesFromLValue(lhs: babel.LVal): IterableIterator<string> {
   }
 }
 
-function assertNever(never: never) {
+function assertNever(never: never): never {
   throw new Error(`Unexpected ast node: ${util.inspect(never)}`);
 }

--- a/src/javascript/jsdoc.ts
+++ b/src/javascript/jsdoc.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Scope} from 'babel-traverse';
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 import * as doctrine from 'doctrine';
 import {Annotation, Tag} from 'doctrine';
@@ -145,7 +145,7 @@ export function getMixinApplications(
     node: babel.Node,
     docs: Annotation,
     warnings: Warning[],
-    scope: Scope): Array<ScannedReference<'element-mixin'>> {
+    path: NodePath): Array<ScannedReference<'element-mixin'>> {
   // TODO(justinfagnani): remove @mixes support
   const appliesMixinAnnotations = docs.tags!.filter(
       (tag) => tag.title === 'appliesMixin' || tag.title === 'mixes');
@@ -167,7 +167,7 @@ export function getMixinApplications(
                  return;
                }
                return new ScannedReference(
-                   'element-mixin', mixinId, sourceRange, undefined, scope);
+                   'element-mixin', mixinId, sourceRange, undefined, path);
              })
              .filter((m) => m !== undefined) as
       Array<ScannedReference<'element-mixin'>>;

--- a/src/model/reference.ts
+++ b/src/model/reference.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Scope} from 'babel-traverse';
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 
 import {Annotation} from '../javascript/jsdoc';
@@ -33,17 +33,17 @@ export class ScannedReference<K extends keyof FeatureKindMap> extends
   readonly identifier: string;
   readonly kind: K;
   readonly sourceRange: SourceRange|undefined;
-  readonly scope: Scope;
+  readonly astPath: NodePath;
   readonly astNode: babel.Node|undefined;
 
   constructor(
       kind: K, identifier: string, sourceRange: SourceRange|undefined,
-      astNode: babel.Node|undefined, scope: Scope, description?: string,
+      astNode: babel.Node|undefined, astPath: NodePath, description?: string,
       jsdoc?: Annotation, warnings?: Warning[]) {
     super(sourceRange, astNode, description, jsdoc, warnings);
     this.kind = kind;
     this.astNode = astNode;
-    this.scope = scope;
+    this.astPath = astPath;
     this.sourceRange = sourceRange;
     this.identifier = identifier;
   }

--- a/src/polymer/behavior-scanner.ts
+++ b/src/polymer/behavior-scanner.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {NodePath, Scope} from 'babel-traverse';
+import {NodePath} from 'babel-traverse';
 
 import * as babel from 'babel-types';
 
@@ -185,7 +185,7 @@ class BehaviorVisitor implements Visitor {
     const behavior = this.currentBehavior!;
 
     this.propertyHandlers =
-        declarationPropertyHandlers(behavior, this.document, path.scope);
+        declarationPropertyHandlers(behavior, this.document, path);
 
     docs.annotateElementHeader(behavior);
     const behaviorTag = jsdoc.getTag(behavior.jsdoc, 'polymerBehavior');
@@ -198,11 +198,11 @@ class BehaviorVisitor implements Visitor {
 
     behavior.privacy =
         esutil.getOrInferPrivacy(behavior.className, behavior.jsdoc);
-    this._parseChainedBehaviors(node, path.scope);
+    this._parseChainedBehaviors(node, path);
 
     this.currentBehavior = this.mergeBehavior(behavior);
-    this.propertyHandlers = declarationPropertyHandlers(
-        this.currentBehavior, this.document, path.scope);
+    this.propertyHandlers =
+        declarationPropertyHandlers(this.currentBehavior, this.document, path);
 
     // Some behaviors are just lists of other behaviors. If this is one then
     // add it to behaviors right away.
@@ -254,7 +254,7 @@ class BehaviorVisitor implements Visitor {
     return newBehavior;
   }
 
-  _parseChainedBehaviors(node: babel.Node, scope: Scope) {
+  _parseChainedBehaviors(node: babel.Node, path: NodePath) {
     if (this.currentBehavior == null) {
       throw new Error(
           `_parsedChainedBehaviors was called without a current behavior.`);
@@ -276,7 +276,7 @@ class BehaviorVisitor implements Visitor {
               behaviorName,
               this.document.sourceRangeForNode(arrElement)!,
               arrElement,
-              scope));
+              path));
         }
       }
       if (chained.length > 0) {

--- a/src/polymer/declaration-property-handlers.ts
+++ b/src/polymer/declaration-property-handlers.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Scope} from 'babel-traverse';
+import {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 
 import * as astValue from '../javascript/ast-value';
@@ -30,7 +30,7 @@ export type BehaviorReferenceOrWarning = {
 }|{kind: 'behaviorReference', reference: ScannedReference<'behavior'>};
 
 export function getBehaviorReference(
-    argNode: babel.Node, document: JavaScriptDocument, scope: Scope):
+    argNode: babel.Node, document: JavaScriptDocument, path: NodePath):
     Result<ScannedReference<'behavior'>, Warning> {
   const behaviorName = astValue.getIdentifierName(argNode);
   if (!behaviorName) {
@@ -53,7 +53,7 @@ export function getBehaviorReference(
         behaviorName,
         document.sourceRangeForNode(argNode)!,
         argNode,
-        scope)
+        path)
   };
 }
 
@@ -69,7 +69,7 @@ export type PropertyHandlers = {
 export function declarationPropertyHandlers(
     declaration: ScannedPolymerElement,
     document: JavaScriptDocument,
-    scope: Scope): PropertyHandlers {
+    path: NodePath): PropertyHandlers {
   return {
     is(node: babel.Node) {
       if (babel.isLiteral(node)) {
@@ -86,7 +86,7 @@ export function declarationPropertyHandlers(
         return;
       }
       for (const element of node.elements) {
-        const result = getBehaviorReference(element, document, scope);
+        const result = getBehaviorReference(element, document, path);
         if (result.successful === false) {
           declaration.warnings.push(result.error);
         } else {

--- a/src/polymer/polymer-element-scanner.ts
+++ b/src/polymer/polymer-element-scanner.ts
@@ -85,7 +85,7 @@ class ElementVisitor implements Visitor {
     });
     element.description = (element.description || '').trim();
     const propertyHandlers =
-        declarationPropertyHandlers(element, this.document, path.scope);
+        declarationPropertyHandlers(element, this.document, path);
 
     const argument = node.arguments[0];
     if (babel.isObjectExpression(argument)) {

--- a/src/polymer/polymer2-mixin-scanner.ts
+++ b/src/polymer/polymer2-mixin-scanner.ts
@@ -94,7 +94,7 @@ export class MixinVisitor implements Visitor {
       privacy: getOrInferPrivacy(namespacedName, docs),
       jsdoc: docs,
       mixins: jsdoc.getMixinApplications(
-          this._document, node, docs, this.warnings, nodePath.scope)
+          this._document, node, docs, this.warnings, nodePath)
     });
     this._currentMixin = mixin;
     this._currentMixinNode = node;


### PR DESCRIPTION
Not with a Scope.

NodePath is more useful, and it's what we need for scoped reference resolution.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not updated, internal change
