### PR TITLE
Stop warning for unloadable documents if we dont expect to be able to load them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Fixed an issue where warnings were generated for imports of resolved URLs
-  which are not loadable and external to the package.  Now we warn only when
-  unable to load a document we expect to be loadable.
+* Import URLs which are resolved, but for which the URL loader returns
+  `canLoad() === false` result in a `not-loadable` Warning instead of
+  `could-not-load`, which is reserved for other failures, such as parser
+  errors or load errors.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.15] - 2018-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fixed an issue where warnings were generated for imports of resolved URLs
+  which are not loadable and external to the package.  Now we warn only when
+  unable to load a document we expect to be loadable.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.15] - 2018-03-15

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -33,6 +33,7 @@ export class ScannedScriptTagImport extends ScannedImport {
         !document._analysisContext.loader.canLoad(resolvedUrl)) {
       return;
     }
+    console.log('i have a resolvedUrl', resolvedUrl);
 
     // TODO(justinfagnani): warn if the same URL is loaded from more than one
     // non-module script tag

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Document, DocumentBackreference, Import, ScannedImport, Severity, Warning} from '../model/model';
+import {Document, DocumentBackreference, Import, ScannedImport} from '../model/model';
 
 /**
  * <script> tags are represented in two different ways: as inline documents,
@@ -24,16 +24,12 @@ export class ScriptTagImport extends Import { readonly type = 'html-script'; }
 
 export class ScannedScriptTagImport extends ScannedImport {
   resolve(document: Document): ScriptTagImport|undefined {
-    if (this.url === undefined) {
-      return;
+    const resolvedUrl = this.getLoadableUrlOrWarn(document);
+    if (this.url === undefined || resolvedUrl === undefined) {
+      // Warning will already have been added to the document if necessary, so
+      // we can just return here.
+      return undefined;
     }
-    const resolvedUrl = document._analysisContext.resolver.resolve(
-        document.parsedDocument.baseUrl, this.url, this);
-    if (resolvedUrl === undefined ||
-        !document._analysisContext.loader.canLoad(resolvedUrl)) {
-      return;
-    }
-    console.log('i have a resolvedUrl', resolvedUrl);
 
     // TODO(justinfagnani): warn if the same URL is loaded from more than one
     // non-module script tag
@@ -77,14 +73,7 @@ export class ScannedScriptTagImport extends ScannedImport {
           false);
     } else {
       // not found or syntax error
-      const error = (this.error ? (this.error.message || this.error) : '');
-      document.warnings.push(new Warning({
-        code: 'could-not-load',
-        message: `Unable to load import: ${error}`,
-        sourceRange: (this.urlSourceRange || this.sourceRange)!,
-        severity: Severity.ERROR,
-        parsedDocument: document.parsedDocument
-      }));
+      this.addCouldNotLoadWarning(document);
       return undefined;
     }
   }

--- a/src/html/html-script-tag.ts
+++ b/src/html/html-script-tag.ts
@@ -29,7 +29,8 @@ export class ScannedScriptTagImport extends ScannedImport {
     }
     const resolvedUrl = document._analysisContext.resolver.resolve(
         document.parsedDocument.baseUrl, this.url, this);
-    if (resolvedUrl === undefined) {
+    if (resolvedUrl === undefined ||
+        !document._analysisContext.loader.canLoad(resolvedUrl)) {
       return;
     }
 

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -74,7 +74,8 @@ export class ScannedImport implements Resolvable {
     }
     const resolvedUrl = document._analysisContext.resolver.resolve(
         document.parsedDocument.baseUrl, this.url, this);
-    if (resolvedUrl === undefined) {
+    if (resolvedUrl === undefined ||
+        !document._analysisContext.loader.canLoad(resolvedUrl)) {
       return;
     }
     const importedDocumentOrWarning =

--- a/src/model/import.ts
+++ b/src/model/import.ts
@@ -67,28 +67,17 @@ export class ScannedImport implements Resolvable {
   }
 
   resolve(document: Document): Import|undefined {
-    if (this.url === undefined) {
-      // We don't issue a warning here because the scanner should have when it
-      // produced an undefined URL.
+    const resolvedUrl = this.getLoadableUrlOrWarn(document);
+    if (this.url === undefined || resolvedUrl === undefined) {
+      // Warning will already have been added to the document if necessary, so
+      // we can just return here.
       return undefined;
     }
-    const resolvedUrl = document._analysisContext.resolver.resolve(
-        document.parsedDocument.baseUrl, this.url, this);
-    if (resolvedUrl === undefined ||
-        !document._analysisContext.loader.canLoad(resolvedUrl)) {
-      return;
-    }
+
     const importedDocumentOrWarning =
         document._analysisContext.getDocument(resolvedUrl);
     if (!(importedDocumentOrWarning instanceof Document)) {
-      const error = this.error ? (this.error.message || this.error) : '';
-      document.warnings.push(new Warning({
-        code: 'could-not-load',
-        message: `Unable to load import: ${error}`,
-        sourceRange: (this.urlSourceRange || this.sourceRange)!,
-        severity: Severity.ERROR,
-        parsedDocument: document.parsedDocument,
-      }));
+      this.addCouldNotLoadWarning(document, importedDocumentOrWarning);
       return undefined;
     }
     return this.constructImport(
@@ -108,6 +97,44 @@ export class ScannedImport implements Resolvable {
         this.astNode,
         this.warnings,
         this.lazy);
+  }
+
+  protected addCouldNotLoadWarning(document: Document, warning?: Warning) {
+    const error = this.error && this.error.message || this.error ||
+        warning && warning.message || '';
+    document.warnings.push(new Warning({
+      code: 'could-not-load',
+      message: `Unable to load import: ${error}`,
+      sourceRange: (this.urlSourceRange || this.sourceRange)!,
+      severity: Severity.ERROR,
+      parsedDocument: document.parsedDocument,
+    }));
+  }
+
+  /**
+   * Resolve the URL for this import and return it if the analyzer
+   */
+  protected getLoadableUrlOrWarn(document: Document): ResolvedUrl|undefined {
+    if (this.url === undefined) {
+      return;
+    }
+    const resolvedUrl = document._analysisContext.resolver.resolve(
+        document.parsedDocument.baseUrl, this.url, this);
+    if (!resolvedUrl) {
+      return;
+    }
+    if (!document._analysisContext.loader.canLoad(resolvedUrl)) {
+      // We have no way to load this resolved URL, so we will warn.
+      document.warnings.push(new Warning({
+        code: 'not-loadable',
+        message: `URL loader not configured to load '${resolvedUrl}'`,
+        sourceRange: (this.urlSourceRange || this.sourceRange)!,
+        severity: Severity.WARNING,
+        parsedDocument: document.parsedDocument,
+      }));
+      return undefined;
+    }
+    return resolvedUrl;
   }
 }
 

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -56,7 +56,7 @@ suite('HtmlScriptScanner', () => {
         [['html-script', 'foo.js']]);
   });
 
