### PR TITLE
Add nodeName to LocalId references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+* Add `nodeName` to `LocalId` references
 
 ## [3.0.0-pre.16] - 2018-03-15
 * Import URLs which are resolved, but for which the URL loader returns

--- a/src/polymer/dom-module-scanner.ts
+++ b/src/polymer/dom-module-scanner.ts
@@ -140,7 +140,8 @@ export class DomModuleScanner implements HtmlScanner {
                   .map(
                       (e) => new LocalId(
                           dom5.getAttribute(e, 'id')!,
-                          document.sourceRangeForNode(e)!));
+                          document.sourceRangeForNode(e)!,
+                          e.nodeName));
           const results =
               scanDatabindingTemplateForExpressions(document, template);
           warnings = results.warnings;

--- a/src/polymer/polymer-element.ts
+++ b/src/polymer/polymer-element.ts
@@ -120,10 +120,12 @@ export function mergePropertyDeclarations(
 export class LocalId {
   name: string;
   range: SourceRange;
+  nodeName: string;
 
-  constructor(name: string, range: SourceRange) {
+  constructor(name: string, range: SourceRange, nodeName: string) {
     this.name = name;
     this.range = range;
+    this.nodeName = nodeName;
   }
 }
 

--- a/src/test/polymer/dom-module-scanner_test.ts
+++ b/src/test/polymer/dom-module-scanner_test.ts
@@ -40,6 +40,9 @@ suite('DomModuleScanner', () => {
     assert.deepEqual(
         features.map((f: ScannedDomModule) => f.localIds.map((l) => l.name)),
         [['foo', 'bar']]);
+    assert.deepEqual(
+        features.map((f: ScannedDomModule) => f.localIds.map((l) => l.nodeName)),
+        [['div', 'span']]);
   });
 
   test('finds databinding expressions IDs', async () => {


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

This name is required for https://github.com/Polymer/gen-typescript-declarations/pull/100 to properly construct the `HTMLElementTagNameMap[nodeName]` type reference.

 - [X] CHANGELOG.md has been updated
