### PR TITLE
PackageUrlResolver no longer requires a `componentDir` and no longer defaults it to `bower_components`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
+* [BREAKING] `PackageUrlResolver` now requires an explicit `componentDir` 
+  option to provide sibling-package component resolution behavior, where it
+  used to assume `bower_components` as a default.  When analyzing an
+  application as opposed to a component, no `componentDir` option should be
+  used.
 * Reference resolution now supports javascript scoping rules, and will follow
   javascript module imports, including aliased imports, namespace imports, and
   re-exports. References to super classes, mixins, and behaviors use this

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -94,10 +94,11 @@ export class Analyzer {
    * at the given directory, but in the future it may take configuration from
    * files including polymer.json or similar.
    */
-  static createForDirectory(dirname: string): Analyzer {
+  static createForDirectory(dirname: string, componentDir?: string): Analyzer {
     return new Analyzer({
       urlLoader: new FSUrlLoader(dirname),
-      urlResolver: new PackageUrlResolver({packageDir: dirname})
+      urlResolver:
+          new PackageUrlResolver({packageDir: dirname, componentDir})
     });
   }
 

--- a/src/test/core/analyzer_test.ts
+++ b/src/test/core/analyzer_test.ts
@@ -886,7 +886,7 @@ var DuplicateNamespace = {};
 
     test('can get warnings from within and without the package', async () => {
       const analyzer = Analyzer.createForDirectory(
-          path.join(fixtureDir, 'project-with-errors'));
+          path.join(fixtureDir, 'project-with-errors'), 'bower_components');
       const pckage = await analyzer.analyzePackage();
       assert.deepEqual(
           Array.from(pckage['_searchRoots']).map((d) => d.url),

--- a/src/test/url-loader/package-url-resolver_test.ts
+++ b/src/test/url-loader/package-url-resolver_test.ts
@@ -22,7 +22,8 @@ suite('PackageUrlResolver', function() {
   suite('resolve', () => {
     let resolver: PackageUrlResolver;
     setup(() => {
-      resolver = new PackageUrlResolver({packageDir: `/1/2`});
+      resolver = new PackageUrlResolver(
+          {packageDir: `/1/2`, componentDir: 'bower_components'});
     });
     test(`resolves file:// urls to themselves`, () => {
       const r = new PackageUrlResolver();
@@ -61,8 +62,8 @@ suite('PackageUrlResolver', function() {
 
     test('resolves sibling with matching name prefix to component dir', () => {
       // Regression test for bug in path containment check.
-      const configured =
-          new PackageUrlResolver({packageDir: '/repos/iron-icons'});
+      const configured = new PackageUrlResolver(
+          {packageDir: '/repos/iron-icons', componentDir: 'bower_components'});
       assert.equal(
           configured.resolve(
               rootedFileUrl`repos/iron-iconset-svg/foo.html` as any as


### PR DESCRIPTION
* Fixes #922 
* [BREAKING] `PackageUrlResolver` now requires an explicit `componentDir` option to provide sibling-package component resolution behavior, where it used to assume `bower_components` as a default.  When analyzing an application as opposed to a component, no `componentDir` option should be used.
* [x] CHANGELOG.md has been updated