-  test('only warn about not loading things we expect to load', async () => {
+  test('could-not-load vs not-loadable warnings', async () => {
     const contents = `
       <script src="does-not-exist-but-should.js"></script>
       <script src="https://else.where/does-not-exist-lol-dont-care.js"></script>
@@ -72,12 +72,13 @@ suite('HtmlScriptScanner', () => {
       throw testDoc.error;
     }
     const warnings = testDoc.value.warnings;
-    assert.isAtLeast(warnings.length, 1);
+    assert.isAtLeast(warnings.length, 2);
     assert.isTrue(warnings.some(
         (w: Warning) => w.code === 'could-not-load' &&
             !!w.message.match('does-not-exist-but-should.js')));
-    assert.isFalse(warnings.some(
-        (w: Warning) => !!w.message.match('does-not-exist-lol-dont-care.js')));
+    assert.isTrue(warnings.some(
+        (w: Warning) => w.code === 'not-loadable' &&
+            !!w.message.match('does-not-exist-lol-dont-care.js')));
   });
 
   suite('modules', () => {

--- a/src/test/html/html-script-scanner_test.ts
+++ b/src/test/html/html-script-scanner_test.ts
@@ -18,7 +18,9 @@ import {Analyzer} from '../../core/analyzer';
 import {HtmlScriptScanner} from '../../html/html-script-scanner';
 import {JavaScriptDocument} from '../../javascript/javascript-document';
 import {Analysis} from '../../model/analysis';
-import {FileRelativeUrl, ScannedImport, ScannedInlineDocument} from '../../model/model';
+import {FileRelativeUrl, ResolvedUrl, ScannedImport, ScannedInlineDocument} from '../../model/model';
+import {Warning} from '../../model/warning';
+import {InMemoryOverlayUrlLoader} from '../../url-loader/overlay-loader';
 import {fixtureDir, runScannerOnContents} from '../test-utils';
 
 suite('HtmlScriptScanner', () => {
@@ -52,6 +54,30 @@ suite('HtmlScriptScanner', () => {
     assert.deepEqual(
         features.map((f: ScannedImport) => [f.type, f.url]),
         [['html-script', 'foo.js']]);
+  });
+
+  test('only warn about not loading things we expect to load', async () => {
+    const contents = `
+      <script src="does-not-exist-but-should.js"></script>
+      <script src="https://else.where/does-not-exist-lol-dont-care.js"></script>
+    `;
+    const urlLoader = new InMemoryOverlayUrlLoader();
+    const analyzer = new Analyzer({urlLoader});
+    const testDocUrl = analyzer.resolveUrl('test-document.html')!;
+    urlLoader.urlContentsMap.set(testDocUrl, contents);
+    urlLoader.canLoad = (url: ResolvedUrl) => url.startsWith('file://');
+    const testDoc =
+        (await analyzer.analyze([testDocUrl])).getDocument(testDocUrl);
+    if (!testDoc.successful) {
+      throw testDoc.error;
+    }
+    const warnings = testDoc.value.warnings;
+    assert.isAtLeast(warnings.length, 1);
+    assert.isTrue(warnings.some(
+        (w: Warning) => w.code === 'could-not-load' &&
+            !!w.message.match('does-not-exist-but-should.js')));
+    assert.isFalse(warnings.some(
+        (w: Warning) => !!w.message.match('does-not-exist-lol-dont-care.js')));
   });
 
   suite('modules', () => {


### PR DESCRIPTION
* [x] CHANGELOG.md has been updated
* Fixed an issue where warnings were generated for imports of resolved URLs
  which are not loadable and external to the package.  Now we warn only when
  unable to load a document we expect to be loadable.