### PR TITLE
Prepare CHANGELOG for 3.0.0-pre.17 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+
+## [3.0.0-pre.17] - 2018-03-20
 * [BREAKING] `FSUrlLoader` is now `FsUrlLoader`.
 * Reference resolution now supports javascript scoping rules, and will follow
   javascript module imports, including aliased imports, namespace imports, and


### PR DESCRIPTION
## [3.0.0-pre.17] - 2018-03-20
 * [BREAKING] `FSUrlLoader` is now `FsUrlLoader`.
 * Reference resolution now supports javascript scoping rules, and will follow
   javascript module imports, including aliased imports, namespace imports, and
   re-exports. References to super classes, mixins, and behaviors use this
   resolution system.
 * Add `nodeName` to `LocalId` references
 * Added an `Export` feature, for JS module exports.
 * [x] CHANGELOG.md has been updated
